### PR TITLE
Add production promotion workflow and observability automation

### DIFF
--- a/.github/workflows/ci-promote-prod.yml
+++ b/.github/workflows/ci-promote-prod.yml
@@ -1,0 +1,111 @@
+name: Promote to Production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify-and-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install and test
+        run: ./scripts/install_and_test.sh
+
+      - name: Collect coverage
+        run: python scripts/collect_coverage.py || true
+
+      - name: Collect performance metrics
+        run: python scripts/collect_perf.py || true
+
+      - name: Scan dependencies
+        run: python scripts/scan_deps.py || true
+
+      - name: Enforce quality gates
+        run: python scripts/enforce_gates.py
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: verify-and-gate
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Deploy frontend
+        working-directory: frontend
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "Vercel secrets are required for production deployment" >&2
+            exit 1
+          fi
+          ENV_FILE="../.env.production"
+          if [ -f "$ENV_FILE" ]; then
+            ENV_FLAG="--env-file $ENV_FILE"
+          else
+            ENV_FLAG=""
+          fi
+          DEPLOY_ARGS="--yes --token $VERCEL_TOKEN --prod"
+          npx vercel deploy $DEPLOY_ARGS --scope "$VERCEL_ORG_ID" $ENV_FLAG
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Deploy backend
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          APP_NAME: ${{ vars.APP_NAME }}
+          ECS_CLUSTER_NAME: ${{ vars.ECS_CLUSTER_NAME }}
+          ECS_SERVICE_NAME: ${{ vars.ECS_SERVICE_NAME }}
+          ECS_DESIRED_COUNT: ${{ vars.ECS_DESIRED_COUNT }}
+          TASK_EXECUTION_ROLE_ARN: ${{ secrets.AWS_ECS_EXECUTION_ROLE_ARN }}
+          TASK_ROLE_ARN: ${{ secrets.AWS_ECS_TASK_ROLE_ARN }}
+          BACKEND_IMAGE: ghcr.io/${{ github.repository }}-backend:sha-${{ github.sha }}
+        run: |
+          chmod +x scripts/deploy_backend.sh
+          ./scripts/deploy_backend.sh production
+
+      - name: Post-deploy health check
+        run: |
+          mkdir -p reports
+          python scripts/health/check_deployment.py \
+            --environment production \
+            --frontend-url "${{ vars.FRONTEND_URL_PRODUCTION }}" \
+            --api-url "${{ vars.API_URL_PRODUCTION }}" \
+            --db-url "${{ vars.DB_URL_PRODUCTION }}" \
+            --out reports/production-pipeline-validation.json
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-artifacts-${{ github.run_number }}
+          path: |
+            reports/*
+            evidence/*
+            dist/*
+          if-no-files-found: ignore

--- a/.github/workflows/ci-secrets-preflight.yml
+++ b/.github/workflows/ci-secrets-preflight.yml
@@ -1,0 +1,63 @@
+name: Secrets Preflight
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  secrets-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required secrets and variables
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ECS_EXECUTION_ROLE_ARN: ${{ secrets.AWS_ECS_EXECUTION_ROLE_ARN }}
+          AWS_ECS_TASK_ROLE_ARN: ${{ secrets.AWS_ECS_TASK_ROLE_ARN }}
+          APP_NAME: ${{ vars.APP_NAME }}
+          ECS_CLUSTER_NAME: ${{ vars.ECS_CLUSTER_NAME }}
+          ECS_SERVICE_NAME: ${{ vars.ECS_SERVICE_NAME }}
+          FRONTEND_URL_STAGING: ${{ vars.FRONTEND_URL_STAGING }}
+          API_URL_STAGING: ${{ vars.API_URL_STAGING }}
+          DB_URL_STAGING: ${{ vars.DB_URL_STAGING }}
+          FRONTEND_URL_PRODUCTION: ${{ vars.FRONTEND_URL_PRODUCTION }}
+          API_URL_PRODUCTION: ${{ vars.API_URL_PRODUCTION }}
+          DB_URL_PRODUCTION: ${{ vars.DB_URL_PRODUCTION }}
+        run: |
+          set -euo pipefail
+          missing=0
+          require() {
+            local var_name="$1"
+            if [[ -z "${!var_name:-}" ]]; then
+              echo "Missing ${var_name}" >&2
+              missing=1
+            fi
+          }
+
+          require VERCEL_TOKEN
+          require VERCEL_ORG_ID
+          require VERCEL_PROJECT_ID
+          require AWS_REGION
+          require AWS_ECS_EXECUTION_ROLE_ARN
+          require AWS_ECS_TASK_ROLE_ARN
+          require APP_NAME
+          require ECS_CLUSTER_NAME
+          require ECS_SERVICE_NAME
+          require FRONTEND_URL_STAGING
+          require API_URL_STAGING
+          require DB_URL_STAGING
+          require FRONTEND_URL_PRODUCTION
+          require API_URL_PRODUCTION
+          require DB_URL_PRODUCTION
+
+          if [[ $missing -ne 0 ]]; then
+            echo "Secrets/vars preflight failed" >&2
+            exit 1
+          fi
+
+          echo "All required secrets and variables are present"

--- a/.github/workflows/nightly-observability.yml
+++ b/.github/workflows/nightly-observability.yml
@@ -1,0 +1,54 @@
+name: Nightly Observability
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  staging-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run staging health check
+        run: |
+          mkdir -p reports
+          python scripts/health/check_deployment.py \
+            --environment staging \
+            --frontend-url "${{ vars.FRONTEND_URL_STAGING }}" \
+            --api-url "${{ vars.API_URL_STAGING }}" \
+            --db-url "${{ vars.DB_URL_STAGING }}" \
+            --out reports/staging-pipeline-validation.json
+
+      - name: Upload staging report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-health-${{ github.run_number }}
+          path: reports/staging-pipeline-validation.json
+          if-no-files-found: error
+
+  production-health:
+    runs-on: ubuntu-latest
+    needs: staging-health
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run production health check
+        run: |
+          mkdir -p reports
+          python scripts/health/check_deployment.py \
+            --environment production \
+            --frontend-url "${{ vars.FRONTEND_URL_PRODUCTION }}" \
+            --api-url "${{ vars.API_URL_PRODUCTION }}" \
+            --db-url "${{ vars.DB_URL_PRODUCTION }}" \
+            --out reports/production-pipeline-validation.json
+
+      - name: Upload production report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-health-${{ github.run_number }}
+          path: reports/production-pipeline-validation.json
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
-.PHONY: setup dev test lint build deploy clean
+.PHONY: setup dev test lint build deploy clean lifecycle pipeline-validate
+
+ENV ?= staging
+FRONTEND_URL ?=
+API_URL ?=
+DB_URL ?=
+LIFECYCLE_ENV := $(strip \
+  $(if $(NAME),NAME="$(NAME)") \
+  $(if $(INDUSTRY),INDUSTRY="$(INDUSTRY)") \
+  $(if $(PROJECT_TYPE),PROJECT_TYPE="$(PROJECT_TYPE)") \
+  $(if $(FE),FE="$(FE)") \
+  $(if $(BE),BE="$(BE)") \
+  $(if $(DB),DB="$(DB)") \
+  $(if $(COMPLIANCE),COMPLIANCE="$(COMPLIANCE)") \
+)
 
 # Setup project
 setup:
@@ -53,3 +67,19 @@ clean:
 	rm -rf dist/
 	rm -rf build/
 	docker-compose down -v
+
+lifecycle:
+	@$(if $(NAME),:,echo "[lifecycle] NAME not provided; set NAME=<client> or ensure workflow.config.json has it." >&2;)
+	@$(if $(INDUSTRY),:,echo "[lifecycle] INDUSTRY not provided; set INDUSTRY=<sector> or rely on workflow.config.json." >&2;)
+	@$(if $(PROJECT_TYPE),:,echo "[lifecycle] PROJECT_TYPE not provided; set PROJECT_TYPE=<type> or rely on workflow.config.json." >&2;)
+	@$(if $(FE),:,echo "[lifecycle] FE not provided; set FE=<frontend> or rely on workflow.config.json." >&2;)
+	@$(if $(BE),:,echo "[lifecycle] BE not provided; set BE=<backend> or rely on workflow.config.json." >&2;)
+	@$(if $(DB),:,echo "[lifecycle] DB not provided; set DB=<database> or rely on workflow.config.json." >&2;)
+	@$(if $(LIFECYCLE_ENV),env $(LIFECYCLE_ENV) ,) ./scripts/e2e_from_brief.sh
+
+pipeline-validate:
+	@if [ -z "$(FRONTEND_URL)" ]; then echo "FRONTEND_URL is required" >&2; exit 1; fi
+	@if [ -z "$(API_URL)" ]; then echo "API_URL is required" >&2; exit 1; fi
+	@if [ -z "$(DB_URL)" ]; then echo "DB_URL is required" >&2; exit 1; fi
+	@mkdir -p reports
+	@python scripts/health/check_deployment.py --environment $(ENV) --frontend-url $(FRONTEND_URL) --api-url $(API_URL) --db-url $(DB_URL) --out reports/$(ENV)-pipeline-validation.json

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -18,9 +18,10 @@ This document describes how to configure the environments, wire in secrets, and 
    - Create the execution role (`TASK_EXECUTION_ROLE_ARN`) with permissions for `AmazonECSTaskExecutionRolePolicy` and private registry access if required.  
    - Create the application task role (`TASK_ROLE_ARN`) with the minimal permissions the API needs (database, SSM, etc.).  
    - Provision an ECS cluster and service (`ECS_CLUSTER_NAME`, `ECS_SERVICE_NAME`) pointing at the task family defined in `deploy/aws/task-definition.json`.  
-4. In **GitHub > Settings > Secrets and variables > Actions** configure per-environment secrets:  
-   - **Secrets**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ECS_EXECUTION_ROLE_ARN`, `AWS_ECS_TASK_ROLE_ARN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `FRONTEND_URL`, `API_HEALTH_URL`, `DB_HEALTH_URL` (optional), `VERCEL_ROLLBACK_TARGET` (or environment-specific overrides).  
-   - **Variables**: `DEPLOY_TARGET=aws`, `AWS_REGION`, `APP_NAME`, `ECS_CLUSTER_NAME`, `ECS_SERVICE_NAME`, `ECS_DESIRED_COUNT`.  
+4. In **GitHub > Settings > Secrets and variables > Actions** configure per-environment secrets:
+   - **Secrets**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ECS_EXECUTION_ROLE_ARN`, `AWS_ECS_TASK_ROLE_ARN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `FRONTEND_URL`, `API_HEALTH_URL`, `DB_HEALTH_URL` (optional), `VERCEL_ROLLBACK_TARGET` (or environment-specific overrides).
+   - **Variables**: `DEPLOY_TARGET=aws`, `AWS_REGION`, `APP_NAME`, `ECS_CLUSTER_NAME`, `ECS_SERVICE_NAME`, `ECS_DESIRED_COUNT`.
+5. In **GitHub > Settings > Environments**, create a `production` environment and require manual approval. The `ci-promote-prod` workflow references this protected environment before any production deployment runs.
 
 > ℹ️ *Secrets should be managed in your password vault (1Password, Bitwarden, etc.). Never commit real credentials to the repository. Share `.env` values via secure channels only.*
 
@@ -33,11 +34,16 @@ make setup
 # Run the build pipeline locally
 make build
 
+# Execute the non-interactive lifecycle (reads workflow.config.json or env overrides)
+NAME=acme INDUSTRY=enterprise PROJECT_TYPE=fullstack FE=nextjs BE=fastapi DB=postgres make lifecycle
+
 # Verify health endpoints (requires staging/prod URLs)
 make pipeline-validate ENV=staging FRONTEND_URL=https://app.staging.example.com API_URL=https://api.staging.example.com/health \
   DB_URL=https://api.staging.example.com/health/db
 
-The pipeline-validate target uses scripts/health/check_deployment.py to hit the public health endpoints and stores results in reports/<env>-pipeline-validation.json.
+The `lifecycle` target wraps `scripts/e2e_from_brief.sh`, passing any stack variables supplied on the command line (and otherwise falling back to `workflow.config.json`). It produces selection.json, generated source, gate evidence, `dist/` submission bundles, and compliance validation logs in `evidence/`.
+
+The `pipeline-validate` target uses `scripts/health/check_deployment.py` to hit the public health endpoints and stores results in `reports/<env>-pipeline-validation.json`.
 
 Deployment workflow
 
@@ -54,6 +60,23 @@ Deploys the AWS backend with scripts/deploy_backend.sh and the frontend via the 
 Executes health verification via scripts/health/check_deployment.py and Postman smoke tests.
 
 On failure, triggers rollback scripts for ECS and Vercel (and optionally posts to Slack).
+
+## Production promotion (`ci-promote-prod.yml`)
+
+Manual production cutovers run through the `ci-promote-prod` workflow. Trigger it with **Run workflow** in GitHub Actions, then complete the required approval in the protected `production` environment. The workflow:
+
+- Re-runs `scripts/install_and_test.sh` and the coverage/perf/dependency collectors before enforcing `scripts/enforce_gates.py`. Promotion aborts if any gate fails.
+- Deploys the frontend through the existing Vercel CLI pattern (reusing `.env.production` when present) and updates ECS with `scripts/deploy_backend.sh production`, targeting the image `ghcr.io/<org>/<repo>-backend:sha-<commit>`.
+- Executes `scripts/health/check_deployment.py` against the production URLs (`FRONTEND_URL_PRODUCTION`, `API_URL_PRODUCTION`, `DB_URL_PRODUCTION`) and writes `reports/production-pipeline-validation.json`.
+- Uploads `reports/`, `evidence/`, and `dist/` as artifacts even when a step fails to preserve release evidence.
+
+## Nightly observability (`nightly-observability.yml`)
+
+Nightly (02:00 UTC) and ad-hoc dispatch runs execute `scripts/health/check_deployment.py` against staging and production using repository variables for the public endpoints. Each job writes `reports/<env>-pipeline-validation.json` and uploads the file as an artifact so the on-call team can review availability evidence the following morning.
+
+## Secrets preflight (`ci-secrets-preflight.yml`)
+
+The `ci-secrets-preflight` workflow runs on every push to `main`, pull request, and manual dispatch. It exports the Vercel tokens, ECS roles, deployment metadata (`APP_NAME`, `ECS_*`), AWS region, and the staging/production health-check URLs into the job environment. If any variable is empty the job fails immediately with a clear message (without echoing secret contents), allowing teams to remediate configuration issues before builds progress.
 
 # Deploy to staging (requires env vars from .env.staging)
 VERCEL_TOKEN=... VERCEL_ORG_ID=... VERCEL_PROJECT_ID=... \


### PR DESCRIPTION
## Summary
- add a manual `ci-promote-prod` workflow that re-runs quality gates, deploys to Vercel/ECS, runs post-deploy health checks, and uploads production evidence
- schedule nightly staging/production health probes and add an early `ci-secrets-preflight` job to fail fast when required secrets or variables are missing
- extend the Makefile with `lifecycle` and `pipeline-validate` helpers and document the new automation and environment protections

## Testing
- python scripts/health/check_deployment.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d1fb195690832eb40d5183c4c2baf9