### PR TITLE
Refactor lifecycle planner to adapt to briefs and add verification

### DIFF
--- a/scripts/plan_from_brief.py
+++ b/scripts/plan_from_brief.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Callable, Dict, Iterable, List, Sequence, Union
 
 from project_generator.core.brief_parser import BriefParser
+from project_generator.core.brief_parser import ScaffoldSpec
 
 
 def parse_args() -> argparse.Namespace:
@@ -20,199 +22,348 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def task(
-    id_: str,
-    title: str,
-    area: str,
-    blocked_by: List[str] | None = None,
-    labels: List[str] | None = None,
-    estimate: str = "1d",
-    acceptance: List[str] | None = None,
-    dod: List[str] | None = None,
-) -> Dict:
-    return {
-        "id": id_,
-        "title": title,
-        "area": area,
-        "estimate": estimate,
-        "blocked_by": blocked_by or [],
-        "labels": labels or [],
-        "acceptance": acceptance or [],
-        "dod": dod or [],
-        "state": "pending",
-    }
+@dataclass
+class TaskTemplate:
+    """Structured template that can render a lane task for the supplied spec."""
 
-
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    be: List[Dict] = []
-    fe: List[Dict] = []
-
-    # Backend lane
-    be.append(
-        task(
-            "BE-SCH",
-            "Design DB schema",
-            "backend",
-            acceptance=["ERD drafted", "tables defined", "naming conventions applied"],
-        )
+    id: str
+    title: str
+    area: str
+    blocked_by: Union[Sequence[str], Callable[[ScaffoldSpec], Sequence[str]]] = field(
+        default_factory=list
     )
-    be.append(
-        task(
+    labels: Sequence[str] = field(default_factory=list)
+    estimate: str = "1d"
+    acceptance: Sequence[str] = field(default_factory=list)
+    dod: Sequence[str] = field(default_factory=list)
+    condition: Callable[[ScaffoldSpec], bool] = lambda spec: True
+
+    def render(self, spec: ScaffoldSpec) -> Dict[str, Any]:
+        fmt = {"spec": spec}
+
+        def _format(values: Iterable[str]) -> List[str]:
+            return [v.format_map(fmt) for v in values]
+
+        blocked_by = self.blocked_by(spec) if callable(self.blocked_by) else self.blocked_by
+        return {
+            "id": self.id,
+            "title": self.title.format_map(fmt),
+            "area": self.area,
+            "estimate": self.estimate,
+            "blocked_by": list(blocked_by),
+            "labels": list(self.labels),
+            "acceptance": _format(self.acceptance),
+            "dod": _format(self.dod),
+            "state": "pending",
+        }
+
+
+def _compliance_flags(spec: ScaffoldSpec) -> set[str]:
+    return {c.lower() for c in spec.compliance if c}
+
+
+def _feature_flags(spec: ScaffoldSpec) -> set[str]:
+    return {f.lower() for f in spec.features if f}
+
+
+def _default_backend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "BE-SCH",
+            "Design {spec.database} schema",
+            "backend",
+            acceptance=[
+                "ERD drafted",
+                "tables defined",
+                "naming conventions applied",
+            ],
+            condition=lambda spec: spec.database != "none",
+        ),
+        TaskTemplate(
             "BE-SEED",
             "Seed loaders (CSV/mock)",
             "backend",
             blocked_by=["BE-SCH"],
             acceptance=["seed scripts run", "sample rows present"],
-        )
-    )
-    be.append(
-        task(
+            condition=lambda spec: spec.database != "none",
+        ),
+        TaskTemplate(
             "BE-MDL",
-            "Aggregates/MatViews (funnel, revenue, etc.)",
+            "Aggregate models aligned to primary KPIs",
             "backend",
             blocked_by=["BE-SEED"],
             acceptance=["views created", "query p95 < 400ms (seed)"],
-        )
-    )
-    be += [
-        task(
-            "BE-API-KPI",
-            "GET /api/v1/kpis",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["returns totals/deltas", "OpenAPI updated"],
+            condition=lambda spec: spec.project_type != "web",
         ),
-        task(
-            "BE-API-REV",
-            "GET /api/v1/revenue",
+        TaskTemplate(
+            "BE-API-CORE",
+            "Expose {spec.backend} service endpoints",
             "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["time series ok", "OpenAPI updated"],
-        ),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task(
-            "BE-EXP",
-            "GET /api/v1/export/csv",
-            "backend",
-            blocked_by=[
-                "BE-API-KPI",
-                "BE-API-REV",
-                "BE-API-CAT",
-                "BE-API-PLT",
-                "BE-API-CUS",
-                "BE-API-FDB",
+            blocked_by=lambda spec: ["BE-MDL"]
+            if spec.project_type != "web" and spec.database != "none"
+            else [],
+            acceptance=[
+                "core endpoints implemented",
+                "OpenAPI updated",
             ],
         ),
-    ]
-    be.append(
-        task(
+        TaskTemplate(
             "BE-AUTH",
-            "Auth0/RBAC skeleton",
+            "Integrate {spec.auth} auth provider",
             "backend",
             labels=["security"],
             acceptance=["role checks present"],
-        )
-    )
-    be.append(
-        task(
+            condition=lambda spec: spec.auth != "none",
+        ),
+        TaskTemplate(
             "BE-OBS",
             "Structured logs + correlation IDs",
             "backend",
             labels=["observability"],
             acceptance=["request id on logs"],
-        )
-    )
-    be.append(
-        task(
+        ),
+        TaskTemplate(
             "BE-TST",
-            "Unit+Integration tests (Testcontainers)",
+            "Unit + integration tests",
             "backend",
-            blocked_by=["BE-API-KPI", "BE-API-REV"],
+            blocked_by=["BE-API-CORE"],
             acceptance=["pytest green", ">= minimal coverage"],
-        )
-    )
+        ),
+    ]
 
-    # Frontend lane
-    fe.append(
-        task(
+
+def _api_backend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "BE-DOMAIN",
+            "Model domain objects and validation schemas",
+            "backend",
+            acceptance=["pydantic/domain schemas captured", "error responses documented"],
+        ),
+        TaskTemplate(
+            "BE-RATE-LIMIT",
+            "Add rate limiting and observability for {spec.backend} APIs",
+            "backend",
+            blocked_by=["BE-DOMAIN"],
+            labels=["security"],
+            acceptance=["throttling enforced", "metrics exported"],
+        ),
+        TaskTemplate(
+            "BE-AUTH",
+            "Integrate {spec.auth} auth provider",
+            "backend",
+            labels=["security"],
+            acceptance=["role checks present"],
+            condition=lambda spec: spec.auth != "none",
+        ),
+        TaskTemplate(
+            "BE-DOCS",
+            "Publish OpenAPI and postman collection",
+            "backend",
+            blocked_by=["BE-RATE-LIMIT"],
+            acceptance=["OpenAPI committed", "client sdk generated"],
+        ),
+        TaskTemplate(
+            "BE-TST",
+            "Contract + integration tests",
+            "backend",
+            blocked_by=["BE-DOCS"],
+            acceptance=["tests green", "newman suite recorded"],
+        ),
+    ]
+
+
+def _compliance_backend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "BE-HIPAA",
+            "HIPAA logging and PHI safeguards",
+            "backend",
+            labels=["compliance"],
+            acceptance=["audit log enabled", "PHI masked in logs"],
+            condition=lambda spec: "hipaa" in _compliance_flags(spec),
+        ),
+        TaskTemplate(
+            "BE-PCI",
+            "PCI DSS encryption + key rotation",
+            "backend",
+            labels=["compliance"],
+            acceptance=["card data encrypted", "rotation policy documented"],
+            condition=lambda spec: "pci" in _compliance_flags(spec),
+        ),
+        TaskTemplate(
+            "BE-GDPR",
+            "GDPR data export/delete flows",
+            "backend",
+            labels=["compliance"],
+            acceptance=["export endpoint present", "delete workflow documented"],
+            condition=lambda spec: "gdpr" in _compliance_flags(spec),
+        ),
+    ]
+
+
+def _feature_backend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "BE-ML",
+            "Serve machine learning predictions",
+            "backend",
+            labels=["ml"],
+            acceptance=["model artifact versioned", "latency within SLA"],
+            condition=lambda spec: "ml" in _feature_flags(spec),
+        ),
+        TaskTemplate(
+            "BE-WORKFLOW",
+            "Orchestrate workflow automation jobs",
+            "backend",
+            labels=["workflow"],
+            acceptance=["scheduler configured", "idempotent runs"],
+            condition=lambda spec: "workflow" in _feature_flags(spec),
+        ),
+    ]
+
+
+def _default_frontend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
             "FE-DSN",
