### PR TITLE
Update sync steps in e2e_from_brief workflow

### DIFF
--- a/scripts/e2e_from_brief.sh
+++ b/scripts/e2e_from_brief.sh
@@ -108,9 +108,9 @@ chmod +x scripts/install_and_test.sh
 ./scripts/install_and_test.sh || true
 
 echo "[E2E] Sync & validate"
-"$PY_BIN" scripts/sync_from_scaffold.py --plan
-"$PY_BIN" scripts/sync_from_scaffold.py --apply
-"$PY_BIN" scripts/validate_tasks.py tasks.json
+"$PY_BIN" scripts/sync_from_scaffold.py --input PLAN.tasks.json
+"$PY_BIN" scripts/sync_from_scaffold.py --input PLAN.tasks.json --apply
+"$PY_BIN" scripts/validate_tasks.py --input tasks.json
 
 echo "[E2E] QC metrics & gates"
 "$PY_BIN" scripts/collect_coverage.py || true


### PR DESCRIPTION
## Summary
- update the e2e fast-path script to preview sync_from_scaffold against PLAN.tasks.json before applying
- invoke validate_tasks with the explicit tasks.json input file after applying the sync

## Testing
- bash scripts/e2e_from_brief.sh *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f33a0f80832e9dbd000e63d64cb3