### PR TITLE
Refine lifecycle planner to be capability-aware

### DIFF
--- a/scripts/plan_from_brief.py
+++ b/scripts/plan_from_brief.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+import re
+from typing import Dict, Iterable, List, Optional
 
 from project_generator.core.brief_parser import BriefParser
 
@@ -16,203 +18,321 @@ from project_generator.core.brief_parser import BriefParser
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Generate FE/BE plan artifacts from brief.md")
     p.add_argument("--brief", required=True, help="Path to brief.md")
-    p.add_argument("--out", default="PLAN.md", help="Path to write PLAN.md (tasks.json will be co-located)")
+    p.add_argument(
+        "--out",
+        default="PLAN.md",
+        help="Path to write PLAN.md (tasks.json will be co-located)",
+    )
+    p.add_argument(
+        "--config",
+        help="Optional workflow.config.json to merge capability flags with the parsed brief",
+    )
     return p.parse_args()
 
 
-def task(
-    id_: str,
-    title: str,
-    area: str,
-    blocked_by: List[str] | None = None,
-    labels: List[str] | None = None,
-    estimate: str = "1d",
-    acceptance: List[str] | None = None,
-    dod: List[str] | None = None,
-) -> Dict:
-    return {
-        "id": id_,
-        "title": title,
-        "area": area,
-        "estimate": estimate,
-        "blocked_by": blocked_by or [],
-        "labels": labels or [],
-        "acceptance": acceptance or [],
-        "dod": dod or [],
-        "state": "pending",
+@dataclass
+class Task:
+    id: str
+    title: str
+    area: str
+    blocked_by: Iterable[str] = field(default_factory=list)
+    labels: Iterable[str] = field(default_factory=list)
+    estimate: str = "1d"
+    acceptance: Iterable[str] = field(default_factory=list)
+    dod: Iterable[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "area": self.area,
+            "estimate": self.estimate,
+            "blocked_by": list(self.blocked_by),
+            "labels": list(self.labels),
+            "acceptance": list(self.acceptance),
+            "dod": list(self.dod),
+            "state": "pending",
+        }
+
+
+def _slugify(prefix: str, value: str, max_tokens: int = 3) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    tokens = [tok for tok in slug.split("-") if tok]
+    if not tokens:
+        tokens = ["feature"]
+    tokens = tokens[:max_tokens]
+    joined = "-".join(tok.upper() for tok in tokens)
+    return f"{prefix}-{joined}"
+
+
+def _feature_area(feature: str, project_type: str, frontend: str, backend: str) -> str:
+    backend_signals = {
+        "api",
+        "service",
+        "checkout",
+        "payment",
+        "billing",
+        "analytics",
+        "report",
+        "data",
+        "inventory",
+        "integration",
+        "workflow",
+        "automation",
+    }
+    frontend_signals = {
+        "page",
+        "dashboard",
+        "ui",
+        "layout",
+        "portal",
+        "form",
+        "component",
+        "screen",
+    }
+    feature_lower = feature.lower()
+    if backend != "none" and (
+        project_type in {"api", "microservices"}
+        or any(sig in feature_lower for sig in backend_signals)
+    ):
+        return "backend"
+    if frontend != "none" and any(sig in feature_lower for sig in frontend_signals):
+        return "frontend"
+    # Default to backend for data-heavy features, frontend otherwise
+    return "backend" if backend != "none" else "frontend"
+
+
+def _feature_tasks(
+    features: Iterable[str],
+    project_type: str,
+    frontend: str,
+    backend: str,
+) -> Dict[str, List[Task]]:
+    buckets: Dict[str, List[Task]] = {"backend": [], "frontend": []}
+    for feature in features:
+        area = _feature_area(feature, project_type, frontend, backend)
+        task_id = _slugify("BE-FTR" if area == "backend" else "FE-FTR", feature)
+        title = f"Implement feature: {feature}"
+        acceptance = ["acceptance criteria captured from brief"]
+        if area == "backend":
+            acceptance.append("API contract documented")
+        else:
+            acceptance.append("UI reviewed with design requirements")
+        buckets[area].append(
+            Task(
+                id=task_id,
+                title=title,
+                area=area,
+                acceptance=acceptance,
+                labels=["feature"],
+            )
+        )
+    return buckets
+
+
+def _normalize_compliance(values: Optional[Iterable[str]]) -> List[str]:
+    if not values:
+        return []
+    if isinstance(values, str):  # type: ignore[arg-type]
+        return [v.strip().lower() for v in values.split(",") if v.strip()]
+    return [str(v).strip().lower() for v in values if str(v).strip()]
+
+
+def _compliance_tasks(compliance: Iterable[str], area: str) -> List[Task]:
+    tasks: List[Task] = []
+    for item in compliance:
+        label = item.upper()
+        if label == "":
+            continue
+        prefix = "BE" if area == "backend" else "FE"
+        task_id = f"{prefix}-COMP-{label.replace('-', '_')}"
+        title = f"Ensure {item.upper()} controls ({area})"
+        acceptance = [f"{item.upper()} requirements validated"]
+        tasks.append(
+            Task(
+                id=task_id,
+                title=title,
+                area=area,
+                acceptance=acceptance,
+                labels=["compliance"],
+            )
+        )
+    return tasks
+
+
+def _backend_core_tasks(spec, workflow: Optional[Dict]) -> List[Task]:
+    if spec.backend == "none":
+        return []
+
+    capabilities = workflow or {}
+    database_enabled = spec.database != "none"
+    auth_enabled = (spec.auth != "none") or bool(capabilities.get("auth"))
+    observability_required = capabilities.get("observability", True)
+
+    tasks: List[Task] = []
+    if database_enabled:
+        tasks.append(
+            Task(
+                id="BE-SCHEMA",
+                title="Design and document database schema",
+                area="backend",
+                acceptance=["ERD drafted", "tables + relationships defined"],
+            )
+        )
+        tasks.append(
+            Task(
+                id="BE-SEED",
+                title="Create seed loaders / fixtures",
+                area="backend",
+                blocked_by=["BE-SCHEMA"],
+                acceptance=["seed scripts execute", "sample data available"],
+            )
+        )
+
+    if spec.project_type in {"api", "fullstack", "microservices"}:
+        tasks.append(
+            Task(
+                id="BE-DOMAIN",
+                title="Model domain services & aggregates",
+                area="backend",
+                blocked_by=["BE-SEED"] if database_enabled else [],
+                acceptance=["domain models stable", "business invariants captured"],
+            )
+        )
+        tasks.append(
+            Task(
+                id="BE-API-CONTRACT",
+                title="Define API contract & versioning strategy",
+                area="backend",
+                blocked_by=["BE-DOMAIN"],
+                acceptance=["OpenAPI drafted", "error models documented"],
+            )
+        )
+
+    if auth_enabled:
+        tasks.append(
+            Task(
+                id="BE-AUTH",
+                title=f"Implement auth integration ({spec.auth})",
+                area="backend",
+                acceptance=["role policies enforced", "token validation in place"],
+                labels=["security"],
+            )
+        )
+
+    if observability_required:
+        tasks.append(
+            Task(
+                id="BE-OBS",
+                title="Instrument logging/metrics/tracing",
+                area="backend",
+                acceptance=["structured logs", "trace ids propagated"],
+                labels=["observability"],
+            )
+        )
+
+    tasks.append(
+        Task(
+            id="BE-TESTS",
+            title="Unit/integration test suite",
+            area="backend",
+            acceptance=["tests passing", "coverage threshold met"],
+            labels=["testing"],
+        )
+    )
+    return tasks
+
+
+def _frontend_core_tasks(spec, workflow: Optional[Dict]) -> List[Task]:
+    if spec.frontend == "none":
+        return []
+
+    capabilities = workflow or {}
+    design_system_required = capabilities.get("design_system", True)
+    accessibility_required = capabilities.get("accessibility", True)
+
+    tasks: List[Task] = [
+        Task(
+            id="FE-SCAFFOLD",
+            title="Bootstrap routing/layout",
+            area="frontend",
+            acceptance=["routes wired", "shared layout established"],
+        ),
+        Task(
+            id="FE-DATA",
+            title="Configure API client / data layer",
+            area="frontend",
+            blocked_by=["FE-SCAFFOLD"],
+            acceptance=["client typed", "error states handled"],
+        ),
+    ]
+
+    if design_system_required:
+        tasks.append(
+            Task(
+                id="FE-DESIGN",
+                title="Apply design system & theming",
+                area="frontend",
+                blocked_by=["FE-SCAFFOLD"],
+                acceptance=["base styles applied", "token usage documented"],
+            )
+        )
+
+    if accessibility_required:
+        tasks.append(
+            Task(
+                id="FE-A11Y",
+                title="Accessibility + performance audit",
+                area="frontend",
+                acceptance=["WCAG AA checklist", "lighthouse ≥ 90"],
+                labels=["a11y", "performance"],
+            )
+        )
+
+    tasks.append(
+        Task(
+            id="FE-TESTS",
+            title="Component/e2e smoke tests",
+            area="frontend",
+            blocked_by=["FE-DATA"],
+            acceptance=["tests passing"],
+            labels=["testing"],
+        )
+    )
+    return tasks
+
+
+def build_plan(spec, workflow_config: Optional[Dict] = None) -> Dict[str, List[Dict]]:
+    """Build a plan that adapts to the parsed brief and workflow flags."""
+
+    workflow_config = workflow_config or {}
+    backend_lane: List[Task] = _backend_core_tasks(spec, workflow_config)
+    frontend_lane: List[Task] = _frontend_core_tasks(spec, workflow_config)
+
+    feature_tasks = _feature_tasks(spec.features, spec.project_type, spec.frontend, spec.backend)
+    backend_lane.extend(feature_tasks["backend"])
+    frontend_lane.extend(feature_tasks["frontend"])
+
+    compliance_sources = _normalize_compliance(workflow_config.get("compliance"))
+    if not compliance_sources:
+        compliance_sources = _normalize_compliance(spec.compliance)
+    if spec.backend != "none":
+        backend_lane.extend(_compliance_tasks(compliance_sources, "backend"))
+    if spec.frontend != "none":
+        frontend_lane.extend(_compliance_tasks(compliance_sources, "frontend"))
+
+    plan = {
+        "backend": [task.as_dict() for task in backend_lane],
+        "frontend": [task.as_dict() for task in frontend_lane],
     }
 
+    # Ensure empty lanes are represented for downstream consumers
+    if not plan["backend"]:
+        plan["backend"] = []
+    if not plan["frontend"]:
+        plan["frontend"] = []
 
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    be: List[Dict] = []
-    fe: List[Dict] = []
-
-    # Backend lane
-    be.append(
-        task(
-            "BE-SCH",
-            "Design DB schema",
-            "backend",
-            acceptance=["ERD drafted", "tables defined", "naming conventions applied"],
-        )
-    )
-    be.append(
-        task(
-            "BE-SEED",
-            "Seed loaders (CSV/mock)",
-            "backend",
-            blocked_by=["BE-SCH"],
-            acceptance=["seed scripts run", "sample rows present"],
-        )
-    )
-    be.append(
-        task(
-            "BE-MDL",
-            "Aggregates/MatViews (funnel, revenue, etc.)",
-            "backend",
-            blocked_by=["BE-SEED"],
-            acceptance=["views created", "query p95 < 400ms (seed)"],
-        )
-    )
-    be += [
-        task(
-            "BE-API-KPI",
-            "GET /api/v1/kpis",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["returns totals/deltas", "OpenAPI updated"],
-        ),
-        task(
-            "BE-API-REV",
-            "GET /api/v1/revenue",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["time series ok", "OpenAPI updated"],
-        ),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task(
-            "BE-EXP",
-            "GET /api/v1/export/csv",
-            "backend",
-            blocked_by=[
-                "BE-API-KPI",
-                "BE-API-REV",
-                "BE-API-CAT",
-                "BE-API-PLT",
-                "BE-API-CUS",
-                "BE-API-FDB",
-            ],
-        ),
-    ]
-    be.append(
-        task(
-            "BE-AUTH",
-            "Auth0/RBAC skeleton",
-            "backend",
-            labels=["security"],
-            acceptance=["role checks present"],
-        )
-    )
-    be.append(
-        task(
-            "BE-OBS",
-            "Structured logs + correlation IDs",
-            "backend",
-            labels=["observability"],
-            acceptance=["request id on logs"],
-        )
-    )
-    be.append(
-        task(
-            "BE-TST",
-            "Unit+Integration tests (Testcontainers)",
-            "backend",
-            blocked_by=["BE-API-KPI", "BE-API-REV"],
-            acceptance=["pytest green", ">= minimal coverage"],
-        )
-    )
-
-    # Frontend lane
-    fe.append(
-        task(
-            "FE-DSN",
-            "Shell/Layout/Routes",
-            "frontend",
-            acceptance=["routes wired", "base theme applied"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-TYPES",
-            "openapi-typescript client",
-            "frontend",
-            acceptance=["types.ts generated", "typed client compiles"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-MOCKS",
-            "MSW/Prism mocks",
-            "frontend",
-            acceptance=["mocks respond", "dev proxy configured"],
-        )
-    )
-    fe += [
-        task(
-            "FE-KPI",
-            "KPI cards + filters",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
-        ),
-        task(
-            "FE-REV",
-            "Revenue chart + range selectors",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
-        ),
-        task("FE-PLT", "Platform distribution (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task(
-            "FE-EXP",
-            "Exports (CSV/PNG)",
-            "frontend",
-            blocked_by=[
-                "FE-KPI",
-                "FE-REV",
-                "FE-PLT",
-                "FE-CAT",
-                "FE-CUS",
-                "FE-FDB",
-            ],
-            acceptance=["CSV downloads"],
-        ),
-    ]
-    fe.append(
-        task(
-            "FE-A11Y-PERF",
-            "WCAG AA + code-split/memoize",
-            "frontend",
-            labels=["a11y", "performance"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-TST",
-            "Component + E2E smoke",
-            "frontend",
-            blocked_by=["FE-KPI", "FE-REV"],
-            acceptance=["tests green"],
-        )
-    )
-
-    return {"backend": be, "frontend": fe}
+    return plan
 
 
 def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:
@@ -242,7 +362,14 @@ def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:
 def main() -> None:
     args = parse_args()
     spec = BriefParser(args.brief).parse()
-    plan = build_plan(spec)
+    workflow_config = None
+    if args.config:
+        config_path = Path(args.config)
+        if config_path.exists():
+            workflow_config = json.loads(config_path.read_text(encoding="utf-8"))
+        else:
+            print(f"[plan_from_brief] config not found: {config_path}")
+    plan = build_plan(spec, workflow_config)
 
     # Write tasks.json
     tasks_json_path = Path(args.out).with_suffix(".tasks.json")

--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -1,158 +1,403 @@
 #!/usr/bin/env python3
-"""
-Pre-lifecycle roadmap generator.
-
-Reads workflow.config.json (or overrides) and the corresponding docs/briefs/<NAME>/brief.md,
-recreates the ordered task lanes, then prints a sequential, human-readable checklist that
-extends the lifecycle automation with the manual quality, deploy, and observability work.
-"""
+"""Pre-lifecycle roadmap generator with capability-aware gating."""
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from project_generator.core.brief_parser import BriefParser  # type: ignore[misc]
+from project_generator.core.brief_parser import BriefParser, ScaffoldSpec  # type: ignore[misc]
 
 
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    """Replica of scripts/plan_from_brief.build_plan to reuse lane ordering."""
-    def task(id_, title, area, blocked_by=None, labels=None, estimate="1d",
-             acceptance=None, dod=None):
-        return {
-            "id": id_,
-            "title": title,
-            "area": area,
-            "estimate": estimate,
-            "blocked_by": blocked_by or [],
-            "labels": labels or [],
-            "acceptance": acceptance or [],
-            "dod": dod or [],
-            "state": "pending",
-        }
+def _load_plan_builder() -> Callable:
+    plan_module_path = ROOT / "scripts" / "plan_from_brief.py"
+    spec = importlib.util.spec_from_file_location("_plan_from_brief", plan_module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load plan_from_brief.py from {plan_module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[misc]
+    return module.build_plan  # type: ignore[attr-defined]
 
-    be: List[Dict] = []
-    fe: List[Dict] = []
 
-    be.append(task("BE-SCH", "Design DB schema", "backend",
-                   acceptance=["ERD drafted", "tables defined", "naming conventions applied"]))
-    be.append(task("BE-SEED", "Seed loaders (CSV/mock)", "backend", blocked_by=["BE-SCH"],
-                   acceptance=["seed scripts run", "sample rows present"]))
-    be.append(task("BE-MDL", "Aggregates/MatViews (funnel, revenue, etc.)", "backend",
-                   blocked_by=["BE-SEED"],
-                   acceptance=["views created", "query p95 < 400ms (seed)"]))
-    be += [
-        task("BE-API-KPI", "GET /api/v1/kpis", "backend", blocked_by=["BE-MDL"],
-             acceptance=["returns totals/deltas", "OpenAPI updated"]),
-        task("BE-API-REV", "GET /api/v1/revenue", "backend", blocked_by=["BE-MDL"],
-             acceptance=["time series ok", "OpenAPI updated"]),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task("BE-EXP", "GET /api/v1/export/csv", "backend",
-             blocked_by=["BE-API-KPI", "BE-API-REV", "BE-API-CAT",
-                         "BE-API-PLT", "BE-API-CUS", "BE-API-FDB"]),
-    ]
-    be.append(task("BE-AUTH", "Auth0/RBAC skeleton", "backend",
-                   labels=["security"], acceptance=["role checks present"]))
-    be.append(task("BE-OBS", "Structured logs + correlation IDs", "backend",
-                   labels=["observability"], acceptance=["request id on logs"]))
-    be.append(task("BE-TST", "Unit+Integration tests (Testcontainers)", "backend",
-                   blocked_by=["BE-API-KPI", "BE-API-REV"],
-                   acceptance=["pytest green", ">= minimal coverage"]))
+build_plan = _load_plan_builder()
 
-    fe.append(task("FE-DSN", "Shell/Layout/Routes", "frontend",
-                   acceptance=["routes wired", "base theme applied"]))
-    fe.append(task("FE-TYPES", "openapi-typescript client", "frontend",
-                   acceptance=["types.ts generated", "typed client compiles"]))
-    fe.append(task("FE-MOCKS", "MSW/Prism mocks", "frontend",
-                   acceptance=["mocks respond", "dev proxy configured"]))
-    fe += [
-        task("FE-KPI", "KPI cards + filters", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-REV", "Revenue chart + range selectors", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-PLT", "Platform distribution (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-EXP", "Exports (CSV/PNG)", "frontend",
-             blocked_by=["FE-KPI", "FE-REV", "FE-PLT", "FE-CAT", "FE-CUS", "FE-FDB"],
-             acceptance=["CSV downloads"]),
-    ]
-    fe.append(task("FE-A11Y-PERF", "WCAG AA + code-split/memoize", "frontend",
-                   labels=["a11y", "performance"]))
-    fe.append(task("FE-TST", "Component + E2E smoke", "frontend",
-                   blocked_by=["FE-KPI", "FE-REV"], acceptance=["tests green"]))
 
-    return {"backend": be, "frontend": fe}
+@dataclass
+class ValidationMessage:
+    status: str
+    message: str
+
+
+@dataclass
+class ChecklistStage:
+    title: str
+    items: List[str]
+
+
+class ScriptResolver:
+    """Locate scripts dynamically so references stay accurate if paths change."""
+
+    def __init__(self, scripts_root: Path):
+        self.scripts_root = scripts_root
+        self._cache: Dict[str, Path] = {}
+
+    def find(self, name: str) -> Optional[Path]:
+        if name in self._cache:
+            return self._cache[name]
+        matches = [p for p in self.scripts_root.rglob(name) if p.is_file()]
+        if matches:
+            self._cache[name] = matches[0]
+            return matches[0]
+        return None
+
+
+@dataclass
+class PlannerContext:
+    name: str
+    config: Dict
+    spec: ScaffoldSpec
+    brief_path: Path
+    output_root: Path
+    project_dir: Path
+    script_resolver: ScriptResolver
+    validations: List[ValidationMessage] = field(default_factory=list)
+    exit_code: int = 0
+    _resolved_scripts: Dict[str, str] = field(default_factory=dict)
+
+    def record(self, status: str, message: str) -> None:
+        self.validations.append(ValidationMessage(status=status, message=message))
+        if status.lower() == "error":
+            self.exit_code = max(self.exit_code, 1)
+
+    def require_artifact(
+        self,
+        path: Path,
+        description: str,
+        required: bool = True,
+        remedy: Optional[str] = None,
+    ) -> bool:
+        exists = path.exists()
+        if exists:
+            self.record("ok", f"{description} present: {path}")
+            return True
+
+        status = "error" if required else "warn"
+        msg = f"{description} missing: {path}"
+        if remedy:
+            msg += f" — {remedy}"
+        self.record(status, msg)
+        return False
+
+    def resolve_script(self, name: str, required: bool = True) -> str:
+        if name in self._resolved_scripts:
+            return self._resolved_scripts[name]
+        resolved = self.script_resolver.find(name)
+        if resolved:
+            rel = resolved.relative_to(ROOT)
+            self.record("ok", f"Script available: {rel}")
+            self._resolved_scripts[name] = rel.as_posix()
+            return self._resolved_scripts[name]
+        status = "error" if required else "warn"
+        self.record(status, f"Script missing: {name}")
+        fallback = Path("scripts") / name
+        self._resolved_scripts[name] = fallback.as_posix()
+        return self._resolved_scripts[name]
+
+    @property
+    def compliance(self) -> List[str]:
+        cfg_val = self.config.get("compliance")
+        if isinstance(cfg_val, str):
+            cfg_items = [c.strip().lower() for c in cfg_val.split(",") if c.strip()]
+        elif isinstance(cfg_val, Iterable):
+            cfg_items = [str(c).strip().lower() for c in cfg_val if str(c).strip()]
+        else:
+            cfg_items = []
+        spec_items = [c.strip().lower() for c in self.spec.compliance if c.strip()]
+        merged = list(dict.fromkeys(cfg_items + spec_items))
+        return merged
 
 
 def format_lane(lane: List[Dict]) -> List[str]:
-    entries = []
-    for idx, t in enumerate(lane, 1):
-        blockers = ", ".join(t["blocked_by"]) if t["blocked_by"] else "none"
-        acceptance = ", ".join(t["acceptance"]) if t["acceptance"] else "see acceptance criteria"
+    entries: List[str] = []
+    for idx, task in enumerate(lane, 1):
+        blockers = ", ".join(task.get("blocked_by", [])) or "none"
+        acceptance = ", ".join(task.get("acceptance", [])) or "see acceptance criteria"
         entries.append(
-            f"{t['id']}: {t['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
+            f"{task['id']}: {task['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
         )
     return entries
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
-    ap.add_argument("--name", help="Client/project name override")
-    ap.add_argument("--config", default="workflow.config.json")
-    ap.add_argument("--output-root", default="../_generated")
-    args = ap.parse_args()
+def environment_stage(ctx: PlannerContext, cfg_path: Path) -> ChecklistStage:
+    industry = ctx.config.get("industry", ctx.spec.industry)
+    project_type = ctx.config.get("project_type", ctx.spec.project_type)
+    frontend = ctx.config.get("frontend", ctx.spec.frontend)
+    backend = ctx.config.get("backend", ctx.spec.backend)
+    database = ctx.config.get("database", ctx.spec.database)
+    auth = ctx.config.get("auth", ctx.spec.auth)
+    deploy = ctx.config.get("deploy", ctx.spec.deploy)
 
-    cfg_path = ROOT / args.config
-    if not cfg_path.exists():
-        print(f"[plan] config not found: {cfg_path}", file=sys.stderr)
-        return 2
+    items = [
+        "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
+        f"Confirm brief exists at {ctx.brief_path}.",
+        (
+            "Verify workflow configuration values "
+            f"(industry={industry}, project_type={project_type}, frontend={frontend}, "
+            f"backend={backend}, database={database}, auth={auth}, deploy={deploy})."
+        ),
+        (
+            "Export automation variables before running lifecycle: "
+            f"NAME={ctx.name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
+            f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={ctx.output_root}\n"
+            "   Optional: AUTH, DEPLOY, COMPLIANCE, FORCE_OUTPUT=1."
+        ),
+    ]
 
-    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    if ctx.compliance:
+        items.append(
+            "Confirm compliance checklists are populated and stored under docs/compliance/ for reuse."
+        )
 
-    name = args.name or os.environ.get("NAME") or cfg.get("name")
-    if not name:
-        print("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)", file=sys.stderr)
-        return 2
+    return ChecklistStage(title="Environment & Inputs", items=items)
 
-    industry = cfg.get("industry", "<unspecified>")
-    project_type = cfg.get("project_type", "<unspecified>")
-    frontend = cfg.get("frontend", "<unspecified>")
-    backend = cfg.get("backend", "<unspecified>")
-    database = cfg.get("database", "<unspecified>")
-    auth = cfg.get("auth") or "none"
-    deploy = cfg.get("deploy") or "n/a"
-    compliance = cfg.get("compliance") or "none"
 
-    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
-    if not brief_path.exists():
-        print(f"[plan] brief not found: {brief_path}", file=sys.stderr)
-        return 2
+def planning_stage(ctx: PlannerContext, plan_md: Path, plan_tasks: Path) -> ChecklistStage:
+    generator = ctx.resolve_script("plan_from_brief.py")
+    validator = ctx.resolve_script("validate_tasks.py")
+    items = [
+        "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
+        (
+            "Generate planning artifacts (dry run supported): "
+            f"python {generator} --brief '{ctx.brief_path}' --out '{plan_md}'"
+        ),
+        (
+            "Validate DAG topology prior to generation: "
+            f"python {validator} --input '{plan_tasks}'"
+        ),
+        "Inspect PLAN lanes and resolve dependencies/blocked tasks before coding.",
+    ]
 
-    spec = BriefParser(str(brief_path)).parse()
-    lanes = build_plan(spec)
+    ctx.require_artifact(
+        plan_md,
+        "PLAN.md artifact",
+        required=False,
+        remedy="Run plan_from_brief to materialise planning documents.",
+    )
+    ctx.require_artifact(
+        plan_tasks,
+        "PLAN.tasks.json artifact",
+        required=False,
+        remedy="Run plan_from_brief to emit task graph JSON.",
+    )
 
-    output_root = Path(args.output_root)
-    project_dir = (output_root / name).resolve()
+    return ChecklistStage(title="Planning & Alignment", items=items)
 
-    frontend_lane = format_lane(lanes["frontend"])
-    backend_lane = format_lane(lanes["backend"])
 
+def stack_preflight_stage(ctx: PlannerContext) -> ChecklistStage:
+    doctor = ctx.resolve_script("doctor.py")
+    generator = ctx.resolve_script("generate_client_project.py")
+    select = ctx.resolve_script("select_stacks.py")
+
+    industry = ctx.config.get("industry", ctx.spec.industry)
+    project_type = ctx.config.get("project_type", ctx.spec.project_type)
+    frontend = ctx.config.get("frontend", ctx.spec.frontend)
+    backend = ctx.config.get("backend", ctx.spec.backend)
+    database = ctx.config.get("database", ctx.spec.database)
+    auth = ctx.config.get("auth", ctx.spec.auth)
+    deploy = ctx.config.get("deploy", ctx.spec.deploy)
+
+    def flag(name: str, value: str) -> str:
+        return f" --{name} '{value}'" if value and value not in {"none", "n/a"} else ""
+
+    select_cmd = (
+        f"python {select} --industry '{industry}' --project-type '{project_type}'"
+        f"{flag('frontend', frontend)}{flag('backend', backend)}{flag('database', database)}"
+        f" --output '{ctx.project_dir}/selection.json'"
+        f" --summary '{ctx.project_dir}/evidence/stack-selection.md'"
+    )
+    if ctx.compliance:
+        select_cmd += f" --compliance '{','.join(ctx.compliance)}'"
+
+    preview_cmd = (
+        f"{generator} --dry-run --workers 8 --yes --name '{ctx.name}' --industry '{industry}' "
+        f"--project-type '{project_type}'{flag('frontend', frontend)}{flag('backend', backend)}"
+        f"{flag('database', database)}{flag('auth', auth)}{flag('deploy', deploy)}"
+    )
+    if ctx.compliance:
+        preview_cmd += f" --compliance '{','.join(ctx.compliance)}'"
+    preview_cmd += f" --output-dir '{ctx.output_root}'"
+
+    items = [
+        f"Tooling doctor & template discovery: python {doctor} --strict",
+        f"Preflight stack selection and capture evidence: {select_cmd}",
+        "Resolve engine/version mismatches reported by select_stacks before continuing.",
+        f"Preview scaffold (no writes): ./{preview_cmd}",
+    ]
+
+    return ChecklistStage(title="Stack Preflight & Generation Prep", items=items)
+
+
+def generation_stage(ctx: PlannerContext) -> ChecklistStage:
+    industry = ctx.config.get("industry", ctx.spec.industry)
+    project_type = ctx.config.get("project_type", ctx.spec.project_type)
+    frontend = ctx.config.get("frontend", ctx.spec.frontend)
+    backend = ctx.config.get("backend", ctx.spec.backend)
+    database = ctx.config.get("database", ctx.spec.database)
+
+    lifecycle_cmd = (
+        "NAME={name} INDUSTRY={industry} PROJECT_TYPE={ptype} FE={fe} BE={be} "
+        "DB={db} OUTPUT_ROOT={out} make lifecycle"
+    ).format(
+        name=ctx.name,
+        industry=industry,
+        ptype=project_type,
+        fe=frontend,
+        be=backend,
+        db=database,
+        out=ctx.output_root,
+    )
+
+    items = [
+        f"When ready, run the one-shot generator (stops on failure): {lifecycle_cmd}",
+        f"Inspect generated project at {ctx.project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
+        "Capture generator logs and stack selection evidence for audit.",
+    ]
+
+    ctx.require_artifact(
+        ctx.project_dir,
+        "Generated project directory",
+        required=False,
+        remedy="Run make lifecycle to emit the scaffold before continuing.",
+    )
+
+    return ChecklistStage(title="Full Scaffold Generation & Bootstrap (queued automation)", items=items)
+
+
+def frontend_stage(ctx: PlannerContext, frontend_lane: List[str]) -> Optional[ChecklistStage]:
+    if not frontend_lane:
+        return None
+    items = [f"Work inside {ctx.project_dir}/frontend following tasks in order:"] + frontend_lane
+    return ChecklistStage(title="Frontend Implementation Sequence", items=items)
+
+
+def backend_stage(ctx: PlannerContext, backend_lane: List[str]) -> Optional[ChecklistStage]:
+    if not backend_lane:
+        return None
+    items = [f"Work inside {ctx.project_dir}/backend following tasks in order:"] + backend_lane
+    if ctx.spec.database == "none":
+        items.append("Database migrations skipped (no database configured).")
+    return ChecklistStage(title="Backend & Data Implementation Sequence", items=items)
+
+
+def integration_stage(ctx: PlannerContext) -> Optional[ChecklistStage]:
+    if ctx.spec.backend == "none" or ctx.spec.database == "none":
+        return None
+    return ChecklistStage(
+        title="Integration, Migrations, and Data Validation",
+        items=[
+            "Create/adjust migrations, run upgrades, and reseed sample data (aligns with schema/seed tasks).",
+            "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types as needed.",
+            "Update MSW/Prism mocks to match live responses.",
+            "Run smoke flows across dashboards/endpoints to confirm acceptance criteria.",
+        ],
+    )
+
+
+def quality_stage(ctx: PlannerContext) -> ChecklistStage:
+    install_and_test = ctx.resolve_script("install_and_test.sh")
+    collect_cov = ctx.resolve_script("collect_coverage.py")
+    collect_perf = ctx.resolve_script("collect_perf.py")
+    scan_deps = ctx.resolve_script("scan_deps.py")
+    enforce_gates = ctx.resolve_script("enforce_gates.py")
+
+    items = [
+        "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
+        "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
+        "Backend quality: `cd backend && black --check . && flake8` (or backend-specific linters).",
+        "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
+        f"Aggregate stack-aware tests: `PROJECT_ROOT={ctx.project_dir} ./{install_and_test}`.",
+        f"Collect metrics: `PROJECT_ROOT={ctx.project_dir} python {collect_cov}`, `python {collect_perf}`, `python {scan_deps}`.",
+        f"Enforce gates: `PROJECT_ROOT={ctx.project_dir} python {enforce_gates}`.",
+    ]
+
+    return ChecklistStage(title="Quality Automation & Gates", items=items)
+
+
+def local_verification_stage(ctx: PlannerContext) -> ChecklistStage:
+    items = [
+        "Run dev servers for experiential QA: `cd frontend && npm run dev`; `cd backend && uvicorn app.main:app --reload` (or generated entrypoint).",
+        "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
+    ]
+    if ctx.spec.backend != "none" and ctx.spec.frontend != "none":
+        items.append(
+            "Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist."
+        )
+    return ChecklistStage(title="Local Verification & Developer Experience", items=items)
+
+
+def compliance_stage(ctx: PlannerContext) -> ChecklistStage:
+    build_pack = ctx.resolve_script("build_submission_pack.sh")
+    validate_assets = ctx.resolve_script("validate_compliance_assets.py", required=bool(ctx.compliance))
+    doc_scan = ctx.resolve_script("check_compliance_docs.py", required=False)
+
+    items = [
+        f"Package deliverables: `PROJECT_ROOT={ctx.project_dir} NAME={ctx.name} ./{build_pack}`.",
+    ]
+    if ctx.compliance:
+        items.append(
+            f"Validate compliance assets: `PROJECT_ROOT={ctx.project_dir} python {validate_assets}`."
+        )
+        items.append(
+            f"Optional doc scan: `PROJECT_ROOT={ctx.project_dir} python {doc_scan}`."
+        )
+    items.append("Archive evidence/, dist/, coverage/, reports/ for hand-off.")
+
+    return ChecklistStage(title="Compliance, Evidence, and Packaging", items=items)
+
+
+def cicd_stage(ctx: PlannerContext) -> Optional[ChecklistStage]:
+    if ctx.config.get("deploy", ctx.spec.deploy) in {"n/a", "none", ""}:
+        return None
+    return ChecklistStage(
+        title="CI/CD Enablement",
+        items=[
+            "Populate GitHub secrets/vars required by CI workflows (deploy + validation).",
+            "Enforce production environment protection/approvals in GitHub.",
+            "Trigger ci-secrets-preflight and resolve missing configuration.",
+            "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
+        ],
+    )
+
+
+def deploy_stage(ctx: PlannerContext) -> Optional[ChecklistStage]:
+    if ctx.config.get("deploy", ctx.spec.deploy) in {"n/a", "none", ""}:
+        return None
+    health_check = ctx.resolve_script("health/check_deployment.py", required=False)
+    rollback_backend = ctx.resolve_script("rollback_backend.sh", required=False)
+    rollback_frontend = ctx.resolve_script("rollback_frontend.sh", required=False)
+
+    items = [
+        "Staging: push to main to invoke deployment workflow (staging environment).",
+        f"Review staging outputs and run health verification (`python {health_check} --environment staging ...`).",
+        "Production: trigger promote workflow, ensure approvals granted, wait for verify and deploy jobs.",
+        "If failures occur, use rollback automation for backend/frontend as appropriate.",
+    ]
+    return ChecklistStage(title="Deploy & Promote", items=items)
+
+
+def observability_stage(ctx: PlannerContext) -> Optional[ChecklistStage]:
+    if ctx.config.get("deploy", ctx.spec.deploy) in {"n/a", "none", ""}:
+        return None
     staging_urls = {
         "frontend": "${vars.FRONTEND_URL_STAGING}",
         "api": "${vars.API_URL_STAGING}",
@@ -163,177 +408,134 @@ def main() -> int:
         "api": "${vars.API_URL_PRODUCTION}",
         "db": "${vars.DB_URL_PRODUCTION}",
     }
-
-    steps: List[Dict[str, List[str]]] = [
-        {
-            "title": "Environment & Inputs",
-            "items": [
-                "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
-                f"Confirm brief exists at {brief_path}.",
-                (
-                    "Verify workflow.config.json values "
-                    f"(industry={industry}, project_type={project_type}, frontend={frontend}, "
-                    f"backend={backend}, database={database}, auth={auth}, deploy={deploy}, compliance={compliance})."
-                ),
-                (
-                    "Export automation variables before running lifecycle: "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root}\n"
-                    "   Optional: AUTH, DEPLOY, COMPLIANCE, NESTJS_ORM, FORCE_OUTPUT=1."
-                ),
-            ],
-        },
-        {
-            "title": "Planning & Alignment",
-            "items": [
-                "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
-                f"Generate planning artifacts for reference (dry run here only): "
-                f"python scripts/plan_from_brief.py --brief '{brief_path}' --out '{project_dir}/PLAN.md'.",
-                f"Validate DAG topology prior to generation: python scripts/validate_tasks.py "
-                f"--input '{project_dir}/PLAN.tasks.json'.",
-                "Inspect PLAN.md lanes and resolve dependencies/blocked tasks before coding.",
-            ],
-        },
-        {
-            "title": "Stack Preflight & Generation Prep",
-            "items": [
-                "Tooling doctor & template discovery: python scripts/doctor.py --strict "
-                "&& ./scripts/generate_client_project.py --list-templates --name \"$NAME\" --industry \"$INDUSTRY\" --project-type \"$PROJECT_TYPE\".",
-                (
-                    "Preflight stack selection and capture evidence: "
-                    "python scripts/select_stacks.py "
-                    f"--industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"--output '{project_dir}/selection.json' --summary '{project_dir}/evidence/stack-selection.md' "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''}"
-                ),
-                "If select_stacks exits with code 3, resolve engine version mismatches before continuing.",
-                (
-                    "Preview scaffold (no writes): ./scripts/generate_client_project.py "
-                    "--dry-run --workers 8 --yes "
-                    f"--name '{name}' --industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"{'--auth ' + auth if auth != 'none' else ''} "
-                    f"{'--deploy ' + deploy if deploy != 'n/a' else ''} "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''} "
-                    f"--output-dir '{output_root}'"
-                ),
-            ],
-        },
-        {
-            "title": "Full Scaffold Generation & Bootstrap (queued automation)",
-            "items": [
-                (
-                    "When ready, run the one-shot generator (stops on any failure): "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root} make lifecycle"
-                ),
-                f"Inspect generated project at {project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
-                "Capture any generator logs or selection evidence for audit.",
-            ],
-        },
-        {
-            "title": "Frontend Implementation Sequence (execute in project workspace)",
-            "items": [
-                f"Work inside {project_dir}/frontend following tasks in order:"
-            ] + frontend_lane,
-        },
-        {
-            "title": "Backend & Data Implementation Sequence",
-            "items": [
-                f"Work inside {project_dir}/backend (and database/ if emitted) following tasks in order:"
-            ] + backend_lane,
-        },
-        {
-            "title": "Integration, Migrations, and Data Validation",
-            "items": [
-                "Create/adjust Alembic migrations, run `alembic upgrade head`, and reseed sample data (aligns with BE-SCH/BE-SEED/BE-MDL).",
-                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types with `npx openapi-typescript` as needed.",
-                "Update MSW/Prism mocks to match live responses (FE-MOCKS).",
-                "Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.",
-            ],
-        },
-        {
-            "title": "Quality Automation & Gates",
-            "items": [
-                "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
-                "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
-                (
-                    "Backend quality: `cd backend && black --check . && flake8` "
-                    "(Python) and/or ESLint for Node backends; run `mypy app` when mypy is enabled."
-                ),
-                "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
-                f"Aggregate stack-aware tests: `PROJECT_ROOT={project_dir} ./scripts/install_and_test.sh` (already done by lifecycle but rerun after local changes).",
-                f"Collect metrics: `PROJECT_ROOT={project_dir} python scripts/collect_coverage.py`, `collect_perf.py`, `scan_deps.py`.",
-                f"Enforce gates: `PROJECT_ROOT={project_dir} python scripts/enforce_gates.py` (blocks if thresholds in gates_config.yaml are missed).",
-            ],
-        },
-        {
-            "title": "Local Verification & Developer Experience",
-            "items": [
-                "Run dev servers for experiential QA: `cd frontend && npm run dev`; `cd backend && uvicorn app.main:app --reload` (or generated entrypoint).",
-                "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
-                f"Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist.",
-            ],
-        },
-        {
-            "title": "Compliance, Evidence, and Packaging",
-            "items": [
-                f"Package deliverables: `PROJECT_ROOT={project_dir} NAME={name} ./scripts/build_submission_pack.sh`.",
-                f"Validate compliance assets: `PROJECT_ROOT={project_dir} python scripts/validate_compliance_assets.py`.",
-                f"Optional doc scan: `PROJECT_ROOT={project_dir} python scripts/check_compliance_docs.py`.",
-                "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
-            ],
-        },
-        {
-            "title": "CI/CD Enablement",
-            "items": [
-                "Populate GitHub secrets/vars required by .github/workflows/ci-secrets-preflight.yml:",
-                "   secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ECS_EXECUTION_ROLE_ARN, AWS_ECS_TASK_ROLE_ARN.",
-                "   vars: AWS_REGION, APP_NAME, ECS_CLUSTER_NAME, ECS_SERVICE_NAME, ECS_DESIRED_COUNT, FRONTEND_URL_STAGING, API_URL_STAGING, DB_URL_STAGING, FRONTEND_URL_PRODUCTION, API_URL_PRODUCTION, DB_URL_PRODUCTION.",
-                "Enforce production environment protection/approvals in GitHub.",
-                "Trigger ci-secrets-preflight (push/pr/dispatch) and resolve any missing configuration.",
-                "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
-            ],
-        },
-        {
-            "title": "Deploy & Promote",
-            "items": [
-                "Staging: push to main to invoke .github/workflows/ci-deploy.yml (environment resolves to staging).",
-                "Review staging artifact outputs, ECS & Vercel deploys, and health verification (`python scripts/health/check_deployment.py --environment staging ...`).",
-                "Production: run GitHub Actions → “Promote to Production”, ensure approvals granted, wait for verify-and-gate + deploy-production jobs.",
-                f"Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
-                "If failures occur, use scripts/rollback_backend.sh and scripts/rollback_frontend.sh via the rollback job or manually.",
-            ],
-        },
-        {
-            "title": "Observability & Continuous Ops",
-            "items": [
-                "Schedule/monitor nightly-observability workflow; ensure staging/production URL vars stay current.",
-                f"Use `make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']}` for ad-hoc validation.",
-                f"Use `make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']}` post-promotion.",
-                "Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance.",
-            ],
-        },
-        {
-            "title": "Final Delivery & Retrospective",
-            "items": [
-                f"Hand off dist/{name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
-                f"Document residual risks or follow-ups in {project_dir}/reports/ or IMPLEMENTATION_SUMMARY.md.",
-                "Capture implementation retrospective and update workflow.config.json/workflow docs for future engagements.",
-            ],
-        },
-    ]
+    return ChecklistStage(
+        title="Observability & Continuous Ops",
+        items=[
+            "Schedule/monitor nightly observability workflows and ensure environment URLs stay current.",
+            f"Use `make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']}` for validation.",
+            f"Use `make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']}` post-promotion.",
+            "Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance.",
+        ],
+    )
 
 
+def retrospective_stage(ctx: PlannerContext) -> ChecklistStage:
+    return ChecklistStage(
+        title="Final Delivery & Retrospective",
+        items=[
+            f"Hand off dist/{ctx.name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
+            f"Document residual risks or follow-ups in {ctx.project_dir}/reports/ or IMPLEMENTATION_SUMMARY.md.",
+            "Capture implementation retrospective and update workflow.config.json/workflow docs for future engagements.",
+        ],
+    )
 
-    for step_idx, step in enumerate(steps, 1):
-        print(f"{step_idx}. {step['title']}")
-        for item_idx, item in enumerate(step["items"], 1):
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
+    ap.add_argument("--name", help="Client/project name override")
+    ap.add_argument("--config", default="workflow.config.json")
+    ap.add_argument("--output-root", default="../_generated")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    cfg_path = ROOT / args.config
+    if not cfg_path.exists():
+        print(f"[plan] config not found: {cfg_path}", file=sys.stderr)
+        return 2
+
+    config = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+    name = args.name or os.environ.get("NAME") or config.get("name")
+    if not name:
+        print(
+            "[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)",
+            file=sys.stderr,
+        )
+        return 2
+
+    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
+    if not brief_path.exists():
+        print(f"[plan] brief not found: {brief_path}", file=sys.stderr)
+        return 2
+
+    spec = BriefParser(str(brief_path)).parse()
+    script_resolver = ScriptResolver(ROOT / "scripts")
+
+    output_root = Path(args.output_root).resolve()
+    project_dir = (output_root / name).resolve()
+
+    ctx = PlannerContext(
+        name=name,
+        config=config,
+        spec=spec,
+        brief_path=brief_path,
+        output_root=output_root,
+        project_dir=project_dir,
+        script_resolver=script_resolver,
+    )
+
+    ctx.require_artifact(cfg_path, "workflow.config.json", required=True)
+    ctx.require_artifact(brief_path, "Project brief", required=True)
+
+    plan = build_plan(spec, config)
+    frontend_lane = format_lane(plan.get("frontend", []))
+    backend_lane = format_lane(plan.get("backend", []))
+
+    plan_md = project_dir / "PLAN.md"
+    plan_tasks = project_dir / "PLAN.tasks.json"
+
+    stages: List[ChecklistStage] = []
+    stages.append(environment_stage(ctx, cfg_path))
+    stages.append(planning_stage(ctx, plan_md, plan_tasks))
+    stages.append(stack_preflight_stage(ctx))
+    stages.append(generation_stage(ctx))
+
+    fe_stage = frontend_stage(ctx, frontend_lane)
+    if fe_stage:
+        stages.append(fe_stage)
+    be_stage = backend_stage(ctx, backend_lane)
+    if be_stage:
+        stages.append(be_stage)
+
+    integration = integration_stage(ctx)
+    if integration:
+        stages.append(integration)
+
+    stages.append(quality_stage(ctx))
+    stages.append(local_verification_stage(ctx))
+    stages.append(compliance_stage(ctx))
+
+    cicd = cicd_stage(ctx)
+    if cicd:
+        stages.append(cicd)
+    deploy = deploy_stage(ctx)
+    if deploy:
+        stages.append(deploy)
+    observability = observability_stage(ctx)
+    if observability:
+        stages.append(observability)
+
+    stages.append(retrospective_stage(ctx))
+
+    for step_idx, stage in enumerate(stages, 1):
+        print(f"{step_idx}. {stage.title}")
+        for item_idx, item in enumerate(stage.items, 1):
             print(f"   {step_idx}.{item_idx} {item}")
         print()
 
-    return 0
+    if ctx.validations:
+        print("Validation summary:")
+        for validation in ctx.validations:
+            prefix = validation.status.upper()
+            print(f" - [{prefix}] {validation.message}")
+
+    if ctx.exit_code:
+        print("[plan] Completed with blocking issues; address errors above.", file=sys.stderr)
+
+    return ctx.exit_code
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_pre_lifecycle_plan_script.py
+++ b/tests/integration/test_pre_lifecycle_plan_script.py
@@ -1,0 +1,101 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+
+
+def _write_brief(name: str, content: str) -> Path:
+    brief_dir = ROOT / "docs" / "briefs" / name
+    brief_dir.mkdir(parents=True, exist_ok=True)
+    brief_path = brief_dir / "brief.md"
+    brief_path.write_text(content, encoding="utf-8")
+    return brief_path
+
+
+@pytest.fixture
+def temp_config(tmp_path):
+    config_path = ROOT / "workflow.test.json"
+    yield config_path
+    if config_path.exists():
+        config_path.unlink()
+
+
+@pytest.fixture
+def cleanup_brief():
+    created = []
+
+    def _create(name: str, body: str) -> Path:
+        path = _write_brief(name, body)
+        created.append(path.parent)
+        return path
+
+    yield _create
+
+    for directory in created:
+        if directory.exists():
+            for child in directory.iterdir():
+                child.unlink()
+            directory.rmdir()
+
+
+def run_script(config_path: Path, name: str, output_root: Path) -> subprocess.CompletedProcess:
+    cmd = [
+        sys.executable,
+        str(SCRIPTS_DIR / "pre_lifecycle_plan.py"),
+        "--config",
+        config_path.name,
+        "--name",
+        name,
+        "--output-root",
+        str(output_root),
+    ]
+    return subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+
+
+def test_pre_lifecycle_skips_frontend_when_unset(temp_config, cleanup_brief, tmp_path):
+    brief_name = "tmp-preplan-backend"
+    cleanup_brief(brief_name, """---\nname: tmp-preplan-backend\nindustry: saas\nproject_type: api\nbackend: fastapi\ndatabase: postgres\n---\nAPI only.""")
+
+    config = {
+        "name": brief_name,
+        "industry": "saas",
+        "project_type": "api",
+        "backend": "fastapi",
+        "frontend": "none",
+        "database": "postgres",
+    }
+    temp_config.write_text(json.dumps(config), encoding="utf-8")
+
+    result = run_script(temp_config, brief_name, tmp_path / "_generated")
+
+    assert result.returncode == 0
+    assert "Backend & Data Implementation Sequence" in result.stdout
+    assert "Frontend Implementation Sequence" not in result.stdout
+
+
+def test_pre_lifecycle_hides_deploy_when_not_configured(temp_config, cleanup_brief, tmp_path):
+    brief_name = "tmp-preplan-nodeploy"
+    cleanup_brief(brief_name, """---\nname: tmp-preplan-nodeploy\nindustry: saas\nproject_type: fullstack\nfrontend: nextjs\nbackend: fastapi\ndatabase: postgres\n---\nFullstack.""")
+
+    config = {
+        "name": brief_name,
+        "industry": "saas",
+        "project_type": "fullstack",
+        "frontend": "nextjs",
+        "backend": "fastapi",
+        "database": "postgres",
+        "deploy": "n/a",
+    }
+    temp_config.write_text(json.dumps(config), encoding="utf-8")
+
+    result = run_script(temp_config, brief_name, tmp_path / "_generated")
+
+    assert result.returncode == 0
+    assert "Deploy & Promote" not in result.stdout
+    assert "Observability & Continuous Ops" not in result.stdout

--- a/tests/test_plan_from_brief_builder.py
+++ b/tests/test_plan_from_brief_builder.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+from project_generator.core.brief_parser import ScaffoldSpec
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN_SPEC = importlib.util.spec_from_file_location(
+    "_plan_from_brief_test", ROOT / "scripts" / "plan_from_brief.py"
+)
+assert PLAN_SPEC and PLAN_SPEC.loader
+PLAN_MODULE = importlib.util.module_from_spec(PLAN_SPEC)
+sys.modules[PLAN_SPEC.name] = PLAN_MODULE
+PLAN_SPEC.loader.exec_module(PLAN_MODULE)  # type: ignore[misc]
+build_plan = PLAN_MODULE.build_plan  # type: ignore[attr-defined]
+
+
+def test_build_plan_backend_only_features():
+    spec = ScaffoldSpec(
+        name="api-only",
+        industry="saas",
+        project_type="api",
+        frontend="none",
+        backend="fastapi",
+        database="postgres",
+        auth="auth0",
+        deploy="aws",
+        compliance=["hipaa"],
+        features=["audit logging", "usage reporting"],
+        separate_repos=True,
+    )
+
+    plan = build_plan(spec, {"compliance": ["soc2"]})
+
+    assert plan["frontend"] == []
+    backend_ids = {task["id"] for task in plan["backend"]}
+    assert "BE-AUTH" in backend_ids  # auth enabled for backend lane
+    assert any(task["id"].startswith("BE-COMP-") for task in plan["backend"])
+    assert any("audit logging" in task["title"].lower() for task in plan["backend"])
+
+
+def test_build_plan_fullstack_feature_distribution():
+    spec = ScaffoldSpec(
+        name="fullstack-app",
+        industry="ecommerce",
+        project_type="fullstack",
+        frontend="nextjs",
+        backend="fastapi",
+        database="postgres",
+        auth="auth0",
+        deploy="aws",
+        compliance=[],
+        features=["admin dashboard", "payment processing"],
+        separate_repos=True,
+    )
+
+    plan = build_plan(spec)
+
+    frontend_ids = {task["id"] for task in plan["frontend"]}
+    backend_ids = {task["id"] for task in plan["backend"]}
+
+    assert any(task_id.startswith("FE-FTR") for task_id in frontend_ids)
+    assert any(task_id.startswith("BE-FTR") for task_id in backend_ids)
+    assert any("dashboard" in task["title"].lower() for task in plan["frontend"])
+    assert any("payment" in task["title"].lower() for task in plan["backend"])


### PR DESCRIPTION
## Summary
- build plan_from_brief lanes dynamically using brief features, compliance, and workflow capability flags
- refactor pre_lifecycle_plan into stage-based, capability-aware checklist with artifact validation and script discovery
- add targeted tests covering adaptive lane generation and checklist gating logic

## Testing
- pytest tests/test_plan_from_brief_builder.py tests/integration/test_pre_lifecycle_plan_script.py


------
https://chatgpt.com/codex/tasks/task_e_68d49d47c2f4832e9d2c087c584ae10b