### PR TITLE
Refine lifecycle planner to be data-driven

### DIFF
--- a/scripts/plan_from_brief.py
+++ b/scripts/plan_from_brief.py
@@ -7,116 +7,146 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import replace
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, Iterable, List, Sequence
 
-from project_generator.core.brief_parser import BriefParser
+from project_generator.core.brief_parser import BriefParser, ScaffoldSpec
 
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Generate FE/BE plan artifacts from brief.md")
     p.add_argument("--brief", required=True, help="Path to brief.md")
     p.add_argument("--out", default="PLAN.md", help="Path to write PLAN.md (tasks.json will be co-located)")
+    p.add_argument(
+        "--config",
+        help="Optional workflow.config.json override to align with lifecycle planning",
+    )
     return p.parse_args()
+
+
+Task = Dict[str, Any]
 
 
 def task(
     id_: str,
     title: str,
     area: str,
-    blocked_by: List[str] | None = None,
-    labels: List[str] | None = None,
+    *,
+    blocked_by: Sequence[str] | None = None,
+    labels: Sequence[str] | None = None,
     estimate: str = "1d",
-    acceptance: List[str] | None = None,
-    dod: List[str] | None = None,
-) -> Dict:
+    acceptance: Sequence[str] | None = None,
+    dod: Sequence[str] | None = None,
+) -> Task:
     return {
         "id": id_,
         "title": title,
         "area": area,
         "estimate": estimate,
-        "blocked_by": blocked_by or [],
-        "labels": labels or [],
-        "acceptance": acceptance or [],
-        "dod": dod or [],
+        "blocked_by": list(blocked_by or []),
+        "labels": list(labels or []),
+        "acceptance": list(acceptance or []),
+        "dod": list(dod or []),
         "state": "pending",
     }
 
 
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    be: List[Dict] = []
-    fe: List[Dict] = []
+def apply_workflow_overrides(spec: ScaffoldSpec, workflow_config: Dict[str, Any] | None) -> ScaffoldSpec:
+    if not workflow_config:
+        return spec
+    overrides: Dict[str, Any] = {}
+    scalar_fields = {
+        "name",
+        "industry",
+        "project_type",
+        "frontend",
+        "backend",
+        "database",
+        "auth",
+        "deploy",
+    }
+    for field in scalar_fields:
+        value = workflow_config.get(field)
+        if isinstance(value, str) and value.strip():
+            overrides[field] = value.strip().lower()
+    if "compliance" in workflow_config:
+        comp_val = workflow_config["compliance"]
+        if isinstance(comp_val, str):
+            overrides["compliance"] = [c.strip().lower() for c in comp_val.split(",") if c.strip()]
+        elif isinstance(comp_val, Iterable):
+            overrides["compliance"] = [str(c).strip().lower() for c in comp_val if str(c).strip()]
+    if "features" in workflow_config:
+        feat_val = workflow_config["features"]
+        if isinstance(feat_val, str):
+            overrides["features"] = [f.strip() for f in feat_val.split(",") if f.strip()]
+        elif isinstance(feat_val, Iterable):
+            overrides["features"] = [str(f).strip() for f in feat_val if str(f).strip()]
+    if not overrides:
+        return spec
+    return replace(spec, **overrides)
 