-            "Shell/Layout/Routes",
+            "Shell/Layout/Routes for {spec.frontend}",
             "frontend",
             acceptance=["routes wired", "base theme applied"],
-        )
-    )
-    fe.append(
-        task(
+        ),
+        TaskTemplate(
             "FE-TYPES",
-            "openapi-typescript client",
+            "Generate typed client from OpenAPI",
             "frontend",
             acceptance=["types.ts generated", "typed client compiles"],
-        )
-    )
-    fe.append(
-        task(
+        ),
+        TaskTemplate(
             "FE-MOCKS",
             "MSW/Prism mocks",
             "frontend",
             acceptance=["mocks respond", "dev proxy configured"],
-        )
-    )
-    fe += [
-        task(
-            "FE-KPI",
-            "KPI cards + filters",
+        ),
+        TaskTemplate(
+            "FE-DASH",
+            "Implement analytics dashboards",
             "frontend",
             blocked_by=["FE-DSN", "FE-TYPES"],
             acceptance=["renders", "no console errors"],
         ),
-        task(
-            "FE-REV",
-            "Revenue chart + range selectors",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
-        ),
-        task("FE-PLT", "Platform distribution (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task(
-            "FE-EXP",
+        TaskTemplate(
+            "FE-EXPORT",
             "Exports (CSV/PNG)",
             "frontend",
-            blocked_by=[
-                "FE-KPI",
-                "FE-REV",
-                "FE-PLT",
-                "FE-CAT",
-                "FE-CUS",
-                "FE-FDB",
-            ],
-            acceptance=["CSV downloads"],
+            blocked_by=["FE-DASH"],
+            acceptance=["download works"],
         ),
-    ]
-    fe.append(
-        task(
-            "FE-A11Y-PERF",
-            "WCAG AA + code-split/memoize",
+        TaskTemplate(
+            "FE-A11Y",
+            "WCAG AA hardening",
             "frontend",
-            labels=["a11y", "performance"],
-        )
-    )
-    fe.append(
-        task(
+            labels=["a11y"],
+        ),
+        TaskTemplate(
             "FE-TST",
             "Component + E2E smoke",
             "frontend",
-            blocked_by=["FE-KPI", "FE-REV"],
+            blocked_by=["FE-DASH"],
             acceptance=["tests green"],
-        )
-    )
+        ),
+    ]
 
-    return {"backend": be, "frontend": fe}
+
+def _mobile_frontend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "FE-MOB-SHELL",
+            "Mobile navigation + routing",
+            "frontend",
+            acceptance=["navigation flows connected", "deep link configured"],
+        ),
+        TaskTemplate(
+            "FE-MOB-AUTH",
+            "Wire {spec.auth} auth into mobile client",
+            "frontend",
+            acceptance=["login succeeds", "tokens persisted securely"],
+            condition=lambda spec: spec.auth != "none",
+        ),
+        TaskTemplate(
+            "FE-MOB-OFFLINE",
+            "Offline persistence + sync",
+            "frontend",
+            acceptance=["cache seeded", "sync retries"],
+            condition=lambda spec: "offline" in _feature_flags(spec),
+        ),
+        TaskTemplate(
+            "FE-MOB-TST",
+            "Device + integration tests",
+            "frontend",
+            acceptance=["tests green"],
+        ),
+    ]
+
+
+def _feature_frontend_templates() -> List[TaskTemplate]:
+    return [
+        TaskTemplate(
+            "FE-REPORTS",
+            "Interactive reporting widgets",
+            "frontend",
+            blocked_by=["FE-DSN", "FE-TYPES"],
+            acceptance=["filters persist", "downloads available"],
+            condition=lambda spec: "reporting" in _feature_flags(spec),
+        ),
+        TaskTemplate(
+            "FE-WORKFLOW",
+            "Workflow builder UI",
+            "frontend",
+            labels=["workflow"],
+            blocked_by=["FE-DSN"],
+            acceptance=["steps reorderable", "state persisted"],
+            condition=lambda spec: "workflow" in _feature_flags(spec),
+        ),
+    ]
+
+
+def _render_lane(spec: ScaffoldSpec, templates: List[TaskTemplate]) -> List[Dict[str, Any]]:
+    lane: List[Dict[str, Any]] = []
+    for template in templates:
+        if template.condition(spec):
+            lane.append(template.render(spec))
+    return lane
+
+
+def build_plan(spec: ScaffoldSpec) -> Dict[str, List[Dict[str, Any]]]:
+    backend_lane: List[Dict[str, Any]]
+    if spec.backend == "none":
+        backend_lane = []
+    elif spec.project_type == "api":
+        backend_lane = _render_lane(
+            spec,
+            _api_backend_templates() + _compliance_backend_templates() + _feature_backend_templates(),
+        )
+    else:
+        backend_lane = _render_lane(
+            spec,
+            _default_backend_templates() + _compliance_backend_templates() + _feature_backend_templates(),
+        )
+
+    frontend_lane: List[Dict[str, Any]]
+    if spec.frontend == "none" or spec.project_type == "api":
+        frontend_lane = []
+    elif spec.project_type == "mobile" or spec.frontend == "expo":
+        frontend_lane = _render_lane(
+            spec,
+            _mobile_frontend_templates() + _feature_frontend_templates(),
+        )
+    else:
+        frontend_lane = _render_lane(
+            spec,
+            _default_frontend_templates() + _feature_frontend_templates(),
+        )
+
+    return {"backend": backend_lane, "frontend": frontend_lane}
 
 
 def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:

