### PR TITLE
Add cursor index metadata generation

### DIFF
--- a/project_generator/core/generator.py
+++ b/project_generator/core/generator.py
@@ -232,9 +232,146 @@ class ProjectGenerator:
         }
         
         if not self.no_cursor_assets:
-            (self.project_root / '.cursor' / 'project.json').write_text(
+            cursor_root = self.project_root / '.cursor'
+            cursor_root.mkdir(parents=True, exist_ok=True)
+            (cursor_root / 'project.json').write_text(
                 json.dumps(project_config, indent=2)
             )
+            index_path = cursor_root / 'index.mdc'
+            index_path.write_text(self._render_cursor_index(project_config))
+
+    def _render_cursor_index(self, project_config: Dict[str, Any]) -> str:
+        """Build the contents of .cursor/index.mdc using project metadata."""
+        name = project_config.get('name', 'Project')
+        industry = project_config.get('industry', 'general')
+        project_type = project_config.get('project_type', 'application')
+        stack = project_config.get('stack', {}) or {}
+        features: List[str] = project_config.get('features') or []
+        compliance: List[str] = project_config.get('compliance') or []
+
+        # Build glob list based on generated directories and stack choices
+        stack_glob_map = {
+            'frontend': 'frontend/**/*',
+            'backend': 'backend/**/*',
+            'database': 'database/**/*',
+        }
+        globs: List[str] = []
+        for key, pattern in stack_glob_map.items():
+            value = stack.get(key)
+            if value and str(value).lower() != 'none' and pattern not in globs:
+                globs.append(pattern)
+
+        # Include common directories created during bootstrap
+        for default_glob in ['docs/**/*', 'scripts/**/*', 'tests/**/*']:
+            if default_glob not in globs:
+                globs.append(default_glob)
+
+        if not globs:
+            globs.append('**/*')
+
+        frontend_desc = stack.get('frontend') if stack.get('frontend') else 'no-frontend'
+        backend_desc = stack.get('backend') if stack.get('backend') else 'no-backend'
+        if isinstance(frontend_desc, str) and frontend_desc.lower() == 'none':
+            frontend_desc = 'no-frontend'
+        if isinstance(backend_desc, str) and backend_desc.lower() == 'none':
+            backend_desc = 'no-backend'
+
+        if frontend_desc == 'no-frontend':
+            frontend_phrase = 'without a dedicated frontend'
+        else:
+            frontend_phrase = f"with a {frontend_desc} frontend"
+
+        if backend_desc == 'no-backend':
+            backend_phrase = 'and without a backend service'
+        else:
+            backend_phrase = f"and {backend_desc} backend"
+
+        description = (
+            f"{name} {project_type} project for the {industry} industry "
+            f"{frontend_phrase} {backend_phrase}."
+        )
+
+        frontmatter_lines = [
+            '---',
+            f'description: "{description}"',
+            'globs:'
+        ]
+        for glob in globs:
+            frontmatter_lines.append(f'  - "{glob}"')
+        frontmatter_lines.append('alwaysApply: true')
+        frontmatter_lines.append('---')
+
+        stack_lines = []
+        for label in ['frontend', 'backend', 'database', 'auth', 'deploy']:
+            value = stack.get(label)
+            if value and str(value).strip() and str(value).lower() != 'none':
+                stack_lines.append(f"- **{label.capitalize()}:** {value}")
+
+        if not stack_lines:
+            stack_lines.append("- Stack details were not specified.")
+
+        feature_text = ', '.join(features) if features else 'None specified'
+
+        compliance_lines: List[str] = []
+        if compliance:
+            for flag in compliance:
+                compliance_lines.append(
+                    f"- Adhere to {flag.upper()} controls across all services and data flows."
+                )
+        else:
+            compliance_lines.append("- No additional regulatory frameworks were selected.")
+
+        rule_lines: List[str] = []
+        if stack.get('frontend') and str(stack.get('frontend')).lower() != 'none':
+            rule_lines.append(
+                f"- Keep the `{stack['frontend']}` frontend synchronized with backend contracts and shared APIs."
+            )
+        if stack.get('backend') and str(stack.get('backend')).lower() != 'none':
+            rule_lines.append(
+                f"- Structure the `{stack['backend']}` backend with clear domain boundaries and automated testing."
+            )
+        if stack.get('database') and str(stack.get('database')).lower() != 'none':
+            rule_lines.append(
+                f"- Manage the `{stack['database']}` data layer with migrations and backups aligned to compliance needs."
+            )
+        if features:
+            rule_lines.append(
+                f"- Prioritize delivery of key features: {', '.join(features)}."
+            )
+        if compliance:
+            for flag in compliance:
+                rule_lines.append(
+                    f"- Document how {flag.upper()} obligations are met in infrastructure, code, and operations."
+                )
+        if not rule_lines:
+            rule_lines.append("- Follow established engineering best practices and keep documentation current.")
+
+        body_lines = [
+            f"# {name} Project Overview",
+            '',
+            f"- **Industry:** {industry}",
+            f"- **Project Type:** {project_type}",
+            f"- **Features:** {feature_text}",
+            '',
+            '## Technology Stack',
+            '',
+        ]
+        body_lines.extend(stack_lines)
+        body_lines.extend([
+            '',
+            '## Compliance Considerations',
+            '',
+        ])
+        body_lines.extend(compliance_lines)
+        body_lines.extend([
+            '',
+            '## Project Rules',
+            '',
+        ])
+        body_lines.extend(rule_lines)
+        body_lines.append('')
+
+        return '\n'.join(frontmatter_lines + [''] + body_lines)
     
     def _generate_frontend(self):
         """Generate frontend application"""

--- a/project_generator/core/tests/test_generator_unit.py
+++ b/project_generator/core/tests/test_generator_unit.py
@@ -45,3 +45,23 @@ def test_generate_cicd_includes_gates_config(tmp_path):
     (gen.project_root / '.github' / 'workflows').mkdir(parents=True, exist_ok=True)
     gen._generate_cicd_workflows()
     assert (gen.project_root / 'gates_config.yaml').exists()
+
+
+def test_create_base_structure_writes_cursor_index(tmp_path):
+    args = _mk_args()
+    args.output_dir = str(tmp_path)
+    args.no_cursor_assets = False
+    gen = ProjectGenerator(args, ProjectValidator(), IndustryConfig(args.industry))
+    gen.project_root = tmp_path / args.name
+    gen.project_root.mkdir(parents=True, exist_ok=True)
+
+    gen._create_base_structure()
+
+    index_path = gen.project_root / '.cursor' / 'index.mdc'
+    assert index_path.exists()
+
+    content = index_path.read_text()
+    assert 'description: "unit-proj api project for the healthcare industry' in content
+    assert '- **Project Type:** api' in content
+    assert 'alwaysApply: true' in content
+    assert '## Project Rules' in content


### PR DESCRIPTION
## Summary
- generate `.cursor/index.mdc` alongside `project.json` using project configuration data
- capture stack, feature, and compliance details in the index frontmatter and rule sections
- add a unit test that validates the new index file is created with the expected metadata

## Testing
- pytest project_generator/core/tests/test_generator_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68d259246dec832eb41132558a065f3e