-    # Backend lane
-    be.append(
-        task(
-            "BE-SCH",
-            "Design DB schema",
-            "backend",
-            acceptance=["ERD drafted", "tables defined", "naming conventions applied"],
+
+def _backend_core_tasks(spec: ScaffoldSpec) -> List[Task]:
+    tasks: List[Task] = []
+    if spec.backend == "none":
+        return tasks
+
+    if spec.database != "none":
+        tasks.extend(
+            [
+                task(
+                    "BE-SCH",
+                    f"Design {spec.database} schema",
+                    "backend",
+                    acceptance=[
+                        "ERD drafted",
+                        "tables defined",
+                        f"naming conventions applied for {spec.database}",
+                    ],
+                ),
+                task(
+                    "BE-SEED",
+                    "Seed loaders (CSV/mock)",
+                    "backend",
+                    blocked_by=["BE-SCH"],
+                    acceptance=["seed scripts run", "sample rows present"],
+                ),
+                task(
+                    "BE-MDL",
+                    "Aggregates/materialized views",
+                    "backend",
+                    blocked_by=["BE-SEED"],
+                    acceptance=["views created", "query p95 < 400ms (seed)"],
+                ),
+            ]
         )
-    )
-    be.append(
-        task(
-            "BE-SEED",
-            "Seed loaders (CSV/mock)",
-            "backend",
-            blocked_by=["BE-SCH"],
-            acceptance=["seed scripts run", "sample rows present"],
+
+    feature_endpoints = _select_backend_endpoints(spec)
+    for idx, endpoint in enumerate(feature_endpoints, 1):
+        deps = ["BE-MDL"] if spec.database != "none" else []
+        tasks.append(
+            task(
+                f"BE-API-{idx:02d}",
+                endpoint,
+                "backend",
+                blocked_by=deps,
+                acceptance=["OpenAPI updated", "contract tests pass"],
+            )
         )
-    )
-    be.append(
-        task(
-            "BE-MDL",
-            "Aggregates/MatViews (funnel, revenue, etc.)",
-            "backend",
-            blocked_by=["BE-SEED"],
-            acceptance=["views created", "query p95 < 400ms (seed)"],
+
+    if spec.auth != "none":
+        tasks.append(
+            task(
+                "BE-AUTH",
+                f"{spec.auth.title()} integration & RBAC",
+                "backend",
+                labels=["security"],
+                acceptance=["role checks present", "token validation tested"],
+            )
         )
-    )
-    be += [
-        task(
-            "BE-API-KPI",
-            "GET /api/v1/kpis",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["returns totals/deltas", "OpenAPI updated"],
-        ),
-        task(
-            "BE-API-REV",
-            "GET /api/v1/revenue",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["time series ok", "OpenAPI updated"],
-        ),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task(
-            "BE-EXP",
-            "GET /api/v1/export/csv",
-            "backend",
-            blocked_by=[
-                "BE-API-KPI",
-                "BE-API-REV",
-                "BE-API-CAT",
-                "BE-API-PLT",
-                "BE-API-CUS",
-                "BE-API-FDB",
-            ],
-        ),
-    ]
-    be.append(
-        task(
-            "BE-AUTH",
-            "Auth0/RBAC skeleton",
-            "backend",
-            labels=["security"],
-            acceptance=["role checks present"],
-        )
-    )
-    be.append(
+
+    tasks.append(
         task(
             "BE-OBS",
             "Structured logs + correlation IDs",
@@ -125,84 +155,172 @@ def build_plan(spec) -> Dict[str, List[Dict]]:
             acceptance=["request id on logs"],
         )
     )
-    be.append(
+
+    tasks.append(
         task(
             "BE-TST",
-            "Unit+Integration tests (Testcontainers)",
+            "Unit + integration test suite",
             "backend",
-            blocked_by=["BE-API-KPI", "BE-API-REV"],
+            blocked_by=[t["id"] for t in tasks if t["id"].startswith("BE-API-")][:2],
             acceptance=["pytest green", ">= minimal coverage"],
         )
     )
 
-    # Frontend lane
-    fe.append(
-        task(
-            "FE-DSN",
-            "Shell/Layout/Routes",
-            "frontend",
-            acceptance=["routes wired", "base theme applied"],
+    for compliance_task in _compliance_tasks(spec, area="backend"):
+        tasks.append(compliance_task)
+
+    for feature_task in _feature_specific_backend_tasks(spec):
+        tasks.append(feature_task)
+
+    return tasks
+
+
+def _select_backend_endpoints(spec: ScaffoldSpec) -> List[str]:
+    if spec.project_type == "api":
+        base_endpoints = ["Expose core domain endpoints"]
+    else:
+        base_endpoints = [
+            "GET /api/v1/kpis",
+            "GET /api/v1/revenue",
+            "GET /api/v1/categories",
+            "GET /api/v1/platforms",
+            "GET /api/v1/feedback",
+        ]
+
+    keywords = {
+        "billing": "POST /api/v1/billing/charges",
+        "ai": "POST /api/v1/assistant/complete",
+        "notifications": "POST /api/v1/notifications",
+        "realtime": "WS /events stream",
+        "analytics": "GET /api/v1/analytics/summary",
+        "reports": "GET /api/v1/reports/export",
+    }
+    for feature in spec.features:
+        normalized = feature.lower()
+        for key, endpoint in keywords.items():
+            if key in normalized and endpoint not in base_endpoints:
+                base_endpoints.append(endpoint)
+
+    if spec.project_type == "api" and len(base_endpoints) == 1:
+        base_endpoints.extend(
+            [
+                "GET /api/v1/health",
+                "GET /api/v1/status",
+            ]
         )
-    )
-    fe.append(
-        task(
-            "FE-TYPES",
-            "openapi-typescript client",
-            "frontend",
-            acceptance=["types.ts generated", "typed client compiles"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-MOCKS",
-            "MSW/Prism mocks",
-            "frontend",
-            acceptance=["mocks respond", "dev proxy configured"],
-        )
-    )
-    fe += [
-        task(
-            "FE-KPI",
-            "KPI cards + filters",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
+
+    return base_endpoints
+
+
+def _feature_specific_backend_tasks(spec: ScaffoldSpec) -> List[Task]:
+    tasks: List[Task] = []
+    feature_map = {
+        "audit": task(
+            "BE-AUDIT",
+            "Persistent audit log",
+            "backend",
+            labels=["compliance"],
+            acceptance=["immutable trail", "admin review endpoint"],
         ),
-        task(
-            "FE-REV",
-            "Revenue chart + range selectors",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
+        "realtime": task(
+            "BE-REALTIME",
+            "Realtime gateway (WebSockets/pub-sub)",
+            "backend",
+            labels=["performance"],
+            acceptance=["fan-out load tested"],
         ),
-        task("FE-PLT", "Platform distribution (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
+        "ml": task(
+            "BE-ML",
+            "Model inference endpoint",
+            "backend",
+            labels=["ml"],
+            acceptance=["latency < 800ms", "fallback path present"],
+        ),
+    }
+    for feature in spec.features:
+        key = feature.lower()
+        for matcher, ft_task in feature_map.items():
+            if matcher in key and ft_task not in tasks:
+                tasks.append(ft_task)
+    return tasks
+
+
+def _frontend_core_tasks(spec: ScaffoldSpec) -> List[Task]:
+    tasks: List[Task] = []
+    if spec.frontend == "none" or spec.project_type == "api":
+        return tasks
+
+    tasks.extend(
+        [
+            task(
+                "FE-DSN",
+                "Shell/Layout/Routes",
+                "frontend",
+                acceptance=["routes wired", "base theme applied"],
+            ),
+            task(
+                "FE-TYPES",
+                "API client generation",
+                "frontend",
+                acceptance=["types generated", "typed client compiles"],
+            ),
+            task(
+                "FE-MOCKS",
+                "Mock service worker / API mocks",
+                "frontend",
+                acceptance=["mocks respond", "dev proxy configured"],
+            ),
+        ]
+    )
+
+    analytics_components = [
+        ("FE-KPI", "KPI cards + filters"),
+        ("FE-REV", "Revenue chart + range selectors"),
+        ("FE-PLT", "Platform distribution (bars)"),
+        ("FE-CAT", "Category ranks (bars)"),
+        ("FE-FDB", "Feedback timeline"),
+    ]
+    for tid, title in analytics_components:
+        tasks.append(
+            task(
+                tid,
+                title,
+                "frontend",
+                blocked_by=["FE-DSN", "FE-TYPES"],
+                acceptance=["renders", "no console errors"],
+            )
+        )
+
+    if "mobile" in (f.lower() for f in spec.features):
+        tasks.append(
+            task(
+                "FE-RESP",
+                "Responsive layout / mobile optimisations",
+                "frontend",
+                labels=["ux"],
+                acceptance=["lighthouse mobile ≥ 80"],
+            )
+        )
+
+    tasks.append(
         task(
             "FE-EXP",
             "Exports (CSV/PNG)",
             "frontend",
-            blocked_by=[
-                "FE-KPI",
-                "FE-REV",
-                "FE-PLT",
-                "FE-CAT",
-                "FE-CUS",
-                "FE-FDB",
-            ],
+            blocked_by=[t["id"] for t in tasks if t["id"].startswith("FE-") and t["id"] not in {"FE-DSN", "FE-TYPES", "FE-MOCKS"}],
             acceptance=["CSV downloads"],
-        ),
-    ]
-    fe.append(
+        )
+    )
+
+    tasks.append(
         task(
             "FE-A11Y-PERF",
-            "WCAG AA + code-split/memoize",
+            "WCAG AA + performance budget",
             "frontend",
             labels=["a11y", "performance"],
         )
     )
-    fe.append(
+    tasks.append(
         task(
             "FE-TST",
             "Component + E2E smoke",
@@ -212,7 +330,73 @@ def build_plan(spec) -> Dict[str, List[Dict]]:
         )
     )
 
-    return {"backend": be, "frontend": fe}
+    for compliance_task in _compliance_tasks(spec, area="frontend"):
+        tasks.append(compliance_task)
+
+    return tasks
+
+
+def _compliance_tasks(spec: ScaffoldSpec, area: str) -> List[Task]:
+    compliance_map = {
+        "hipaa": task(
+            f"{area.upper()}-HIPAA",
+            "HIPAA safeguards implementation",
+            area,
+            labels=["compliance"],
+            acceptance=["logging PHI access", "BAA reviewed"],
+        ),
+        "pci": task(
+            f"{area.upper()}-PCI",
+            "PCI DSS controls",
+            area,
+            labels=["compliance"],
+            acceptance=["encryption at rest/in transit verified"],
+        ),
+        "gdpr": task(
+            f"{area.upper()}-GDPR",
+            "GDPR data subject workflows",
+            area,
+            labels=["compliance"],
+            acceptance=["erasure + export flows covered"],
+        ),
+        "soc2": task(
+            f"{area.upper()}-SOC2",
+            "SOC2 audit evidence",
+            area,
+            labels=["compliance"],
+            acceptance=["controls mapped", "evidence stored"],
+        ),
+    }
+    tasks: List[Task] = []
+    for rule in spec.compliance:
+        key = rule.lower()
+        if key in compliance_map:
+            tasks.append(compliance_map[key])
+    return tasks
+
+
+def build_plan(spec: ScaffoldSpec, workflow_config: Dict[str, Any] | None = None) -> Dict[str, List[Task]]:
+    effective_spec = apply_workflow_overrides(spec, workflow_config)
+
+    backend_lane = _backend_core_tasks(effective_spec)
+    frontend_lane = _frontend_core_tasks(effective_spec)
+
+    lanes = {
+        "backend": backend_lane,
+        "frontend": frontend_lane,
+    }
+
+    # honour workflow config lane disablement
+    disabled_lanes = {
+        lane
+        for lane, enabled in (workflow_config or {}).get("lanes", {}).items()
+        if not enabled
+    }
+    for lane in disabled_lanes:
+        if lane in lanes:
+            lanes[lane] = []
+
+    return lanes
 
 
 def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:
@@ -242,7 +426,14 @@ def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:
 def main() -> None:
     args = parse_args()
     spec = BriefParser(args.brief).parse()
-    plan = build_plan(spec)
+    workflow_cfg: Dict[str, Any] | None = None
+    if args.config:
+        cfg_path = Path(args.config)
+        if not cfg_path.exists():
+            raise FileNotFoundError(f"Workflow config not found: {cfg_path}")
+        workflow_cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+    plan = build_plan(spec, workflow_cfg)
 
     # Write tasks.json
     tasks_json_path = Path(args.out).with_suffix(".tasks.json")

--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -1,122 +1,582 @@
 #!/usr/bin/env python3
-"""
-Pre-lifecycle roadmap generator.
-
-Reads workflow.config.json (or overrides) and the corresponding docs/briefs/<NAME>/brief.md,
-recreates the ordered task lanes, then prints a sequential, human-readable checklist that
-extends the lifecycle automation with the manual quality, deploy, and observability work.
-"""
+"""Pre-lifecycle roadmap generator with capability-aware branching."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import shlex
+import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Sequence, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from project_generator.core.brief_parser import BriefParser  # type: ignore[misc]
+from project_generator.core.brief_parser import BriefParser, ScaffoldSpec  # type: ignore[misc]
+from scripts.plan_from_brief import apply_workflow_overrides, build_plan  # type: ignore[misc]
 
 
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    """Replica of scripts/plan_from_brief.build_plan to reuse lane ordering."""
-    def task(id_, title, area, blocked_by=None, labels=None, estimate="1d",
-             acceptance=None, dod=None):
-        return {
-            "id": id_,
-            "title": title,
-            "area": area,
-            "estimate": estimate,
-            "blocked_by": blocked_by or [],
-            "labels": labels or [],
-            "acceptance": acceptance or [],
-            "dod": dod or [],
-            "state": "pending",
-        }
+@dataclass
+class ChecklistItem:
+    description: str
+    command: str | None = None
+    requires: Tuple[Path, ...] = ()
+    optional: bool = False
 
-    be: List[Dict] = []
-    fe: List[Dict] = []
 
-    be.append(task("BE-SCH", "Design DB schema", "backend",
-                   acceptance=["ERD drafted", "tables defined", "naming conventions applied"]))
-    be.append(task("BE-SEED", "Seed loaders (CSV/mock)", "backend", blocked_by=["BE-SCH"],
-                   acceptance=["seed scripts run", "sample rows present"]))
-    be.append(task("BE-MDL", "Aggregates/MatViews (funnel, revenue, etc.)", "backend",
-                   blocked_by=["BE-SEED"],
-                   acceptance=["views created", "query p95 < 400ms (seed)"]))
-    be += [
-        task("BE-API-KPI", "GET /api/v1/kpis", "backend", blocked_by=["BE-MDL"],
-             acceptance=["returns totals/deltas", "OpenAPI updated"]),
-        task("BE-API-REV", "GET /api/v1/revenue", "backend", blocked_by=["BE-MDL"],
-             acceptance=["time series ok", "OpenAPI updated"]),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task("BE-EXP", "GET /api/v1/export/csv", "backend",
-             blocked_by=["BE-API-KPI", "BE-API-REV", "BE-API-CAT",
-                         "BE-API-PLT", "BE-API-CUS", "BE-API-FDB"]),
-    ]
-    be.append(task("BE-AUTH", "Auth0/RBAC skeleton", "backend",
-                   labels=["security"], acceptance=["role checks present"]))
-    be.append(task("BE-OBS", "Structured logs + correlation IDs", "backend",
-                   labels=["observability"], acceptance=["request id on logs"]))
-    be.append(task("BE-TST", "Unit+Integration tests (Testcontainers)", "backend",
-                   blocked_by=["BE-API-KPI", "BE-API-REV"],
-                   acceptance=["pytest green", ">= minimal coverage"]))
+@dataclass
+class Stage:
+    title: str
+    items: List[ChecklistItem] = field(default_factory=list)
 
-    fe.append(task("FE-DSN", "Shell/Layout/Routes", "frontend",
-                   acceptance=["routes wired", "base theme applied"]))
-    fe.append(task("FE-TYPES", "openapi-typescript client", "frontend",
-                   acceptance=["types.ts generated", "typed client compiles"]))
-    fe.append(task("FE-MOCKS", "MSW/Prism mocks", "frontend",
-                   acceptance=["mocks respond", "dev proxy configured"]))
-    fe += [
-        task("FE-KPI", "KPI cards + filters", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-REV", "Revenue chart + range selectors", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-PLT", "Platform distribution (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-EXP", "Exports (CSV/PNG)", "frontend",
-             blocked_by=["FE-KPI", "FE-REV", "FE-PLT", "FE-CAT", "FE-CUS", "FE-FDB"],
-             acceptance=["CSV downloads"]),
-    ]
-    fe.append(task("FE-A11Y-PERF", "WCAG AA + code-split/memoize", "frontend",
-                   labels=["a11y", "performance"]))
-    fe.append(task("FE-TST", "Component + E2E smoke", "frontend",
-                   blocked_by=["FE-KPI", "FE-REV"], acceptance=["tests green"]))
 
-    return {"backend": be, "frontend": fe}
+@dataclass
+class CommandResult:
+    stage: str
+    description: str
+    command: str
+    returncode: int
+
+
+class ScriptLocator:
+    """Utility to discover scripts relative to the repo root."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self._cache: Dict[str, Path] = {}
+
+    def path(self, name: str) -> Path:
+        if name not in self._cache:
+            matches = sorted((self.root / "scripts").rglob(name))
+            if not matches:
+                raise FileNotFoundError(f"Unable to locate script '{name}' under {self.root / 'scripts'}")
+            self._cache[name] = matches[0]
+        return self._cache[name]
+
+    def rel(self, name: str) -> Path:
+        return self.path(name).relative_to(self.root)
+
+
+def shell_join(parts: Sequence[str]) -> str:
+    return " ".join(shlex.quote(str(p)) for p in parts)
 
 
 def format_lane(lane: List[Dict]) -> List[str]:
-    entries = []
-    for idx, t in enumerate(lane, 1):
-        blockers = ", ".join(t["blocked_by"]) if t["blocked_by"] else "none"
-        acceptance = ", ".join(t["acceptance"]) if t["acceptance"] else "see acceptance criteria"
+    entries: List[str] = []
+    for idx, task in enumerate(lane, 1):
+        blockers = ", ".join(task["blocked_by"]) if task["blocked_by"] else "none"
+        acceptance = ", ".join(task["acceptance"]) if task["acceptance"] else "see acceptance criteria"
         entries.append(
-            f"{t['id']}: {t['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
+            f"{idx:02d}. {task['id']}: {task['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
         )
     return entries
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
+def artifact_item(description: str, *paths: Path, optional: bool = False) -> ChecklistItem:
+    return ChecklistItem(description=description, requires=tuple(paths), optional=optional)
+
+
+def _build_environment_stage(
+    cfg_path: Path,
+    brief_path: Path,
+    output_root: Path,
+    spec: ScaffoldSpec,
+) -> Stage:
+    exports = shell_join(
+        [
+            f"NAME={spec.name}",
+            f"INDUSTRY={spec.industry}",
+            f"PROJECT_TYPE={spec.project_type}",
+            f"FE={spec.frontend}",
+            f"BE={spec.backend}",
+            f"DB={spec.database}",
+            f"OUTPUT_ROOT={output_root}",
+        ]
+    )
+    description = (
+        "Export automation variables before running lifecycle: "
+        f"{exports} [optional: AUTH, DEPLOY, COMPLIANCE, FORCE_OUTPUT=1]"
+    )
+    return Stage(
+        title="Environment & Inputs",
+        items=[
+            ChecklistItem("Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git."),
+            artifact_item(f"Confirm workflow config exists at {cfg_path}", cfg_path),
+            artifact_item(f"Confirm brief exists at {brief_path}", brief_path),
+            ChecklistItem(
+                "Verify workflow.config.json values "
+                f"(industry={spec.industry}, project_type={spec.project_type}, frontend={spec.frontend}, "
+                f"backend={spec.backend}, database={spec.database}, auth={spec.auth}, deploy={spec.deploy}, "
+                f"compliance={','.join(spec.compliance) if spec.compliance else 'none'})."
+            ),
+            ChecklistItem(description),
+        ],
+    )
+
+
+def _build_planning_stage(
+    locator: ScriptLocator,
+    brief_path: Path,
+    project_dir: Path,
+    plan_path: Path,
+    plan_tasks: Path,
+    workflow_cfg_path: Path | None,
+) -> Stage:
+    plan_cmd_parts = ["python", str(locator.rel("plan_from_brief.py")), "--brief", str(brief_path), "--out", str(plan_path)]
+    if workflow_cfg_path is not None:
+        plan_cmd_parts.extend(["--config", str(workflow_cfg_path)])
+    plan_cmd = shell_join(plan_cmd_parts)
+
+    validate_cmd = shell_join([
+        "python",
+        str(locator.rel("validate_tasks.py")),
+        "--input",
+        str(plan_tasks),
+    ])
+
+    return Stage(
+        title="Planning & Alignment",
+        items=[
+            ChecklistItem("Review brief acceptance criteria, compliance asks, and stakeholder priorities."),
+            ChecklistItem(f"Generate planning artifacts: {plan_cmd}", command=plan_cmd),
+            artifact_item(f"Ensure PLAN.md exists at {plan_path}", plan_path),
+            artifact_item(f"Ensure PLAN.tasks.json exists at {plan_tasks}", plan_tasks),
+            ChecklistItem(f"Validate DAG topology: {validate_cmd}", command=validate_cmd, requires=(plan_tasks,)),
+        ],
+    )
+
+
+def _build_preflight_stage(
+    locator: ScriptLocator,
+    spec: ScaffoldSpec,
+    project_dir: Path,
+    output_root: Path,
+    compliance: Sequence[str],
+) -> Stage:
+    doctor_cmd = shell_join([
+        "python",
+        str(locator.rel("doctor.py")),
+        "--strict",
+    ])
+    generator = locator.rel("generate_client_project.py")
+    list_cmd = shell_join(
+        [
+            "python",
+            str(generator),
+            "--list-templates",
+            "--name",
+            spec.name,
+            "--industry",
+            spec.industry,
+            "--project-type",
+            spec.project_type,
+        ]
+    )
+
+    select_parts = [
+        "python",
+        str(locator.rel("select_stacks.py")),
+        "--industry",
+        spec.industry,
+        "--project-type",
+        spec.project_type,
+        "--frontend",
+        spec.frontend,
+        "--backend",
+        spec.backend,
+        "--database",
+        spec.database,
+        "--output",
+        str(project_dir / "selection.json"),
+        "--summary",
+        str(project_dir / "evidence" / "stack-selection.md"),
+    ]
+    if spec.auth != "none":
+        select_parts.extend(["--auth", spec.auth])
+    if compliance:
+        select_parts.extend(["--compliance", ",".join(compliance)])
+    select_cmd = shell_join(select_parts)
+
+    dry_run_parts = [
+        "python",
+        str(generator),
+        "--dry-run",
+        "--workers",
+        "8",
+        "--yes",
+        "--name",
+        spec.name,
+        "--industry",
+        spec.industry,
+        "--project-type",
+        spec.project_type,
+        "--frontend",
+        spec.frontend,
+        "--backend",
+        spec.backend,
+        "--database",
+        spec.database,
+        "--output-dir",
+        str(output_root),
+    ]
+    if spec.auth != "none":
+        dry_run_parts.extend(["--auth", spec.auth])
+    if spec.deploy not in {"n/a", "none"}:
+        dry_run_parts.extend(["--deploy", spec.deploy])
+    if compliance:
+        dry_run_parts.extend(["--compliance", ",".join(compliance)])
+    dry_run_cmd = shell_join(dry_run_parts)
+
+    return Stage(
+        title="Stack Preflight & Generation Prep",
+        items=[
+            ChecklistItem(f"Tooling doctor: {doctor_cmd}", command=doctor_cmd),
+            ChecklistItem(f"Template discovery: {list_cmd}", command=list_cmd),
+            ChecklistItem(
+                f"Select stacks and capture evidence: {select_cmd}",
+                command=select_cmd,
+            ),
+            ChecklistItem(
+                "If select_stacks exits with code 3, resolve engine version mismatches before continuing."
+            ),
+            ChecklistItem(f"Preview scaffold (no writes): {dry_run_cmd}", command=dry_run_cmd),
+        ],
+    )
+
+
+def _build_generation_stage(spec: ScaffoldSpec, output_root: Path, project_dir: Path) -> Stage:
+    exports = [
+        f"NAME={spec.name}",
+        f"INDUSTRY={spec.industry}",
+        f"PROJECT_TYPE={spec.project_type}",
+        f"FE={spec.frontend}",
+        f"BE={spec.backend}",
+        f"DB={spec.database}",
+        f"OUTPUT_ROOT={output_root}",
+    ]
+    if spec.auth != "none":
+        exports.append(f"AUTH={spec.auth}")
+    if spec.deploy not in {"n/a", "none"}:
+        exports.append(f"DEPLOY={spec.deploy}")
+    if spec.compliance:
+        exports.append(f"COMPLIANCE={','.join(spec.compliance)}")
+    lifecycle_cmd = shell_join(exports + ["make", "lifecycle"])
+
+    return Stage(
+        title="Full Scaffold Generation & Bootstrap",
+        items=[
+            ChecklistItem(
+                f"Run lifecycle generator (stops on failure): {lifecycle_cmd}",
+                command=lifecycle_cmd,
+            ),
+            artifact_item(f"Inspect generated project at {project_dir}", project_dir),
+            artifact_item(
+                "Ensure evidence/, PLAN.*, tasks.json, and dist/ artifacts exist",
+                project_dir / "evidence",
+                project_dir / "PLAN.md",
+                project_dir / "PLAN.tasks.json",
+                project_dir / "dist",
+                optional=False,
+            ),
+            ChecklistItem("Capture generator logs and stack selection evidence for audit."),
+        ],
+    )
+
+
+def _build_lane_stage(title: str, intro: str, lane: List[str]) -> Stage | None:
+    if not lane:
+        return None
+    items = [ChecklistItem(intro)]
+    items.extend(ChecklistItem(entry) for entry in lane)
+    return Stage(title=title, items=items)
+
+
+def _build_integration_stage(spec: ScaffoldSpec) -> Stage:
+    items: List[ChecklistItem] = []
+    if spec.database != "none":
+        items.append(
+            ChecklistItem(
+                "Create/adjust migrations, apply them, and reseed sample data (aligns with BE schema tasks)."
+            )
+        )
+    if spec.backend != "none":
+        items.append(
+            ChecklistItem(
+                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types after changes."
+            )
+        )
+    if spec.frontend != "none" and spec.project_type != "api":
+        items.append(ChecklistItem("Update MSW/Prism mocks to match live responses."))
+    items.append(ChecklistItem("Run smoke flows across dashboards/endpoints to confirm PLAN acceptance."))
+    return Stage(title="Integration, Data, and Contract Validation", items=items)
+
+
+def _build_quality_stage(
+    locator: ScriptLocator,
+    project_dir: Path,
+    include_frontend: bool,
+    include_backend: bool,
+) -> Stage:
+    items: List[ChecklistItem] = []
+    if include_frontend:
+        items.extend(
+            [
+                ChecklistItem(
+                    "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check`.")
+            ,
+                ChecklistItem(
+                    "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`."
+                ),
+            ]
+        )
+    if include_backend:
+        items.extend(
+            [
+                ChecklistItem(
+                    "Backend quality: run formatter/lint (black, flake8, eslint) appropriate for the generated stack."
+                ),
+                ChecklistItem(
+                    "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`."
+                ),
+            ]
+        )
+    install_and_test = shell_join([
+        f"PROJECT_ROOT={project_dir}",
+        str(locator.rel("install_and_test.sh")),
+    ])
+    items.append(ChecklistItem(f"Aggregate stack-aware tests: {install_and_test}", command=install_and_test))
+    items.append(
+        ChecklistItem(
+            f"Collect metrics: PROJECT_ROOT={project_dir} python {locator.rel('collect_coverage.py')} / collect_perf.py / scan_deps.py"
+        )
+    )
+    items.append(
+        ChecklistItem(
+            f"Enforce gates: PROJECT_ROOT={project_dir} python {locator.rel('enforce_gates.py')}"
+        )
+    )
+    return Stage(title="Quality Automation & Gates", items=items)
+
+
+def _build_local_verification_stage(project_dir: Path, include_frontend: bool, include_backend: bool) -> Stage:
+    items: List[ChecklistItem] = []
+    if include_frontend:
+        items.append(ChecklistItem("Run `cd frontend && npm run dev` for experiential QA."))
+    if include_backend:
+        items.append(ChecklistItem("Run backend dev server (uvicorn/stack default) for manual verification."))
+    if include_frontend or include_backend:
+        items.append(ChecklistItem("Execute API/UI smoke via Postman/Newman or Playwright as applicable."))
+    items.append(
+        ChecklistItem(
+            "Run make pipeline-validate ENV=local once health endpoints exist to assert end-to-end readiness."
+        )
+    )
+    return Stage(title="Local Verification & Developer Experience", items=items)
+
+
+def _build_compliance_stage(
+    locator: ScriptLocator,
+    project_dir: Path,
+    compliance: Sequence[str],
+) -> Stage | None:
+    if not compliance:
+        return None
+    build_pack = shell_join([
+        f"PROJECT_ROOT={project_dir}",
+        f"NAME={Path(project_dir).name}",
+        str(locator.rel("build_submission_pack.sh")),
+    ])
+    validate_assets = shell_join([
+        f"PROJECT_ROOT={project_dir}",
+        "python",
+        str(locator.rel("validate_compliance_assets.py")),
+    ])
+    check_docs = shell_join([
+        f"PROJECT_ROOT={project_dir}",
+        "python",
+        str(locator.rel("check_compliance_docs.py")),
+    ])
+    items = [
+        ChecklistItem(f"Package deliverables: {build_pack}", command=build_pack),
+        ChecklistItem(f"Validate compliance assets: {validate_assets}", command=validate_assets),
+        ChecklistItem(f"Optional doc scan: {check_docs}", command=check_docs, optional=True),
+        ChecklistItem("Archive evidence/, dist/, coverage/, and reports/ for hand-off."),
+    ]
+    return Stage(title="Compliance, Evidence, and Packaging", items=items)
+
+
+def _build_ci_stage(spec: ScaffoldSpec) -> Stage:
+    items = [
+        ChecklistItem(
+            "Populate GitHub secrets/vars required by CI workflows (see .github/workflows)."
+        ),
+        ChecklistItem("Enforce production environment protection/approvals in GitHub."),
+        ChecklistItem("Trigger ci-secrets-preflight and resolve missing configuration."),
+        ChecklistItem("Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass."),
+    ]
+    return Stage(title="CI/CD Enablement", items=items)
+
+
+def _build_deploy_stage(locator: ScriptLocator, spec: ScaffoldSpec) -> Stage | None:
+    if spec.deploy in {"n/a", "none"}:
+        return None
+    health_cmd = shell_join([
+        "python",
+        str(locator.rel("health/check_deployment.py")),
+        "--environment",
+        "staging",
+    ])
+    items = [
+        ChecklistItem("Staging: push to main to invoke deployment workflow."),
+        ChecklistItem(f"Review staging deploy health via {health_cmd}.", command=health_cmd),
+        ChecklistItem(
+            "Production: trigger promotion workflow, ensure approvals granted, monitor verify-and-gate jobs."
+        ),
+        ChecklistItem(
+            "Post deploy: download production validation reports and confirm smoke + newman tests passed."
+        ),
+        ChecklistItem(
+            "If failures occur, invoke rollback scripts (backend/frontend) via GitHub Actions or manually."
+        ),
+    ]
+    return Stage(title="Deploy & Promote", items=items)
+
+
+def _build_observability_stage(spec: ScaffoldSpec, staging_urls: Dict[str, str], prod_urls: Dict[str, str]) -> Stage:
+    items = [
+        ChecklistItem("Schedule and monitor nightly observability workflows; ensure environment URLs stay current."),
+    ]
+    if spec.deploy not in {"n/a", "none"}:
+        items.extend(
+            [
+                ChecklistItem(
+                    f"Validate staging via make pipeline-validate with FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']}"
+                ),
+                ChecklistItem(
+                    f"Validate production via make pipeline-validate with FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']}"
+                ),
+            ]
+        )
+    items.append(ChecklistItem("Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance."))
+    return Stage(title="Observability & Continuous Ops", items=items)
+
+
+def _build_final_stage(project_dir: Path, spec: ScaffoldSpec) -> Stage:
+    items = [
+        ChecklistItem(
+            f"Hand off dist/{spec.name}-submission, PLAN artifacts, selection.json, and compliance logs."
+        ),
+        ChecklistItem(
+            f"Document residual risks or follow-ups in {project_dir / 'reports'} or IMPLEMENTATION_SUMMARY.md."
+        ),
+        ChecklistItem("Capture implementation retrospective and update workflow config/docs for future engagements."),
+    ]
+    return Stage(title="Final Delivery & Retrospective", items=items)
+
+
+def build_stages(
+    cfg_path: Path,
+    brief_path: Path,
+    output_root: Path,
+    project_dir: Path,
+    spec: ScaffoldSpec,
+    workflow_cfg: Dict[str, object],
+    lanes: Dict[str, List[Dict]],
+) -> List[Stage]:
+    locator = ScriptLocator(ROOT)
+    plan_path = project_dir / "PLAN.md"
+    plan_tasks = project_dir / "PLAN.tasks.json"
+
+    compliance = list(spec.compliance)
+
+    stages: List[Stage] = []
+    stages.append(_build_environment_stage(cfg_path, brief_path, output_root, spec))
+    stages.append(
+        _build_planning_stage(
+            locator,
+            brief_path,
+            project_dir,
+            plan_path,
+            plan_tasks,
+            cfg_path if cfg_path.exists() else None,
+        )
+    )
+    stages.append(
+        _build_preflight_stage(locator, spec, project_dir, output_root, compliance)
+    )
+    stages.append(_build_generation_stage(spec, output_root, project_dir))
+
+    frontend_lane = format_lane(lanes.get("frontend", []))
+    backend_lane = format_lane(lanes.get("backend", []))
+
+    frontend_stage = _build_lane_stage(
+        "Frontend Implementation Sequence", f"Work inside {project_dir / 'frontend'} following tasks in order:", frontend_lane
+    )
+    backend_stage = _build_lane_stage(
+        "Backend & Data Implementation Sequence",
+        f"Work inside {project_dir / 'backend'} (and database/ if emitted) following tasks in order:",
+        backend_lane,
+    )
+    if frontend_stage:
+        stages.append(frontend_stage)
+    if backend_stage:
+        stages.append(backend_stage)
+
+    stages.append(_build_integration_stage(spec))
+    stages.append(
+        _build_quality_stage(
+            locator,
+            project_dir,
+            include_frontend=bool(frontend_lane),
+            include_backend=bool(backend_lane),
+        )
+    )
+    stages.append(
+        _build_local_verification_stage(
+            project_dir,
+            include_frontend=bool(frontend_lane),
+            include_backend=bool(backend_lane),
+        )
+    )
+    compliance_stage = _build_compliance_stage(locator, project_dir, compliance)
+    if compliance_stage:
+        stages.append(compliance_stage)
+    stages.append(_build_ci_stage(spec))
+    deploy_stage = _build_deploy_stage(locator, spec)
+    if deploy_stage:
+        stages.append(deploy_stage)
+
+    staging_urls = {
+        "frontend": "${vars.FRONTEND_URL_STAGING}",
+        "api": "${vars.API_URL_STAGING}",
+        "db": "${vars.DB_URL_STAGING}",
+    }
+    prod_urls = {
+        "frontend": "${vars.FRONTEND_URL_PRODUCTION}",
+        "api": "${vars.API_URL_PRODUCTION}",
+        "db": "${vars.DB_URL_PRODUCTION}",
+    }
+    stages.append(_build_observability_stage(spec, staging_urls, prod_urls))
+    stages.append(_build_final_stage(project_dir, spec))
+
+    return stages
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Print or execute the pre-lifecycle execution plan.")
     ap.add_argument("--name", help="Client/project name override")
     ap.add_argument("--config", default="workflow.config.json")
     ap.add_argument("--output-root", default="../_generated")
-    args = ap.parse_args()
+    ap.add_argument("--execute", action="store_true", help="Execute commands inline and report status")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
 
     cfg_path = ROOT / args.config
     if not cfg_path.exists():
@@ -130,210 +590,52 @@ def main() -> int:
         print("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)", file=sys.stderr)
         return 2
 
-    industry = cfg.get("industry", "<unspecified>")
-    project_type = cfg.get("project_type", "<unspecified>")
-    frontend = cfg.get("frontend", "<unspecified>")
-    backend = cfg.get("backend", "<unspecified>")
-    database = cfg.get("database", "<unspecified>")
-    auth = cfg.get("auth") or "none"
-    deploy = cfg.get("deploy") or "n/a"
-    compliance = cfg.get("compliance") or "none"
-
     brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
     if not brief_path.exists():
         print(f"[plan] brief not found: {brief_path}", file=sys.stderr)
         return 2
 
     spec = BriefParser(str(brief_path)).parse()
-    lanes = build_plan(spec)
+    effective_spec = apply_workflow_overrides(spec, cfg)
+    lanes = build_plan(spec, cfg)
 
-    output_root = Path(args.output_root)
+    output_root = (ROOT / args.output_root).resolve()
     project_dir = (output_root / name).resolve()
 
-    frontend_lane = format_lane(lanes["frontend"])
-    backend_lane = format_lane(lanes["backend"])
+    stages = build_stages(cfg_path, brief_path, output_root, project_dir, effective_spec, cfg, lanes)
 
-    staging_urls = {
-        "frontend": "${vars.FRONTEND_URL_STAGING}",
-        "api": "${vars.API_URL_STAGING}",
-        "db": "${vars.DB_URL_STAGING}",
-    }
-    prod_urls = {
-        "frontend": "${vars.FRONTEND_URL_PRODUCTION}",
-        "api": "${vars.API_URL_PRODUCTION}",
-        "db": "${vars.DB_URL_PRODUCTION}",
-    }
+    exit_code = 0
+    command_results: List[CommandResult] = []
 
-    steps: List[Dict[str, List[str]]] = [
-        {
-            "title": "Environment & Inputs",
-            "items": [
-                "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
-                f"Confirm brief exists at {brief_path}.",
-                (
-                    "Verify workflow.config.json values "
-                    f"(industry={industry}, project_type={project_type}, frontend={frontend}, "
-                    f"backend={backend}, database={database}, auth={auth}, deploy={deploy}, compliance={compliance})."
-                ),
-                (
-                    "Export automation variables before running lifecycle: "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root}\n"
-                    "   Optional: AUTH, DEPLOY, COMPLIANCE, NESTJS_ORM, FORCE_OUTPUT=1."
-                ),
-            ],
-        },
-        {
-            "title": "Planning & Alignment",
-            "items": [
-                "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
-                f"Generate planning artifacts for reference (dry run here only): "
-                f"python scripts/plan_from_brief.py --brief '{brief_path}' --out '{project_dir}/PLAN.md'.",
-                f"Validate DAG topology prior to generation: python scripts/validate_tasks.py "
-                f"--input '{project_dir}/PLAN.tasks.json'.",
-                "Inspect PLAN.md lanes and resolve dependencies/blocked tasks before coding.",
-            ],
-        },
-        {
-            "title": "Stack Preflight & Generation Prep",
-            "items": [
-                "Tooling doctor & template discovery: python scripts/doctor.py --strict "
-                "&& ./scripts/generate_client_project.py --list-templates --name \"$NAME\" --industry \"$INDUSTRY\" --project-type \"$PROJECT_TYPE\".",
-                (
-                    "Preflight stack selection and capture evidence: "
-                    "python scripts/select_stacks.py "
-                    f"--industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"--output '{project_dir}/selection.json' --summary '{project_dir}/evidence/stack-selection.md' "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''}"
-                ),
-                "If select_stacks exits with code 3, resolve engine version mismatches before continuing.",
-                (
-                    "Preview scaffold (no writes): ./scripts/generate_client_project.py "
-                    "--dry-run --workers 8 --yes "
-                    f"--name '{name}' --industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"{'--auth ' + auth if auth != 'none' else ''} "
-                    f"{'--deploy ' + deploy if deploy != 'n/a' else ''} "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''} "
-                    f"--output-dir '{output_root}'"
-                ),
-            ],
-        },
-        {
-            "title": "Full Scaffold Generation & Bootstrap (queued automation)",
-            "items": [
-                (
-                    "When ready, run the one-shot generator (stops on any failure): "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root} make lifecycle"
-                ),
-                f"Inspect generated project at {project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
-                "Capture any generator logs or selection evidence for audit.",
-            ],
-        },
-        {
-            "title": "Frontend Implementation Sequence (execute in project workspace)",
-            "items": [
-                f"Work inside {project_dir}/frontend following tasks in order:"
-            ] + frontend_lane,
-        },
-        {
-            "title": "Backend & Data Implementation Sequence",
-            "items": [
-                f"Work inside {project_dir}/backend (and database/ if emitted) following tasks in order:"
-            ] + backend_lane,
-        },
-        {
-            "title": "Integration, Migrations, and Data Validation",
-            "items": [
-                "Create/adjust Alembic migrations, run `alembic upgrade head`, and reseed sample data (aligns with BE-SCH/BE-SEED/BE-MDL).",
-                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types with `npx openapi-typescript` as needed.",
-                "Update MSW/Prism mocks to match live responses (FE-MOCKS).",
-                "Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.",
-            ],
-        },
-        {
-            "title": "Quality Automation & Gates",
-            "items": [
-                "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
-                "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
-                (
-                    "Backend quality: `cd backend && black --check . && flake8` "
-                    "(Python) and/or ESLint for Node backends; run `mypy app` when mypy is enabled."
-                ),
-                "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
-                f"Aggregate stack-aware tests: `PROJECT_ROOT={project_dir} ./scripts/install_and_test.sh` (already done by lifecycle but rerun after local changes).",
-                f"Collect metrics: `PROJECT_ROOT={project_dir} python scripts/collect_coverage.py`, `collect_perf.py`, `scan_deps.py`.",
-                f"Enforce gates: `PROJECT_ROOT={project_dir} python scripts/enforce_gates.py` (blocks if thresholds in gates_config.yaml are missed).",
-            ],
-        },
-        {
-            "title": "Local Verification & Developer Experience",
-            "items": [
-                "Run dev servers for experiential QA: `cd frontend && npm run dev`; `cd backend && uvicorn app.main:app --reload` (or generated entrypoint).",
-                "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
-                f"Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist.",
-            ],
-        },
-        {
-            "title": "Compliance, Evidence, and Packaging",
-            "items": [
-                f"Package deliverables: `PROJECT_ROOT={project_dir} NAME={name} ./scripts/build_submission_pack.sh`.",
-                f"Validate compliance assets: `PROJECT_ROOT={project_dir} python scripts/validate_compliance_assets.py`.",
-                f"Optional doc scan: `PROJECT_ROOT={project_dir} python scripts/check_compliance_docs.py`.",
-                "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
-            ],
-        },
-        {
-            "title": "CI/CD Enablement",
-            "items": [
-                "Populate GitHub secrets/vars required by .github/workflows/ci-secrets-preflight.yml:",
-                "   secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ECS_EXECUTION_ROLE_ARN, AWS_ECS_TASK_ROLE_ARN.",
-                "   vars: AWS_REGION, APP_NAME, ECS_CLUSTER_NAME, ECS_SERVICE_NAME, ECS_DESIRED_COUNT, FRONTEND_URL_STAGING, API_URL_STAGING, DB_URL_STAGING, FRONTEND_URL_PRODUCTION, API_URL_PRODUCTION, DB_URL_PRODUCTION.",
-                "Enforce production environment protection/approvals in GitHub.",
-                "Trigger ci-secrets-preflight (push/pr/dispatch) and resolve any missing configuration.",
-                "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
-            ],
-        },
-        {
-            "title": "Deploy & Promote",
-            "items": [
-                "Staging: push to main to invoke .github/workflows/ci-deploy.yml (environment resolves to staging).",
-                "Review staging artifact outputs, ECS & Vercel deploys, and health verification (`python scripts/health/check_deployment.py --environment staging ...`).",
-                "Production: run GitHub Actions → “Promote to Production”, ensure approvals granted, wait for verify-and-gate + deploy-production jobs.",
-                f"Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
-                "If failures occur, use scripts/rollback_backend.sh and scripts/rollback_frontend.sh via the rollback job or manually.",
-            ],
-        },
-        {
-            "title": "Observability & Continuous Ops",
-            "items": [
-                "Schedule/monitor nightly-observability workflow; ensure staging/production URL vars stay current.",
-                f"Use `make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']}` for ad-hoc validation.",
-                f"Use `make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']}` post-promotion.",
-                "Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance.",
-            ],
-        },
-        {
-            "title": "Final Delivery & Retrospective",
-            "items": [
-                f"Hand off dist/{name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
-                f"Document residual risks or follow-ups in {project_dir}/reports/ or IMPLEMENTATION_SUMMARY.md.",
-                "Capture implementation retrospective and update workflow.config.json/workflow docs for future engagements.",
-            ],
-        },
-    ]
-
-
-
-    for step_idx, step in enumerate(steps, 1):
-        print(f"{step_idx}. {step['title']}")
-        for item_idx, item in enumerate(step["items"], 1):
-            print(f"   {step_idx}.{item_idx} {item}")
+    for stage_idx, stage in enumerate(stages, 1):
+        print(f"{stage_idx}. {stage.title}")
+        for item_idx, item in enumerate(stage.items, 1):
+            missing = [path for path in item.requires if not path.exists()]
+            status = ""
+            if missing:
+                status = " [MISSING: " + ", ".join(str(p) for p in missing) + "]"
+                if not item.optional:
+                    exit_code = max(exit_code, 1)
+            print(f"   {stage_idx}.{item_idx} {item.description}{status}")
+            if item.command:
+                print(f"       command: {item.command}")
+                if args.execute and not missing:
+                    result = subprocess.run(item.command, shell=True, cwd=ROOT)
+                    command_results.append(
+                        CommandResult(stage.title, item.description, item.command, result.returncode)
+                    )
+                    if result.returncode != 0:
+                        exit_code = max(exit_code, result.returncode)
         print()
 
-    return 0
+    if args.execute and command_results:
+        print("Command Summary:")
+        for result in command_results:
+            emoji = "✅" if result.returncode == 0 else "❌"
+            print(f" {emoji} [{result.stage}] {result.description} -> {result.returncode}")
+        print()
+
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/test_pre_lifecycle_plan.py
+++ b/tests/test_pre_lifecycle_plan.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_generator.core.brief_parser import ScaffoldSpec
+from scripts.plan_from_brief import apply_workflow_overrides, build_plan
+from scripts.pre_lifecycle_plan import build_stages
+
+
+def make_spec(**overrides) -> ScaffoldSpec:
+    base = {
+        "name": "demo",
+        "industry": "saas",
+        "project_type": "fullstack",
+        "frontend": "nextjs",
+        "backend": "fastapi",
+        "database": "postgres",
+        "auth": "auth0",
+        "deploy": "aws",
+        "compliance": [],
+        "features": [],
+        "separate_repos": True,
+    }
+    base.update(overrides)
+    return ScaffoldSpec(**base)
+
+
+def test_build_plan_omits_backend_when_disabled():
+    spec = make_spec(backend="none", database="none")
+    plan = build_plan(spec, {})
+    assert plan["backend"] == []
+
+
+def test_build_plan_includes_compliance_tasks():
+    spec = make_spec(compliance=["hipaa"])
+    plan = build_plan(spec, {})
+    backend_ids = {task["id"] for task in plan["backend"]}
+    assert "BACKEND-HIPAA" in backend_ids
+
+
+def test_apply_workflow_overrides_merges_fields():
+    spec = make_spec()
+    cfg = {"frontend": "none", "compliance": ["pci", "hipaa"], "features": ["realtime"]}
+    effective = apply_workflow_overrides(spec, cfg)
+    assert effective.frontend == "none"
+    assert set(effective.compliance) == {"pci", "hipaa"}
+    assert "realtime" in effective.features
+
+
+@pytest.fixture()
+def staging_paths(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    cfg_path = tmp_path / "workflow.config.json"
+    cfg_path.write_text("{}", encoding="utf-8")
+    brief_path = tmp_path / "brief.md"
+    brief_path.write_text("# Brief", encoding="utf-8")
+    output_root = tmp_path / "generated"
+    project_dir = output_root / "demo"
+    return cfg_path, brief_path, output_root, project_dir
+
+
+def test_build_stages_skips_backend_and_compliance(staging_paths):
+    cfg_path, brief_path, output_root, project_dir = staging_paths
+    spec = make_spec(backend="none", database="none")
+    lanes = {"frontend": [], "backend": []}
+    stages = build_stages(cfg_path, brief_path, output_root, project_dir, spec, {}, lanes)
+    titles = [stage.title for stage in stages]
+    assert "Backend & Data Implementation Sequence" not in titles
+    assert "Compliance, Evidence, and Packaging" not in titles
+
+
+def test_build_stages_includes_compliance_when_present(staging_paths):
+    cfg_path, brief_path, output_root, project_dir = staging_paths
+    spec = make_spec(compliance=["hipaa"])
+    lanes = build_plan(spec, {})
+    stages = build_stages(cfg_path, brief_path, output_root, project_dir, spec, {}, lanes)
+    titles = [stage.title for stage in stages]
+    assert "Compliance, Evidence, and Packaging" in titles


### PR DESCRIPTION
## Summary
- make plan_from_brief data-driven with workflow overrides, feature/compliance-aware tasks, and optional config input
- refactor pre_lifecycle_plan into modular stages with capability gating, artifact checks, script discovery, and optional command execution
- add unit tests covering lane adaptation, compliance gating, and workflow override behaviour

## Testing
- pytest tests/test_pre_lifecycle_plan.py

------
https://chatgpt.com/codex/tasks/task_e_68d49d47c2f4832e9d2c087c584ae10b