--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -1,340 +1,749 @@
 #!/usr/bin/env python3
-"""
-Pre-lifecycle roadmap generator.
-
-Reads workflow.config.json (or overrides) and the corresponding docs/briefs/<NAME>/brief.md,
-recreates the ordered task lanes, then prints a sequential, human-readable checklist that
-extends the lifecycle automation with the manual quality, deploy, and observability work.
-"""
+"""Pre-lifecycle roadmap generator with validation and adaptive sequencing."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Iterable, List, Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from project_generator.core.brief_parser import BriefParser  # type: ignore[misc]
+from project_generator.core.brief_parser import BriefParser, ScaffoldSpec  # type: ignore[misc]
+
+from scripts.plan_from_brief import build_plan  # noqa: E402
 
 
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    """Replica of scripts/plan_from_brief.build_plan to reuse lane ordering."""
-    def task(id_, title, area, blocked_by=None, labels=None, estimate="1d",
-             acceptance=None, dod=None):
-        return {
-            "id": id_,
-            "title": title,
-            "area": area,
-            "estimate": estimate,
-            "blocked_by": blocked_by or [],
-            "labels": labels or [],
-            "acceptance": acceptance or [],
-            "dod": dod or [],
-            "state": "pending",
-        }
-
-    be: List[Dict] = []
-    fe: List[Dict] = []
-
-    be.append(task("BE-SCH", "Design DB schema", "backend",
-                   acceptance=["ERD drafted", "tables defined", "naming conventions applied"]))
-    be.append(task("BE-SEED", "Seed loaders (CSV/mock)", "backend", blocked_by=["BE-SCH"],
-                   acceptance=["seed scripts run", "sample rows present"]))
-    be.append(task("BE-MDL", "Aggregates/MatViews (funnel, revenue, etc.)", "backend",
-                   blocked_by=["BE-SEED"],
-                   acceptance=["views created", "query p95 < 400ms (seed)"]))
-    be += [
-        task("BE-API-KPI", "GET /api/v1/kpis", "backend", blocked_by=["BE-MDL"],
-             acceptance=["returns totals/deltas", "OpenAPI updated"]),
-        task("BE-API-REV", "GET /api/v1/revenue", "backend", blocked_by=["BE-MDL"],
-             acceptance=["time series ok", "OpenAPI updated"]),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task("BE-EXP", "GET /api/v1/export/csv", "backend",
-             blocked_by=["BE-API-KPI", "BE-API-REV", "BE-API-CAT",
-                         "BE-API-PLT", "BE-API-CUS", "BE-API-FDB"]),
-    ]
-    be.append(task("BE-AUTH", "Auth0/RBAC skeleton", "backend",
-                   labels=["security"], acceptance=["role checks present"]))
-    be.append(task("BE-OBS", "Structured logs + correlation IDs", "backend",
-                   labels=["observability"], acceptance=["request id on logs"]))
-    be.append(task("BE-TST", "Unit+Integration tests (Testcontainers)", "backend",
-                   blocked_by=["BE-API-KPI", "BE-API-REV"],
-                   acceptance=["pytest green", ">= minimal coverage"]))
-
-    fe.append(task("FE-DSN", "Shell/Layout/Routes", "frontend",
-                   acceptance=["routes wired", "base theme applied"]))
-    fe.append(task("FE-TYPES", "openapi-typescript client", "frontend",
-                   acceptance=["types.ts generated", "typed client compiles"]))
-    fe.append(task("FE-MOCKS", "MSW/Prism mocks", "frontend",
-                   acceptance=["mocks respond", "dev proxy configured"]))
-    fe += [
-        task("FE-KPI", "KPI cards + filters", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-REV", "Revenue chart + range selectors", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-PLT", "Platform distribution (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-EXP", "Exports (CSV/PNG)", "frontend",
-             blocked_by=["FE-KPI", "FE-REV", "FE-PLT", "FE-CAT", "FE-CUS", "FE-FDB"],
-             acceptance=["CSV downloads"]),
-    ]
-    fe.append(task("FE-A11Y-PERF", "WCAG AA + code-split/memoize", "frontend",
-                   labels=["a11y", "performance"]))
-    fe.append(task("FE-TST", "Component + E2E smoke", "frontend",
-                   blocked_by=["FE-KPI", "FE-REV"], acceptance=["tests green"]))
-
-    return {"backend": be, "frontend": fe}
+# ---------------------------------------------------------------------------
+# Dataclasses modelling the checklist + validation metadata
 
 
-def format_lane(lane: List[Dict]) -> List[str]:
-    entries = []
-    for idx, t in enumerate(lane, 1):
-        blockers = ", ".join(t["blocked_by"]) if t["blocked_by"] else "none"
-        acceptance = ", ".join(t["acceptance"]) if t["acceptance"] else "see acceptance criteria"
-        entries.append(
-            f"{t['id']}: {t['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
+@dataclass
+class Check:
+    description: str
+    validator: Callable[[], bool]
+    failure_message: str
+
+
+@dataclass
+class Command:
+    description: str
+    args: Sequence[str]
+
+
+@dataclass
+class ChecklistStep:
+    title: str
+    items: List[str]
+    checks: List[Check] = field(default_factory=list)
+    commands: List[Command] = field(default_factory=list)
+
+
+@dataclass
+class ChecklistContext:
+    spec: ScaffoldSpec
+    config: dict
+    brief_path: Path
+    project_dir: Path
+    output_root: Path
+    lanes: dict
+
+    @property
+    def has_frontend(self) -> bool:
+        return bool(self.lanes.get("frontend"))
+
+    @property
+    def has_backend(self) -> bool:
+        return bool(self.lanes.get("backend"))
+
+    @property
+    def has_database(self) -> bool:
+        return self.spec.database != "none"
+
+    @property
+    def has_deploy(self) -> bool:
+        deploy = (self.config.get("deploy") or self.spec.deploy or "").lower()
+        return deploy not in {"", "n/a", "none"}
+
+    @property
+    def compliance_flags(self) -> List[str]:
+        compliance = self.config.get("compliance") or self.spec.compliance
+        if isinstance(compliance, str):
+            compliance = [c.strip() for c in compliance.split(",") if c.strip()]
+        return [c.lower() for c in compliance]
+
+
+# ---------------------------------------------------------------------------
+# Script discovery helpers
+
+
+def resolve_script(script_name: str) -> Path:
+    base = ROOT / "scripts"
+    candidate = base / script_name
+    if candidate.exists():
+        return candidate
+    matches = list(base.rglob(script_name))
+    if not matches:
+        raise FileNotFoundError(f"Unable to locate script '{script_name}' under {base}")
+    return matches[0]
+
+
+def _format_lane(lane: Iterable[dict]) -> List[str]:
+    formatted: List[str] = []
+    for task in lane:
+        blockers = ", ".join(task["blocked_by"]) if task.get("blocked_by") else "none"
+        acceptance = ", ".join(task.get("acceptance") or []) or "see acceptance criteria"
+        formatted.append(
+            f"{task['id']}: {task['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
         )
-    return entries
+    return formatted
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
-    ap.add_argument("--name", help="Client/project name override")
-    ap.add_argument("--config", default="workflow.config.json")
-    ap.add_argument("--output-root", default="../_generated")
-    args = ap.parse_args()
+# ---------------------------------------------------------------------------
+# Checklist builder
 
-    cfg_path = ROOT / args.config
-    if not cfg_path.exists():
-        print(f"[plan] config not found: {cfg_path}", file=sys.stderr)
-        return 2
 
-    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+class ChecklistBuilder:
+    def __init__(self, ctx: ChecklistContext) -> None:
+        self.ctx = ctx
 
-    name = args.name or os.environ.get("NAME") or cfg.get("name")
-    if not name:
-        print("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)", file=sys.stderr)
-        return 2
+    def build(self) -> List[ChecklistStep]:
+        steps: List[ChecklistStep] = []
+        steps.append(self._environment_inputs())
+        steps.append(self._planning_alignment())
+        steps.append(self._stack_preflight())
+        steps.append(self._generation())
 
-    industry = cfg.get("industry", "<unspecified>")
-    project_type = cfg.get("project_type", "<unspecified>")
-    frontend = cfg.get("frontend", "<unspecified>")
-    backend = cfg.get("backend", "<unspecified>")
-    database = cfg.get("database", "<unspecified>")
-    auth = cfg.get("auth") or "none"
-    deploy = cfg.get("deploy") or "n/a"
-    compliance = cfg.get("compliance") or "none"
+        if self.ctx.has_frontend:
+            steps.append(self._frontend_lane())
+        if self.ctx.has_backend:
+            steps.append(self._backend_lane())
+        if self.ctx.has_backend or self.ctx.has_database:
+            integration = self._integration_stage()
+            if integration:
+                steps.append(integration)
 
-    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
-    if not brief_path.exists():
-        print(f"[plan] brief not found: {brief_path}", file=sys.stderr)
-        return 2
+        quality = self._quality_stage()
+        if quality:
+            steps.append(quality)
 
-    spec = BriefParser(str(brief_path)).parse()
-    lanes = build_plan(spec)
+        local = self._local_verification()
+        if local:
+            steps.append(local)
 
-    output_root = Path(args.output_root)
-    project_dir = (output_root / name).resolve()
+        packaging = self._packaging_stage()
+        if packaging:
+            steps.append(packaging)
 
-    frontend_lane = format_lane(lanes["frontend"])
-    backend_lane = format_lane(lanes["backend"])
+        steps.append(self._ci_stage())
 
-    staging_urls = {
-        "frontend": "${vars.FRONTEND_URL_STAGING}",
-        "api": "${vars.API_URL_STAGING}",
-        "db": "${vars.DB_URL_STAGING}",
-    }
-    prod_urls = {
-        "frontend": "${vars.FRONTEND_URL_PRODUCTION}",
-        "api": "${vars.API_URL_PRODUCTION}",
-        "db": "${vars.DB_URL_PRODUCTION}",
-    }
+        if self.ctx.has_deploy:
+            steps.append(self._deploy_stage())
+            steps.append(self._observability_stage())
 
-    steps: List[Dict[str, List[str]]] = [
-        {
-            "title": "Environment & Inputs",
-            "items": [
+        steps.append(self._final_delivery())
+        return steps
+
+    # ---- stage builders ----
+
+    def _environment_inputs(self) -> ChecklistStep:
+        cfg = self.ctx.config
+        spec = self.ctx.spec
+        return ChecklistStep(
+            title="Environment & Inputs",
+            items=[
                 "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
-                f"Confirm brief exists at {brief_path}.",
+                f"Confirm brief exists at {self.ctx.brief_path}.",
                 (
                     "Verify workflow.config.json values "
-                    f"(industry={industry}, project_type={project_type}, frontend={frontend}, "
-                    f"backend={backend}, database={database}, auth={auth}, deploy={deploy}, compliance={compliance})."
+                    f"(industry={spec.industry}, project_type={spec.project_type}, frontend={spec.frontend}, "
+                    f"backend={spec.backend}, database={spec.database}, auth={spec.auth}, "
+                    f"deploy={cfg.get('deploy') or spec.deploy}, compliance={self.ctx.compliance_flags or ['none']})."
                 ),
                 (
                     "Export automation variables before running lifecycle: "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root}\n"
+                    f"NAME={spec.name} INDUSTRY={spec.industry} PROJECT_TYPE={spec.project_type} "
+                    f"FE={spec.frontend} BE={spec.backend} DB={spec.database} OUTPUT_ROOT={self.ctx.output_root}\n"
                     "   Optional: AUTH, DEPLOY, COMPLIANCE, NESTJS_ORM, FORCE_OUTPUT=1."
                 ),
             ],
-        },
-        {
-            "title": "Planning & Alignment",
-            "items": [
+            checks=[
+                Check(
+                    description="workflow.config.json present",
+                    validator=lambda cfg_path=ROOT
+                    / "workflow.config.json": cfg_path.exists(),
+                    failure_message="Expected workflow.config.json at repo root.",
+                ),
+                Check(
+                    description="brief.md present",
+                    validator=lambda brief=self.ctx.brief_path: brief.exists(),
+                    failure_message=f"Brief missing at {self.ctx.brief_path}",
+                ),
+            ],
+        )
+
+    def _planning_alignment(self) -> ChecklistStep:
+        project_dir = self.ctx.project_dir
+        plan_md = project_dir / "PLAN.md"
+        plan_tasks = project_dir / "PLAN.tasks.json"
+        plan_script = resolve_script("plan_from_brief.py")
+        validate_tasks = resolve_script("validate_tasks.py")
+
+        return ChecklistStep(
+            title="Planning & Alignment",
+            items=[
                 "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
-                f"Generate planning artifacts for reference (dry run here only): "
-                f"python scripts/plan_from_brief.py --brief '{brief_path}' --out '{project_dir}/PLAN.md'.",
-                f"Validate DAG topology prior to generation: python scripts/validate_tasks.py "
-                f"--input '{project_dir}/PLAN.tasks.json'.",
+                (
+                    "Generate planning artifacts for reference (dry run here only): "
+                    f"python {plan_script} --brief '{self.ctx.brief_path}' --out '{plan_md}'."
+                ),
+        
+                (
+                    "Validate DAG topology prior to generation: python "
+                    f"{validate_tasks} --input '{plan_tasks}'."
+                ),
                 "Inspect PLAN.md lanes and resolve dependencies/blocked tasks before coding.",
             ],
-        },
-        {
-            "title": "Stack Preflight & Generation Prep",
-            "items": [
-                "Tooling doctor & template discovery: python scripts/doctor.py --strict "
-                "&& ./scripts/generate_client_project.py --list-templates --name \"$NAME\" --industry \"$INDUSTRY\" --project-type \"$PROJECT_TYPE\".",
+            checks=[
+                Check(
+                    description="PLAN.tasks.json available",
+                    validator=lambda path=plan_tasks: path.exists(),
+                    failure_message=f"Run plan_from_brief.py to generate {plan_tasks} before validating tasks.",
+                )
+            ],
+            commands=[
+                Command(
+                    description="plan_from_brief --help",
+                    args=[sys.executable, str(plan_script), "--help"],
+                ),
+            ],
+        )
+
+    def _stack_preflight(self) -> ChecklistStep:
+        spec = self.ctx.spec
+        project_dir = self.ctx.project_dir
+        doctor = resolve_script("doctor.py")
+        generator = resolve_script("generate_client_project.py")
+        select_stacks = resolve_script("select_stacks.py")
+
+        evidence_summary = project_dir / "evidence" / "stack-selection.md"
+        selection_json = project_dir / "selection.json"
+
+        base_command = (
+            f"NAME={spec.name} INDUSTRY={spec.industry} PROJECT_TYPE={spec.project_type} "
+            f"FE={spec.frontend} BE={spec.backend} DB={spec.database} OUTPUT_ROOT={self.ctx.output_root}"
+        )
+
+        select_args = [
+            sys.executable,
+            str(select_stacks),
+            "--industry",
+            spec.industry,
+            "--project-type",
+            spec.project_type,
+            "--frontend",
+            spec.frontend,
+            "--backend",
+            spec.backend,
+            "--database",
+            spec.database,
+            "--output",
+            str(selection_json),
+            "--summary",
+            str(evidence_summary),
+        ]
+
+        compliance_flags = [c for c in self.ctx.compliance_flags if c != "none"]
+        for flag in compliance_flags:
+            select_args.extend(["--compliance", flag])
+
+        if spec.auth and spec.auth != "none":
+            select_args.extend(["--auth", spec.auth])
+
+        return ChecklistStep(
+            title="Stack Preflight & Generation Prep",
+            items=[
+                f"Tooling doctor & template discovery: python {doctor} --strict",
                 (
                     "Preflight stack selection and capture evidence: "
-                    "python scripts/select_stacks.py "
-                    f"--industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"--output '{project_dir}/selection.json' --summary '{project_dir}/evidence/stack-selection.md' "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''}"
+                    + " ".join(map(str, select_args))
                 ),
                 "If select_stacks exits with code 3, resolve engine version mismatches before continuing.",
                 (
-                    "Preview scaffold (no writes): ./scripts/generate_client_project.py "
-                    "--dry-run --workers 8 --yes "
-                    f"--name '{name}' --industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"{'--auth ' + auth if auth != 'none' else ''} "
-                    f"{'--deploy ' + deploy if deploy != 'n/a' else ''} "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''} "
-                    f"--output-dir '{output_root}'"
+                    "Preview scaffold (no writes): "
+                    f"python {generator} --dry-run --workers 8 --yes --name '{spec.name}' "
+                    f"--industry '{spec.industry}' --project-type '{spec.project_type}' "
+                    f"--frontend '{spec.frontend}' --backend '{spec.backend}' --database '{spec.database}' "
+                    + (
+                        f"--auth '{spec.auth}' "
+                        if spec.auth and spec.auth != "none"
+                        else ""
+                    )
+                    + (
+                        f"--deploy '{self.ctx.config.get('deploy') or spec.deploy}' "
+                        if self.ctx.has_deploy
+                        else ""
+                    )
+                    + (
+                        " " + " ".join(f"--compliance '{flag}'" for flag in compliance_flags)
+                        if compliance_flags
+                        else ""
+                    )
+                    + f" --output-dir '{self.ctx.output_root}'"
                 ),
             ],
-        },
-        {
-            "title": "Full Scaffold Generation & Bootstrap (queued automation)",
-            "items": [
-                (
-                    "When ready, run the one-shot generator (stops on any failure): "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root} make lifecycle"
+            checks=[
+                Check(
+                    description="stack selection evidence exists",
+                    validator=lambda path=evidence_summary: path.exists(),
+                    failure_message=(
+                        f"Expected stack selection summary at {evidence_summary}. Run select_stacks.py first."
+                    ),
                 ),
-                f"Inspect generated project at {project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
-                "Capture any generator logs or selection evidence for audit.",
             ],
-        },
-        {
-            "title": "Frontend Implementation Sequence (execute in project workspace)",
-            "items": [
-                f"Work inside {project_dir}/frontend following tasks in order:"
-            ] + frontend_lane,
-        },
-        {
-            "title": "Backend & Data Implementation Sequence",
-            "items": [
-                f"Work inside {project_dir}/backend (and database/ if emitted) following tasks in order:"
-            ] + backend_lane,
-        },
-        {
-            "title": "Integration, Migrations, and Data Validation",
-            "items": [
-                "Create/adjust Alembic migrations, run `alembic upgrade head`, and reseed sample data (aligns with BE-SCH/BE-SEED/BE-MDL).",
-                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types with `npx openapi-typescript` as needed.",
-                "Update MSW/Prism mocks to match live responses (FE-MOCKS).",
-                "Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.",
-            ],
-        },
-        {
-            "title": "Quality Automation & Gates",
-            "items": [
-                "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
-                "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
-                (
-                    "Backend quality: `cd backend && black --check . && flake8` "
-                    "(Python) and/or ESLint for Node backends; run `mypy app` when mypy is enabled."
+            commands=[
+                Command(
+                    description="doctor --help",
+                    args=[sys.executable, str(doctor), "--help"],
                 ),
-                "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
-                f"Aggregate stack-aware tests: `PROJECT_ROOT={project_dir} ./scripts/install_and_test.sh` (already done by lifecycle but rerun after local changes).",
-                f"Collect metrics: `PROJECT_ROOT={project_dir} python scripts/collect_coverage.py`, `collect_perf.py`, `scan_deps.py`.",
-                f"Enforce gates: `PROJECT_ROOT={project_dir} python scripts/enforce_gates.py` (blocks if thresholds in gates_config.yaml are missed).",
+                Command(description="select_stacks --help", args=[sys.executable, str(select_stacks), "--help"]),
             ],
-        },
-        {
-            "title": "Local Verification & Developer Experience",
-            "items": [
-                "Run dev servers for experiential QA: `cd frontend && npm run dev`; `cd backend && uvicorn app.main:app --reload` (or generated entrypoint).",
-                "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
-                f"Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist.",
-            ],
-        },
-        {
-            "title": "Compliance, Evidence, and Packaging",
-            "items": [
-                f"Package deliverables: `PROJECT_ROOT={project_dir} NAME={name} ./scripts/build_submission_pack.sh`.",
-                f"Validate compliance assets: `PROJECT_ROOT={project_dir} python scripts/validate_compliance_assets.py`.",
-                f"Optional doc scan: `PROJECT_ROOT={project_dir} python scripts/check_compliance_docs.py`.",
-                "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
-            ],
-        },
-        {
-            "title": "CI/CD Enablement",
-            "items": [
+        )
+
+    def _generation(self) -> ChecklistStep:
+        spec = self.ctx.spec
+        project_dir = self.ctx.project_dir
+        checks = [
+            Check(
+                description="Generated project directory exists",
+                validator=lambda path=project_dir: path.exists(),
+                failure_message=f"Run make lifecycle to generate {project_dir}.",
+            ),
+            Check(
+                description="PLAN.md emitted",
+                validator=lambda path=project_dir / "PLAN.md": path.exists(),
+                failure_message=f"Expected PLAN.md in {project_dir}.",
+            ),
+            Check(
+                description="tasks.json emitted",
+                validator=lambda path=project_dir / "PLAN.tasks.json": path.exists(),
+                failure_message=f"Expected PLAN.tasks.json in {project_dir}.",
+            ),
+        ]
+
+        evidence_dir = project_dir / "evidence"
+        checks.append(
+            Check(
+                description="Evidence directory present",
+                validator=lambda path=evidence_dir: path.exists(),
+                failure_message=f"Generator did not create {evidence_dir}.",
+            )
+        )
+
+        items = [
+            (
+                "When ready, run the one-shot generator (stops on any failure): "
+                f"NAME={spec.name} INDUSTRY={spec.industry} PROJECT_TYPE={spec.project_type} "
+                f"FE={spec.frontend} BE={spec.backend} DB={spec.database} OUTPUT_ROOT={self.ctx.output_root} make lifecycle"
+            ),
+            f"Inspect generated project at {project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
+            "Capture any generator logs or selection evidence for audit.",
+        ]
+
+        return ChecklistStep(
+            title="Full Scaffold Generation & Bootstrap (queued automation)",
+            items=items,
+            checks=checks,
+        )
+
+    def _frontend_lane(self) -> ChecklistStep:
+        lane_entries = _format_lane(self.ctx.lanes.get("frontend", []))
+        project_dir = self.ctx.project_dir / "frontend"
+        checks = [
+            Check(
+                description="Frontend workspace exists",
+                validator=lambda path=project_dir: path.exists(),
+                failure_message=f"Expected frontend workspace at {project_dir}",
+            )
+        ]
+        return ChecklistStep(
+            title="Frontend Implementation Sequence (execute in project workspace)",
+            items=[f"Work inside {project_dir} following tasks in order:"] + lane_entries,
+            checks=checks,
+        )
+
+    def _backend_lane(self) -> ChecklistStep:
+        lane_entries = _format_lane(self.ctx.lanes.get("backend", []))
+        project_dir = self.ctx.project_dir / "backend"
+        checks = [
+            Check(
+                description="Backend workspace exists",
+                validator=lambda path=project_dir: path.exists(),
+                failure_message=f"Expected backend workspace at {project_dir}",
+            )
+        ]
+        return ChecklistStep(
+            title="Backend & Data Implementation Sequence",
+            items=[f"Work inside {project_dir} following tasks in order:"] + lane_entries,
+            checks=checks,
+        )
+
+    def _integration_stage(self) -> ChecklistStep | None:
+        items: List[str] = []
+
+        if self.ctx.has_database:
+            items.append(
+                "Create/adjust migrations, apply upgrades, and reseed sample data (aligns with data modelling tasks)."
+            )
+        if self.ctx.has_backend:
+            items.append(
+                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types as needed."
+            )
+        if self.ctx.has_frontend:
+            items.append("Update MSW/Prism mocks to match live responses.")
+        if not items:
+            return None
+
+        items.append("Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.")
+
+        return ChecklistStep(
+            title="Integration, Data Validation, and Contracts",
+            items=items,
+        )
+
+    def _quality_stage(self) -> ChecklistStep | None:
+        items: List[str] = []
+        project_dir = self.ctx.project_dir
+
+        if self.ctx.has_frontend:
+            items.extend(
+                [
+                    "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
+                    "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
+                ]
+            )
+
+        if self.ctx.has_backend:
+            items.extend(
+                [
+                    "Backend quality: `cd backend && black --check . && flake8` (adjust for generated stack).",
+                    "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
+                ]
+            )
+
+        if not items:
+            return None
+
+        items.extend(
+            [
+                f"Aggregate stack-aware tests: `PROJECT_ROOT={project_dir} ./scripts/install_and_test.sh`.",
+                f"Collect metrics: `PROJECT_ROOT={project_dir} python ./scripts/collect_coverage.py`, `collect_perf.py`, `scan_deps.py`.",
+                f"Enforce gates: `PROJECT_ROOT={project_dir} python ./scripts/enforce_gates.py`.",
+            ]
+        )
+
+        return ChecklistStep(title="Quality Automation & Gates", items=items)
+
+    def _local_verification(self) -> ChecklistStep | None:
+        project_dir = self.ctx.project_dir
+        items: List[str] = []
+
+        if self.ctx.has_frontend:
+            items.append(
+                "Run dev server: `cd frontend && npm run dev` for experiential QA."
+            )
+        if self.ctx.has_backend:
+            items.append(
+                "Backend dev server: `cd backend && uvicorn app.main:app --reload` (or generated entrypoint)."
+            )
+        if not items:
+            return None
+
+        items.append(
+            "Execute API/UI smoke tests via Postman/Newman or Playwright as applicable."
+        )
+        items.append(
+            "Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist."
+        )
+
+        return ChecklistStep(title="Local Verification & Developer Experience", items=items)
+
+    def _packaging_stage(self) -> ChecklistStep | None:
+        project_dir = self.ctx.project_dir
+        compliance_flags = [c for c in self.ctx.compliance_flags if c != "none"]
+
+        items = [
+            f"Package deliverables: `PROJECT_ROOT={project_dir} NAME={self.ctx.spec.name} ./scripts/build_submission_pack.sh`.",
+            "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
+        ]
+
+        if compliance_flags:
+            validate_compliance = resolve_script("validate_compliance_assets.py")
+            check_docs = resolve_script("check_compliance_docs.py")
+            items.insert(
+                1,
+                f"Validate compliance assets: `PROJECT_ROOT={project_dir} python {validate_compliance}`.",
+            )
+            items.insert(
+                2,
+                f"Optional doc scan: `PROJECT_ROOT={project_dir} python {check_docs}`.",
+            )
+            title = "Compliance, Evidence, and Packaging"
+        else:
+            title = "Packaging & Evidence"
+
+        return ChecklistStep(title=title, items=items)
+
+    def _ci_stage(self) -> ChecklistStep:
+        staging_urls = {
+            "frontend": "${vars.FRONTEND_URL_STAGING}",
+            "api": "${vars.API_URL_STAGING}",
+            "db": "${vars.DB_URL_STAGING}",
+        }
+        prod_urls = {
+            "frontend": "${vars.FRONTEND_URL_PRODUCTION}",
+            "api": "${vars.API_URL_PRODUCTION}",
+            "db": "${vars.DB_URL_PRODUCTION}",
+        }
+
+        return ChecklistStep(
+            title="CI/CD Enablement",
+            items=[
                 "Populate GitHub secrets/vars required by .github/workflows/ci-secrets-preflight.yml:",
                 "   secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ECS_EXECUTION_ROLE_ARN, AWS_ECS_TASK_ROLE_ARN.",
                 "   vars: AWS_REGION, APP_NAME, ECS_CLUSTER_NAME, ECS_SERVICE_NAME, ECS_DESIRED_COUNT, FRONTEND_URL_STAGING, API_URL_STAGING, DB_URL_STAGING, FRONTEND_URL_PRODUCTION, API_URL_PRODUCTION, DB_URL_PRODUCTION.",
                 "Enforce production environment protection/approvals in GitHub.",
                 "Trigger ci-secrets-preflight (push/pr/dispatch) and resolve any missing configuration.",
                 "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
+                f"Record validation URLs: staging={staging_urls}, production={prod_urls}.",
             ],
-        },
-        {
-            "title": "Deploy & Promote",
-            "items": [
+        )
+
+    def _deploy_stage(self) -> ChecklistStep:
+        check_deployment = resolve_script("health/check_deployment.py")
+        rollback_backend = resolve_script("rollback_backend.sh")
+        rollback_frontend = resolve_script("rollback_frontend.sh")
+
+        return ChecklistStep(
+            title="Deploy & Promote",
+            items=[
                 "Staging: push to main to invoke .github/workflows/ci-deploy.yml (environment resolves to staging).",
-                "Review staging artifact outputs, ECS & Vercel deploys, and health verification (`python scripts/health/check_deployment.py --environment staging ...`).",
+                "Review staging artifact outputs, ECS & Vercel deploys, and health verification "
+                f"(`python {check_deployment} --environment staging ...`).",
                 "Production: run GitHub Actions → “Promote to Production”, ensure approvals granted, wait for verify-and-gate + deploy-production jobs.",
-                f"Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
-                "If failures occur, use scripts/rollback_backend.sh and scripts/rollback_frontend.sh via the rollback job or manually.",
+                "Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
+                f"If failures occur, use {rollback_backend} and {rollback_frontend} via the rollback job or manually.",
             ],
-        },
-        {
-            "title": "Observability & Continuous Ops",
-            "items": [
+        )
+
+    def _observability_stage(self) -> ChecklistStep:
+        staging_urls = {
+            "frontend": "${vars.FRONTEND_URL_STAGING}",
+            "api": "${vars.API_URL_STAGING}",
+            "db": "${vars.DB_URL_STAGING}",
+        }
+        prod_urls = {
+            "frontend": "${vars.FRONTEND_URL_PRODUCTION}",
+            "api": "${vars.API_URL_PRODUCTION}",
+            "db": "${vars.DB_URL_PRODUCTION}",
+        }
+        return ChecklistStep(
+            title="Observability & Continuous Ops",
+            items=[
                 "Schedule/monitor nightly-observability workflow; ensure staging/production URL vars stay current.",
                 f"Use `make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']}` for ad-hoc validation.",
                 f"Use `make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']}` post-promotion.",
                 "Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance.",
             ],
-        },
-        {
-            "title": "Final Delivery & Retrospective",
-            "items": [
-                f"Hand off dist/{name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
+        )
+
+    def _final_delivery(self) -> ChecklistStep:
+        project_dir = self.ctx.project_dir
+        return ChecklistStep(
+            title="Final Delivery & Retrospective",
+            items=[
+                f"Hand off dist/{self.ctx.spec.name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
                 f"Document residual risks or follow-ups in {project_dir}/reports/ or IMPLEMENTATION_SUMMARY.md.",
                 "Capture implementation retrospective and update workflow.config.json/workflow docs for future engagements.",
             ],
-        },
-    ]
+        )
 
 
+# ---------------------------------------------------------------------------
+# CLI + verification harness
 
-    for step_idx, step in enumerate(steps, 1):
-        print(f"{step_idx}. {step['title']}")
-        for item_idx, item in enumerate(step["items"], 1):
-            print(f"   {step_idx}.{item_idx} {item}")
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
+    ap.add_argument("--name", help="Client/project name override")
+    ap.add_argument("--config", default="workflow.config.json")
+    ap.add_argument("--output-root", default="../_generated")
+    ap.add_argument("--verify", action="store_true", help="Run artifact checks and report summary")
+    ap.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run artifact checks and lightweight --help commands for referenced scripts",
+    )
+    return ap.parse_args()
+
+
+def _load_config(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(f"[plan] config not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_name(cfg: dict, override: str | None) -> str:
+    name = override or os.environ.get("NAME") or cfg.get("name")
+    if not name:
+        raise ValueError("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)")
+    return str(name)
+
+
+def _parse_brief(path: Path) -> ScaffoldSpec:
+    if not path.exists():
+        raise FileNotFoundError(f"[plan] brief not found: {path}")
+    return BriefParser(str(path)).parse()
+
+
+def _normalize_output_root(output_root: str) -> Path:
+    return Path(output_root).resolve()
+
+
+@dataclass
+class CheckResult:
+    description: str
+    passed: bool
+    message: str
+
+
+@dataclass
+class CommandResult:
+    description: str
+    returncode: int
+    stderr: str
+
+
+def run_checks(steps: Sequence[ChecklistStep]) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    for step in steps:
+        for check in step.checks:
+            try:
+                passed = bool(check.validator())
+            except Exception as exc:  # pragma: no cover - defensive
+                passed = False
+                message = f"check raised {exc}"
+            else:
+                message = "" if passed else check.failure_message
+            results.append(CheckResult(description=f"{step.title}: {check.description}", passed=passed, message=message))
+    return results
+
+
+def run_commands(steps: Sequence[ChecklistStep]) -> List[CommandResult]:
+    results: List[CommandResult] = []
+    for step in steps:
+        for command in step.commands:
+            completed = subprocess.run(command.args, capture_output=True, text=True)
+            stderr = completed.stderr.strip()
+            results.append(
+                CommandResult(
+                    description=f"{step.title}: {command.description}",
+                    returncode=completed.returncode,
+                    stderr=stderr,
+                )
+            )
+    return results
+
+
+def print_steps(steps: Sequence[ChecklistStep]) -> None:
+    for idx, step in enumerate(steps, 1):
+        print(f"{idx}. {step.title}")
+        for item_idx, item in enumerate(step.items, 1):
+            print(f"   {idx}.{item_idx} {item}")
         print()
 
-    return 0
+
+def summarize(results: Sequence[CheckResult | CommandResult]) -> int:
+    exit_code = 0
+    if not results:
+        return exit_code
+
+    print("Verification Summary:")
+    for result in results:
+        if isinstance(result, CheckResult):
+            status = "PASS" if result.passed else "FAIL"
+            print(f" - [{status}] {result.description}")
+            if not result.passed and result.message:
+                print(f"     → {result.message}")
+            if not result.passed:
+                exit_code = 1
+        else:
+            status = "PASS" if result.returncode == 0 else "FAIL"
+            print(f" - [{status}] {result.description}")
+            if result.stderr:
+                print(f"     → {result.stderr}")
+            if result.returncode != 0:
+                exit_code = 1
+    print()
+    return exit_code
 
 
-if __name__ == "__main__":
+def main() -> int:
+    args = parse_args()
+
+    try:
+        cfg = _load_config(ROOT / args.config)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    try:
+        name = _resolve_name(cfg, args.name)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
+    try:
+        spec = _parse_brief(brief_path)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    output_root = _normalize_output_root(args.output_root)
+    project_dir = (output_root / name).resolve()
+
+    lanes = build_plan(spec)
+
+    ctx = ChecklistContext(
+        spec=spec,
+        config=cfg,
+        brief_path=brief_path,
+        project_dir=project_dir,
+        output_root=output_root,
+        lanes=lanes,
+    )
+
+    steps = ChecklistBuilder(ctx).build()
+    print_steps(steps)
+
+    exit_code = 0
+    if args.verify or args.execute:
+        check_results = run_checks(steps)
+        command_results: List[CommandResult] = []
+        if args.execute:
+            command_results = run_commands(steps)
+        exit_code = summarize([*check_results, *command_results])
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
     raise SystemExit(main())
+

--- a/tests/test_plan_from_brief_dynamic.py
+++ b/tests/test_plan_from_brief_dynamic.py
@@ -1,0 +1,43 @@
+from scripts.plan_from_brief import build_plan
+from project_generator.core.brief_parser import ScaffoldSpec
+
+
+def _spec(**overrides):
+    base = dict(
+        name="demo",
+        industry="saas",
+        project_type="fullstack",
+        frontend="nextjs",
+        backend="fastapi",
+        database="postgres",
+        auth="auth0",
+        deploy="aws",
+        compliance=[],
+        features=[],
+        separate_repos=True,
+    )
+    base.update(overrides)
+    return ScaffoldSpec(**base)
+
+
+def test_api_project_skips_frontend_lane():
+    plan = build_plan(_spec(project_type="api", frontend="none"))
+    assert plan["frontend"] == []
+    backend_ids = [task["id"] for task in plan["backend"]]
+    assert "BE-DOCS" in backend_ids
+
+
+def test_mobile_project_uses_mobile_templates():
+    plan = build_plan(
+        _spec(project_type="mobile", frontend="expo", features=["offline"], auth="cognito")
+    )
+    frontend_ids = [task["id"] for task in plan["frontend"]]
+    assert "FE-MOB-SHELL" in frontend_ids
+    assert "FE-MOB-OFFLINE" in frontend_ids
+
+
+def test_compliance_tasks_present_when_requested():
+    plan = build_plan(_spec(compliance=["hipaa", "gdpr"]))
+    backend_ids = [task["id"] for task in plan["backend"]]
+    assert "BE-HIPAA" in backend_ids
+    assert "BE-GDPR" in backend_ids

--- a/tests/test_pre_lifecycle_plan_builder.py
+++ b/tests/test_pre_lifecycle_plan_builder.py
@@ -1,0 +1,79 @@
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from project_generator.core.brief_parser import ScaffoldSpec
+
+from scripts.pre_lifecycle_plan import ChecklistBuilder, ChecklistContext
+
+
+@pytest.fixture()
+def spec() -> ScaffoldSpec:
+    return ScaffoldSpec(
+        name="demo",
+        industry="saas",
+        project_type="fullstack",
+        frontend="nextjs",
+        backend="fastapi",
+        database="postgres",
+        auth="auth0",
+        deploy="aws",
+        compliance=["hipaa"],
+        features=["reporting"],
+        separate_repos=True,
+    )
+
+
+def _ctx(spec: ScaffoldSpec, tmp_path: Path, lanes: dict, **config_overrides) -> ChecklistContext:
+    config = {
+        "deploy": spec.deploy,
+        "compliance": spec.compliance,
+        "frontend": spec.frontend,
+        "backend": spec.backend,
+        "database": spec.database,
+    }
+    config.update(config_overrides)
+    brief_path = tmp_path / "docs" / "briefs" / spec.name / "brief.md"
+    brief_path.parent.mkdir(parents=True)
+    brief_path.write_text("demo", encoding="utf-8")
+    project_dir = tmp_path / spec.name
+    project_dir.mkdir()
+    (project_dir / "PLAN.md").write_text("plan", encoding="utf-8")
+    (project_dir / "PLAN.tasks.json").write_text("{}", encoding="utf-8")
+    (project_dir / "evidence").mkdir()
+    (project_dir / "frontend").mkdir()
+    (project_dir / "backend").mkdir()
+    return ChecklistContext(
+        spec=spec,
+        config=config,
+        brief_path=brief_path,
+        project_dir=project_dir,
+        output_root=tmp_path,
+        lanes=lanes,
+    )
+
+
+def test_frontend_stage_omitted_when_lane_empty(spec: ScaffoldSpec, tmp_path: Path):
+    lanes = {"backend": [{"id": "BE", "title": "", "blocked_by": [], "acceptance": []}], "frontend": []}
+    ctx = _ctx(replace(spec, frontend="none"), tmp_path, lanes, frontend="none")
+    steps = ChecklistBuilder(ctx).build()
+    titles = [step.title for step in steps]
+    assert "Frontend Implementation Sequence (execute in project workspace)" not in titles
+
+
+def test_deploy_and_observability_skipped_when_no_deploy(spec: ScaffoldSpec, tmp_path: Path):
+    lanes = {"backend": [], "frontend": []}
+    ctx = _ctx(spec, tmp_path, lanes, deploy="n/a")
+    steps = ChecklistBuilder(ctx).build()
+    titles = [step.title for step in steps]
+    assert "Deploy & Promote" not in titles
+    assert "Observability & Continuous Ops" not in titles
+
+
+def test_packaging_stage_includes_compliance(spec: ScaffoldSpec, tmp_path: Path):
+    lanes = {"backend": [], "frontend": []}
+    ctx = _ctx(spec, tmp_path, lanes)
+    steps = ChecklistBuilder(ctx).build()
+    packaging = next(step for step in steps if "Packaging" in step.title)
+    assert any("validate_compliance_assets" in item for item in packaging.items)


### PR DESCRIPTION
## Summary
- refactor scripts/plan_from_brief.py to derive backend/frontend lanes from the parsed brief, including conditional compliance and feature work
- rebuild scripts/pre_lifecycle_plan.py around modular stage builders with script discovery, artifact checks, optional execution reporting, and capability-aware instructions
- add targeted unit tests covering the dynamic plan generation and checklist gating behaviour

## Testing
- pytest tests/test_plan_from_brief_dynamic.py tests/test_pre_lifecycle_plan_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68d49d47c2f4832e9d2c087c584ae10b