### PR TITLE
Improve project rule inclusion fallbacks and tests

### DIFF
--- a/project_generator/core/generator.py
+++ b/project_generator/core/generator.py
@@ -645,6 +645,19 @@ class ProjectGenerator:
         except Exception:
             return
 
+    def _resolve_template_rule_source(self, template_root: Path, fname: str) -> Optional[Path]:
+        """Return a matching rule path from template-packs when available."""
+        mapping: dict[str, Path] = {
+            'nextjs.mdc': template_root / 'frontend' / 'nextjs' / 'nextjs.mdc',
+            'nextjs-formatting.mdc': template_root / 'frontend' / 'nextjs' / 'formatting.mdc',
+            'typescript.mdc': template_root / 'frontend' / 'nextjs' / 'typescript.mdc',
+            'fastapi.mdc': template_root / 'backend' / 'fastapi' / 'fastapi.mdc',
+        }
+        candidate = mapping.get(fname)
+        if candidate and candidate.exists():
+            return candidate
+        return None
+
     def _write_fallback_rule_if_known(self, rules_dir: Path, fname: str) -> None:
         """Write a minimal embedded rule if we recognize the filename."""
         mapping: dict[str, str] = {
@@ -878,16 +891,16 @@ class ProjectGenerator:
         """Copy a minimal set of project rules (.mdc) for the chosen stack into the generated project.
 
         This runs only when the user passes --include-project-rules and .cursor assets are enabled.
-        It selects a small, opinionated subset to avoid ceremony: all files are copied as-is (generally alwaysApply: false).
+        It selects a small, opinionated subset to avoid ceremony. Missing source files fall back to
+        embedded minimal generators or populated template pack rules.
         """
         try:
             if not getattr(self.args, 'include_project_rules', False):
                 return
-            # Locate source rules in the root repo
+            # Locate source rules in the root repo and template fallback locations
             repo_root = Path(__file__).resolve().parents[2]
             source_dir = repo_root / '.cursor' / 'rules' / 'project-rules'
-            if not source_dir.exists():
-                return
+            template_rules_root = repo_root / 'template-packs' / 'rules'
 
             # Frontend minimal sets
             fe = (getattr(self.args, 'frontend', 'none') or 'none').lower()
@@ -909,7 +922,7 @@ class ProjectGenerator:
 
             # Database add-ons
             db = (getattr(self.args, 'database', 'none') or 'none').lower()
-            db_addons = []
+            db_addons: list[str] = []
             if db == 'mongodb':
                 db_addons.append('mongodb.mdc')
             elif db == 'firebase':
@@ -928,20 +941,39 @@ class ProjectGenerator:
                     seen.add(f)
                     filtered.append(f)
 
+            rules_dir.mkdir(parents=True, exist_ok=True)
+
             for fname in filtered:
+                dest = rules_dir / fname
+                dest.parent.mkdir(parents=True, exist_ok=True)
+
+                produced = False
                 src = source_dir / fname
                 if src.exists() and src.is_file():
-                    dest = rules_dir / fname
-                    dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy(src, dest)
+                    produced = True
+                else:
+                    template_src = self._resolve_template_rule_source(template_rules_root, fname)
+                    if template_src and template_src.exists():
+                        shutil.copy(template_src, dest)
+                        produced = True
+
+                if not produced:
+                    self._write_fallback_rule_if_known(rules_dir, fname)
+                    produced = dest.exists()
+
+                if produced:
                     try:
-                        self._rules_selected_includes.append(str(Path('project-rules') / fname))
+                        selected_entry = str(Path('project-rules') / fname)
+                        if selected_entry not in self._rules_selected_includes:
+                            self._rules_selected_includes.append(selected_entry)
                     except Exception:
                         pass
         except Exception:
             # Non-fatal: rule inclusion should never break generation
             return
-    
+
+
     def _generate_compliance_rules_content(self, compliance: str) -> str:
         """Generate Cursor-style .mdc content with YAML frontmatter for a compliance standard."""
         c = (compliance or '').strip().lower()

--- a/project_generator/tests/test_unit/test_generator.py
+++ b/project_generator/tests/test_unit/test_generator.py
@@ -262,6 +262,58 @@ class TestProjectGenerator:
         # Directory should be removed
         assert not project_dir.exists()
 
+    def test_include_selected_project_rules_outputs(self, generator: ProjectGenerator, temp_dir: Path):
+        """Include project rules when requested, using fallbacks for missing sources."""
+        generator.args.include_project_rules = True
+        project_dir = temp_dir / generator.args.name
+        rules_dir = project_dir / '.cursor' / 'rules' / 'project-rules'
+        rules_dir.mkdir(parents=True, exist_ok=True)
+        generator.project_root = project_dir
+
+        generator._include_selected_project_rules(rules_dir)
+
+        fe_map = {
+            'nextjs': ['nextjs.mdc', 'nextjs-formatting.mdc', 'nextjs-rsc-and-client.mdc', 'typescript.mdc'],
+            'angular': ['angular.mdc', 'typescript.mdc'],
+            'expo': ['expo.mdc', 'react-native.mdc', 'typescript.mdc'],
+            'nuxt': ['vue.mdc', 'typescript.mdc'],
+        }
+        be_map = {
+            'fastapi': ['fastapi.mdc', 'python.mdc', 'rest-api.mdc', 'open-api.mdc'],
+            'django': ['django.mdc', 'python.mdc', 'rest-api.mdc', 'open-api.mdc'],
+            'nestjs': ['nodejs.mdc', 'typescript.mdc', 'rest-api.mdc', 'open-api.mdc'],
+            'go': ['golang.mdc', 'nethttp.mdc', 'rest-api.mdc', 'open-api.mdc'],
+        }
+        db_addons: list[str] = []
+        if generator.args.database.lower() == 'mongodb':
+            db_addons.append('mongodb.mdc')
+        elif generator.args.database.lower() == 'firebase':
+            db_addons.append('firebase.mdc')
+
+        expected = []
+        expected += fe_map.get(generator.args.frontend, [])
+        expected += be_map.get(generator.args.backend, [])
+        expected += db_addons
+
+        deduped: list[str] = []
+        for name in expected:
+            if name and name not in deduped:
+                deduped.append(name)
+
+        generated_files = sorted(p.name for p in rules_dir.glob('*.mdc'))
+        assert generated_files, "No project rules were emitted"
+        assert set(generated_files) == set(deduped)
+        for name in deduped:
+            assert (rules_dir / name).exists()
+
+        recorded = {Path(entry).name for entry in generator._rules_selected_includes}
+        assert set(deduped).issubset(recorded)
+
+        rsc_rule = rules_dir / 'nextjs-rsc-and-client.mdc'
+        assert rsc_rule.exists()
+        assert 'SCOPE: project:test-project' in rsc_rule.read_text(encoding='utf-8')
+
+
     def test_get_ignore_patterns(self, generator: ProjectGenerator):
         """Test getting ignore patterns for template copying"""
         patterns = generator.get_ignore_patterns()


### PR DESCRIPTION
## Summary
- enhance project rule inclusion to use template-pack copies or embedded fallbacks when source files are missing
- add helper to resolve template rule sources and ensure selected rule tracking includes generated content
- cover rule inclusion logic with a unit test that asserts the expected .mdc files are written for typical stacks

## Testing
- pytest project_generator/tests/test_unit/test_generator.py::TestProjectGenerator::test_include_selected_project_rules_outputs

------
https://chatgpt.com/codex/tasks/task_e_68d25a58c438832ea0480d4e7293d789