### PR TITLE
Refactor lifecycle planner for dynamic gating and validation

### DIFF
--- a/scripts/lifecycle_tasks.py
+++ b/scripts/lifecycle_tasks.py
@@ -1,0 +1,392 @@
+"""Utility helpers for lifecycle planning tasks.
+
+The previous implementation inside ``plan_from_brief`` and
+``pre_lifecycle_plan`` duplicated a static set of backend and frontend
+tasks.  This module centralises the logic and makes it data-driven so
+lane contents can adapt to the parsed brief and workflow configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+from project_generator.core.brief_parser import ScaffoldSpec
+
+
+@dataclass
+class Task:
+    """Serializable structure describing a work item in the plan."""
+
+    id: str
+    title: str
+    area: str
+    blocked_by: Sequence[str] = ()
+    labels: Sequence[str] = ()
+    estimate: str = "1d"
+    acceptance: Sequence[str] = ()
+    dod: Sequence[str] = ()
+
+    def as_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "area": self.area,
+            "estimate": self.estimate,
+            "blocked_by": list(self.blocked_by),
+            "labels": list(self.labels),
+            "acceptance": list(self.acceptance),
+            "dod": list(self.dod),
+            "state": "pending",
+        }
+
+
+def _requires_backend(spec: ScaffoldSpec) -> bool:
+    return spec.backend != "none"
+
+
+def _requires_frontend(spec: ScaffoldSpec) -> bool:
+    return spec.frontend != "none"
+
+
+def _requires_database(spec: ScaffoldSpec, cfg: Dict) -> bool:
+    db = cfg.get("database", spec.database)
+    return db not in {"", "none", None}
+
+
+def _requires_auth(spec: ScaffoldSpec, cfg: Dict) -> bool:
+    auth = cfg.get("auth", spec.auth)
+    return auth not in {"", "none", None}
+
+
+def _requires_compliance(spec: ScaffoldSpec, cfg: Dict) -> bool:
+    compliance = cfg.get("compliance", spec.compliance)
+    if isinstance(compliance, str):
+        compliance = [c.strip().lower() for c in compliance.split(",") if c.strip()]
+    return bool(compliance)
+
+
+def _features(spec: ScaffoldSpec, cfg: Dict) -> Iterable[str]:
+    raw = cfg.get("features") or spec.features
+    if isinstance(raw, str):
+        return [p.strip().lower() for p in raw.split(",") if p.strip()]
+    return [str(p).strip().lower() for p in raw]
+
+
+def _project_type(spec: ScaffoldSpec, cfg: Dict) -> str:
+    return (cfg.get("project_type") or spec.project_type or "fullstack").lower()
+
+
+def _normalise_capability(value) -> str:
+    if isinstance(value, str):
+        return value.lower()
+    return str(value).lower()
+
+
+def _task(*args, **kwargs) -> Task:
+    return Task(*args, **kwargs)
+
+
+def _backend_api_tasks(has_analytics: bool) -> List[Task]:
+    api_tasks = [
+        _task(
+            "BE-API-KPI",
+            "GET /api/v1/kpis",
+            "backend",
+            blocked_by=["BE-MDL"],
+            acceptance=["returns totals/deltas", "OpenAPI updated"],
+        ),
+        _task(
+            "BE-API-REV",
+            "GET /api/v1/revenue",
+            "backend",
+            blocked_by=["BE-MDL"],
+            acceptance=["time series ok", "OpenAPI updated"],
+        ),
+        _task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
+        _task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
+        _task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
+        _task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
+        _task(
+            "BE-EXP",
+            "GET /api/v1/export/csv",
+            "backend",
+            blocked_by=[
+                "BE-API-KPI",
+                "BE-API-REV",
+                "BE-API-CAT",
+                "BE-API-PLT",
+                "BE-API-CUS",
+                "BE-API-FDB",
+            ],
+        ),
+    ]
+    if has_analytics:
+        api_tasks.insert(
+            0,
+            _task(
+                "BE-ANALYTICS",
+                "Aggregate analytics pipelines",
+                "backend",
+                blocked_by=["BE-MDL"],
+                labels=["analytics"],
+                acceptance=["aggregations exposed", "metrics documented"],
+            ),
+        )
+    return api_tasks
+
+
+def _frontend_feature_tasks(features: Iterable[str]) -> List[Task]:
+    features = list(dict.fromkeys(features))  # stable unique order
+    tasks: List[Task] = []
+    feature_map = {
+        "realtime": _task(
+            "FE-REALTIME",
+            "Real-time data channel",
+            "frontend",
+            blocked_by=["FE-DSN"],
+            labels=["realtime"],
+            acceptance=["live updates", "fallback poll implemented"],
+        ),
+        "collaboration": _task(
+            "FE-COLLAB",
+            "Collaboration widgets",
+            "frontend",
+            blocked_by=["FE-DSN", "FE-MOCKS"],
+            acceptance=["status badges rendered", "activity feed updates"],
+        ),
+        "analytics": _task(
+            "FE-ANALYTICS",
+            "Analytics visualisations",
+            "frontend",
+            blocked_by=["FE-DSN", "FE-TYPES"],
+            acceptance=["charts responsive", "tooltips accessible"],
+        ),
+        "offline": _task(
+            "FE-OFFLINE",
+            "Offline caching strategy",
+            "frontend",
+            blocked_by=["FE-DSN"],
+            labels=["pwa"],
+            acceptance=["core routes cached", "sync strategy documented"],
+        ),
+    }
+    for feature in features:
+        if feature in feature_map:
+            tasks.append(feature_map[feature])
+    return tasks
+
+
+def build_plan(spec: ScaffoldSpec, workflow_config: Dict | None = None) -> Dict[str, List[Dict]]:
+    """Create backend/frontend lanes derived from the brief and config."""
+
+    cfg: Dict = workflow_config.copy() if workflow_config else {}
+    lanes: Dict[str, List[Task]] = {"backend": [], "frontend": []}
+
+    requires_backend = _requires_backend(spec)
+    requires_frontend = _requires_frontend(spec)
+    requires_db = _requires_database(spec, cfg)
+    requires_auth = _requires_auth(spec, cfg)
+    requires_compliance = _requires_compliance(spec, cfg)
+    project_type = _project_type(spec, cfg)
+    features = list(_features(spec, cfg))
+    has_analytics = any("analytics" in f for f in features)
+
+    if requires_backend:
+        backend_lane = lanes["backend"]
+        if requires_db:
+            backend_lane.extend(
+                [
+                    _task(
+                        "BE-SCH",
+                        "Design DB schema",
+                        "backend",
+                        acceptance=["ERD drafted", "tables defined", "naming conventions applied"],
+                    ),
+                    _task(
+                        "BE-SEED",
+                        "Seed loaders (CSV/mock)",
+                        "backend",
+                        blocked_by=["BE-SCH"],
+                        acceptance=["seed scripts run", "sample rows present"],
+                    ),
+                    _task(
+                        "BE-MDL",
+                        "Model domain aggregates",
+                        "backend",
+                        blocked_by=["BE-SEED"],
+                        acceptance=["views or services created", "query p95 < 400ms (seed)"],
+                    ),
+                ]
+            )
+        else:
+            backend_lane.append(
+                _task(
+                    "BE-DATA-CONTRACTS",
+                    "Define service/data contracts",
+                    "backend",
+                    acceptance=["pydantic/dto layer defined", "error schema documented"],
+                )
+            )
+
+        if project_type in {"api", "fullstack", "microservices"}:
+            backend_lane.extend(_backend_api_tasks(has_analytics))
+
+        if requires_auth:
+            backend_lane.append(
+                _task(
+                    "BE-AUTH",
+                    f"{_normalise_capability(cfg.get('auth', spec.auth)).upper()} integration",
+                    "backend",
+                    labels=["security"],
+                    acceptance=["role checks present", "token validation wired"],
+                )
+            )
+
+        backend_lane.append(
+            _task(
+                "BE-OBS",
+                "Structured logs + correlation IDs",
+                "backend",
+                labels=["observability"],
+                acceptance=["request id on logs"],
+            )
+        )
+
+        if "realtime" in features:
+            backend_lane.append(
+                _task(
+                    "BE-REALTIME",
+                    "Realtime channel / websocket broker",
+                    "backend",
+                    blocked_by=["BE-OBS"],
+                    acceptance=["pub/sub working", "fallback documented"],
+                )
+            )
+
+        if requires_compliance:
+            backend_lane.append(
+                _task(
+                    "BE-COMPLIANCE",
+                    "Compliance hardening & audit logging",
+                    "backend",
+                    labels=["compliance"],
+                    acceptance=[
+                        "audit logs persisted",
+                        "data retention documented",
+                        "access controls reviewed",
+                    ],
+                )
+            )
+
+        backend_lane.append(
+            _task(
+                "BE-TST",
+                "Unit + integration tests",
+                "backend",
+                blocked_by=[t.id for t in backend_lane if t.id.startswith("BE-API")][:2],
+                acceptance=["pytest green", ">= minimal coverage"],
+            )
+        )
+
+    if requires_frontend:
+        frontend_lane = lanes["frontend"]
+        frontend_lane.extend(
+            [
+                _task(
+                    "FE-DSN",
+                    "Shell/Layout/Routes",
+                    "frontend",
+                    acceptance=["routes wired", "base theme applied"],
+                ),
+                _task(
+                    "FE-TYPES",
+                    "Typed API client",
+                    "frontend",
+                    blocked_by=["FE-DSN"],
+                    acceptance=["types generated", "client builds"],
+                ),
+                _task(
+                    "FE-MOCKS",
+                    "MSW/Prism mocks",
+                    "frontend",
+                    acceptance=["mocks respond", "dev proxy configured"],
+                ),
+            ]
+        )
+
+        frontend_lane.extend(
+            [
+                _task(
+                    "FE-KPI",
+                    "KPI cards + filters",
+                    "frontend",
+                    blocked_by=["FE-DSN", "FE-TYPES"],
+                    acceptance=["renders", "no console errors"],
+                ),
+                _task(
+                    "FE-REV",
+                    "Revenue or trend chart",
+                    "frontend",
+                    blocked_by=["FE-DSN", "FE-TYPES"],
+                    acceptance=["renders", "no console errors"],
+                ),
+                _task("FE-PLT", "Segment distribution", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
+                _task("FE-CAT", "Category ranks", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
+                _task("FE-CUS", "Customer insights", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
+                _task(
+                    "FE-FDB",
+                    "Feedback or activity timeline",
+                    "frontend",
+                    blocked_by=["FE-DSN", "FE-TYPES"],
+                ),
+                _task(
+                    "FE-EXP",
+                    "Exports (CSV/PNG)",
+                    "frontend",
+                    blocked_by=[
+                        "FE-KPI",
+                        "FE-REV",
+                        "FE-PLT",
+                        "FE-CAT",
+                        "FE-CUS",
+                        "FE-FDB",
+                    ],
+                    acceptance=["Exports working"],
+                ),
+            ]
+        )
+
+        frontend_lane.extend(_frontend_feature_tasks(features))
+
+        if requires_compliance:
+            frontend_lane.append(
+                _task(
+                    "FE-COMPLIANCE",
+                    "Accessibility + compliance evidence",
+                    "frontend",
+                    labels=["compliance"],
+                    acceptance=["WCAG AA", "policies documented"],
+                )
+            )
+
+        frontend_lane.append(
+            _task(
+                "FE-A11Y-PERF",
+                "WCAG + performance tuning",
+                "frontend",
+                labels=["a11y", "performance"],
+            )
+        )
+        frontend_lane.append(
+            _task(
+                "FE-TST",
+                "Component + E2E smoke",
+                "frontend",
+                blocked_by=["FE-KPI", "FE-REV"],
+                acceptance=["tests green"],
+            )
+        )
+
+    return {lane: [task.as_dict() for task in tasks] for lane, tasks in lanes.items()}
+

--- a/scripts/plan_from_brief.py
+++ b/scripts/plan_from_brief.py
@@ -10,7 +10,15 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from project_generator.core.brief_parser import BriefParser
+
+from scripts.lifecycle_tasks import build_plan
 
 
 def parse_args() -> argparse.Namespace:
@@ -18,203 +26,6 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--brief", required=True, help="Path to brief.md")
     p.add_argument("--out", default="PLAN.md", help="Path to write PLAN.md (tasks.json will be co-located)")
     return p.parse_args()
-
-
-def task(
-    id_: str,
-    title: str,
-    area: str,
-    blocked_by: List[str] | None = None,
-    labels: List[str] | None = None,
-    estimate: str = "1d",
-    acceptance: List[str] | None = None,
-    dod: List[str] | None = None,
-) -> Dict:
-    return {
-        "id": id_,
-        "title": title,
-        "area": area,
-        "estimate": estimate,
-        "blocked_by": blocked_by or [],
-        "labels": labels or [],
-        "acceptance": acceptance or [],
-        "dod": dod or [],
-        "state": "pending",
-    }
-
-
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    be: List[Dict] = []
-    fe: List[Dict] = []
-
-    # Backend lane
-    be.append(
-        task(
-            "BE-SCH",
-            "Design DB schema",
-            "backend",
-            acceptance=["ERD drafted", "tables defined", "naming conventions applied"],
-        )
-    )
-    be.append(
-        task(
-            "BE-SEED",
-            "Seed loaders (CSV/mock)",
-            "backend",
-            blocked_by=["BE-SCH"],
-            acceptance=["seed scripts run", "sample rows present"],
-        )
-    )
-    be.append(
-        task(
-            "BE-MDL",
-            "Aggregates/MatViews (funnel, revenue, etc.)",
-            "backend",
-            blocked_by=["BE-SEED"],
-            acceptance=["views created", "query p95 < 400ms (seed)"],
-        )
-    )
-    be += [
-        task(
-            "BE-API-KPI",
-            "GET /api/v1/kpis",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["returns totals/deltas", "OpenAPI updated"],
-        ),
-        task(
-            "BE-API-REV",
-            "GET /api/v1/revenue",
-            "backend",
-            blocked_by=["BE-MDL"],
-            acceptance=["time series ok", "OpenAPI updated"],
-        ),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task(
-            "BE-EXP",
-            "GET /api/v1/export/csv",
-            "backend",
-            blocked_by=[
-                "BE-API-KPI",
-                "BE-API-REV",
-                "BE-API-CAT",
-                "BE-API-PLT",
-                "BE-API-CUS",
-                "BE-API-FDB",
-            ],
-        ),
-    ]
-    be.append(
-        task(
-            "BE-AUTH",
-            "Auth0/RBAC skeleton",
-            "backend",
-            labels=["security"],
-            acceptance=["role checks present"],
-        )
-    )
-    be.append(
-        task(
-            "BE-OBS",
-            "Structured logs + correlation IDs",
-            "backend",
-            labels=["observability"],
-            acceptance=["request id on logs"],
-        )
-    )
-    be.append(
-        task(
-            "BE-TST",
-            "Unit+Integration tests (Testcontainers)",
-            "backend",
-            blocked_by=["BE-API-KPI", "BE-API-REV"],
-            acceptance=["pytest green", ">= minimal coverage"],
-        )
-    )
-
-    # Frontend lane
-    fe.append(
-        task(
-            "FE-DSN",
-            "Shell/Layout/Routes",
-            "frontend",
-            acceptance=["routes wired", "base theme applied"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-TYPES",
-            "openapi-typescript client",
-            "frontend",
-            acceptance=["types.ts generated", "typed client compiles"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-MOCKS",
-            "MSW/Prism mocks",
-            "frontend",
-            acceptance=["mocks respond", "dev proxy configured"],
-        )
-    )
-    fe += [
-        task(
-            "FE-KPI",
-            "KPI cards + filters",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
-        ),
-        task(
-            "FE-REV",
-            "Revenue chart + range selectors",
-            "frontend",
-            blocked_by=["FE-DSN", "FE-TYPES"],
-            acceptance=["renders", "no console errors"],
-        ),
-        task("FE-PLT", "Platform distribution (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend", blocked_by=["FE-DSN", "FE-TYPES"]),
-        task(
-            "FE-EXP",
-            "Exports (CSV/PNG)",
-            "frontend",
-            blocked_by=[
-                "FE-KPI",
-                "FE-REV",
-                "FE-PLT",
-                "FE-CAT",
-                "FE-CUS",
-                "FE-FDB",
-            ],
-            acceptance=["CSV downloads"],
-        ),
-    ]
-    fe.append(
-        task(
-            "FE-A11Y-PERF",
-            "WCAG AA + code-split/memoize",
-            "frontend",
-            labels=["a11y", "performance"],
-        )
-    )
-    fe.append(
-        task(
-            "FE-TST",
-            "Component + E2E smoke",
-            "frontend",
-            blocked_by=["FE-KPI", "FE-REV"],
-            acceptance=["tests green"],
-        )
-    )
-
-    return {"backend": be, "frontend": fe}
-
-
 def render_plan_md(spec, plan: Dict[str, List[Dict]]) -> str:
     lines: List[str] = []
     lines.append(f"# PLAN — {spec.name}\n")

--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -1,158 +1,535 @@
 #!/usr/bin/env python3
-"""
-Pre-lifecycle roadmap generator.
-
-Reads workflow.config.json (or overrides) and the corresponding docs/briefs/<NAME>/brief.md,
-recreates the ordered task lanes, then prints a sequential, human-readable checklist that
-extends the lifecycle automation with the manual quality, deploy, and observability work.
-"""
+"""Pre-lifecycle roadmap generator with dynamic gating and validation."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-from project_generator.core.brief_parser import BriefParser  # type: ignore[misc]
+from project_generator.core.brief_parser import BriefParser, ScaffoldSpec  # type: ignore[misc]
 
-
-def build_plan(spec) -> Dict[str, List[Dict]]:
-    """Replica of scripts/plan_from_brief.build_plan to reuse lane ordering."""
-    def task(id_, title, area, blocked_by=None, labels=None, estimate="1d",
-             acceptance=None, dod=None):
-        return {
-            "id": id_,
-            "title": title,
-            "area": area,
-            "estimate": estimate,
-            "blocked_by": blocked_by or [],
-            "labels": labels or [],
-            "acceptance": acceptance or [],
-            "dod": dod or [],
-            "state": "pending",
-        }
-
-    be: List[Dict] = []
-    fe: List[Dict] = []
-
-    be.append(task("BE-SCH", "Design DB schema", "backend",
-                   acceptance=["ERD drafted", "tables defined", "naming conventions applied"]))
-    be.append(task("BE-SEED", "Seed loaders (CSV/mock)", "backend", blocked_by=["BE-SCH"],
-                   acceptance=["seed scripts run", "sample rows present"]))
-    be.append(task("BE-MDL", "Aggregates/MatViews (funnel, revenue, etc.)", "backend",
-                   blocked_by=["BE-SEED"],
-                   acceptance=["views created", "query p95 < 400ms (seed)"]))
-    be += [
-        task("BE-API-KPI", "GET /api/v1/kpis", "backend", blocked_by=["BE-MDL"],
-             acceptance=["returns totals/deltas", "OpenAPI updated"]),
-        task("BE-API-REV", "GET /api/v1/revenue", "backend", blocked_by=["BE-MDL"],
-             acceptance=["time series ok", "OpenAPI updated"]),
-        task("BE-API-CAT", "GET /api/v1/categories", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-PLT", "GET /api/v1/platforms", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-CUS", "GET /api/v1/customers/insights", "backend", blocked_by=["BE-MDL"]),
-        task("BE-API-FDB", "GET /api/v1/feedback", "backend", blocked_by=["BE-MDL"]),
-        task("BE-EXP", "GET /api/v1/export/csv", "backend",
-             blocked_by=["BE-API-KPI", "BE-API-REV", "BE-API-CAT",
-                         "BE-API-PLT", "BE-API-CUS", "BE-API-FDB"]),
-    ]
-    be.append(task("BE-AUTH", "Auth0/RBAC skeleton", "backend",
-                   labels=["security"], acceptance=["role checks present"]))
-    be.append(task("BE-OBS", "Structured logs + correlation IDs", "backend",
-                   labels=["observability"], acceptance=["request id on logs"]))
-    be.append(task("BE-TST", "Unit+Integration tests (Testcontainers)", "backend",
-                   blocked_by=["BE-API-KPI", "BE-API-REV"],
-                   acceptance=["pytest green", ">= minimal coverage"]))
-
-    fe.append(task("FE-DSN", "Shell/Layout/Routes", "frontend",
-                   acceptance=["routes wired", "base theme applied"]))
-    fe.append(task("FE-TYPES", "openapi-typescript client", "frontend",
-                   acceptance=["types.ts generated", "typed client compiles"]))
-    fe.append(task("FE-MOCKS", "MSW/Prism mocks", "frontend",
-                   acceptance=["mocks respond", "dev proxy configured"]))
-    fe += [
-        task("FE-KPI", "KPI cards + filters", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-REV", "Revenue chart + range selectors", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"], acceptance=["renders", "no console errors"]),
-        task("FE-PLT", "Platform distribution (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CAT", "Category ranks (bars)", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-CUS", "Customer insights panel", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-FDB", "Feedback timeline", "frontend",
-             blocked_by=["FE-DSN", "FE-TYPES"]),
-        task("FE-EXP", "Exports (CSV/PNG)", "frontend",
-             blocked_by=["FE-KPI", "FE-REV", "FE-PLT", "FE-CAT", "FE-CUS", "FE-FDB"],
-             acceptance=["CSV downloads"]),
-    ]
-    fe.append(task("FE-A11Y-PERF", "WCAG AA + code-split/memoize", "frontend",
-                   labels=["a11y", "performance"]))
-    fe.append(task("FE-TST", "Component + E2E smoke", "frontend",
-                   blocked_by=["FE-KPI", "FE-REV"], acceptance=["tests green"]))
-
-    return {"backend": be, "frontend": fe}
+from scripts.lifecycle_tasks import build_plan
 
 
-def format_lane(lane: List[Dict]) -> List[str]:
-    entries = []
-    for idx, t in enumerate(lane, 1):
-        blockers = ", ".join(t["blocked_by"]) if t["blocked_by"] else "none"
-        acceptance = ", ".join(t["acceptance"]) if t["acceptance"] else "see acceptance criteria"
-        entries.append(
-            f"{t['id']}: {t['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
-        )
-    return entries
+# ---------------------------------------------------------------------------
+# Dataclasses and helpers
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
-    ap.add_argument("--name", help="Client/project name override")
-    ap.add_argument("--config", default="workflow.config.json")
-    ap.add_argument("--output-root", default="../_generated")
-    args = ap.parse_args()
+Status = str
 
-    cfg_path = ROOT / args.config
-    if not cfg_path.exists():
-        print(f"[plan] config not found: {cfg_path}", file=sys.stderr)
-        return 2
 
-    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+@dataclass
+class PlanContext:
+    name: str
+    config: Dict
+    spec: ScaffoldSpec
+    brief_path: Path
+    output_root: Path
+    project_dir: Path
+    root: Path = ROOT
 
-    name = args.name or os.environ.get("NAME") or cfg.get("name")
-    if not name:
-        print("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)", file=sys.stderr)
-        return 2
+    def script_path(self, *parts: str) -> Path:
+        return self.root / "scripts" / Path(*parts)
 
-    industry = cfg.get("industry", "<unspecified>")
-    project_type = cfg.get("project_type", "<unspecified>")
-    frontend = cfg.get("frontend", "<unspecified>")
-    backend = cfg.get("backend", "<unspecified>")
-    database = cfg.get("database", "<unspecified>")
-    auth = cfg.get("auth") or "none"
-    deploy = cfg.get("deploy") or "n/a"
-    compliance = cfg.get("compliance") or "none"
+    def display_path(self, path: Path) -> str:
+        try:
+            return str(path.relative_to(self.root))
+        except ValueError:
+            return str(path)
 
-    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
-    if not brief_path.exists():
-        print(f"[plan] brief not found: {brief_path}", file=sys.stderr)
-        return 2
+    # Capability flags -----------------------------------------------------
+    @property
+    def has_frontend(self) -> bool:
+        return (self.config.get("frontend") or self.spec.frontend) not in {None, "", "none"}
 
-    spec = BriefParser(str(brief_path)).parse()
-    lanes = build_plan(spec)
+    @property
+    def has_backend(self) -> bool:
+        return (self.config.get("backend") or self.spec.backend) not in {None, "", "none"}
 
-    output_root = Path(args.output_root)
-    project_dir = (output_root / name).resolve()
+    @property
+    def has_database(self) -> bool:
+        return (self.config.get("database") or self.spec.database) not in {None, "", "none"}
 
-    frontend_lane = format_lane(lanes["frontend"])
-    backend_lane = format_lane(lanes["backend"])
+    @property
+    def requires_auth(self) -> bool:
+        return (self.config.get("auth") or self.spec.auth) not in {None, "", "none"}
 
+    @property
+    def compliance_labels(self) -> List[str]:
+        compliance = self.config.get("compliance", self.spec.compliance)
+        if isinstance(compliance, str):
+            return [c.strip().lower() for c in compliance.split(",") if c.strip()]
+        return [str(c).strip().lower() for c in compliance or []]
+
+    @property
+    def requires_compliance(self) -> bool:
+        return bool(self.compliance_labels)
+
+    @property
+    def deploy_target(self) -> str:
+        deploy = self.config.get("deploy", self.spec.deploy)
+        if isinstance(deploy, str):
+            return deploy.lower()
+        return str(deploy).lower()
+
+    @property
+    def requires_deploy(self) -> bool:
+        return self.deploy_target not in {"", "n/a", "none"}
+
+
+ArtifactProvider = Callable[[PlanContext], Path]
+Condition = Callable[[PlanContext], bool]
+
+
+@dataclass
+class PlanItem:
+    description: str
+    command: Optional[str] = None
+    artifacts: Sequence[ArtifactProvider] = ()
+    condition: Optional[Condition] = None
+
+    def is_active(self, ctx: PlanContext) -> bool:
+        return self.condition(ctx) if self.condition else True
+
+    def evaluate(self, ctx: PlanContext, execute: bool) -> Tuple[Status, str]:
+        missing: List[Path] = []
+        for artifact_fn in self.artifacts:
+            path = artifact_fn(ctx)
+            if not path.exists():
+                missing.append(path)
+
+        if missing:
+            missing_paths = ", ".join(ctx.display_path(p) for p in missing)
+            return "error", f"{self.description} [missing: {missing_paths}]"
+
+        if execute and self.command:
+            proc = subprocess.run(self.command, shell=True, cwd=ctx.root)
+            status: Status = "ok" if proc.returncode == 0 else "error"
+            detail = "succeeded" if status == "ok" else f"failed (exit {proc.returncode})"
+            return status, f"{self.description} [command {detail}]"
+
+        if self.command:
+            return "pending", f"{self.description}"
+
+        return "info", self.description
+
+
+@dataclass
+class PlanStep:
+    title: str
+    items: List[PlanItem]
+    condition: Optional[Condition] = None
+
+    def is_active(self, ctx: PlanContext) -> bool:
+        return self.condition(ctx) if self.condition else True
+
+
+def _artifact(path: Path) -> ArtifactProvider:
+    return lambda ctx, p=path: p
+
+
+# ---------------------------------------------------------------------------
+# Stage builders
+
+
+def environment_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="Environment & Inputs",
+        items=[
+            PlanItem(
+                "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
+            ),
+            PlanItem(
+                f"Confirm brief exists at {ctx.display_path(ctx.brief_path)}.",
+                artifacts=[_artifact(ctx.brief_path)],
+            ),
+            PlanItem(
+                "Verify workflow.config.json values "
+                f"(industry={ctx.config.get('industry', ctx.spec.industry)}, "
+                f"project_type={ctx.config.get('project_type', ctx.spec.project_type)}, "
+                f"frontend={ctx.config.get('frontend', ctx.spec.frontend)}, "
+                f"backend={ctx.config.get('backend', ctx.spec.backend)}, "
+                f"database={ctx.config.get('database', ctx.spec.database)}, "
+                f"auth={ctx.config.get('auth', ctx.spec.auth)}, "
+                f"deploy={ctx.config.get('deploy', ctx.spec.deploy)}, "
+                f"compliance={ctx.config.get('compliance', ctx.spec.compliance)}).",
+            ),
+            PlanItem(
+                "Export automation variables before running lifecycle: "
+                f"NAME={ctx.name} INDUSTRY={ctx.spec.industry} PROJECT_TYPE={ctx.spec.project_type} "
+                f"FE={ctx.spec.frontend} BE={ctx.spec.backend} DB={ctx.spec.database} OUTPUT_ROOT={ctx.output_root} "
+                "Optional: AUTH, DEPLOY, COMPLIANCE, NESTJS_ORM, FORCE_OUTPUT=1.",
+            ),
+        ],
+    )
+
+
+def planning_stage(ctx: PlanContext) -> PlanStep:
+    plan_script = ctx.script_path("plan_from_brief.py")
+    validator_script = ctx.script_path("validate_tasks.py")
+    return PlanStep(
+        title="Planning & Alignment",
+        items=[
+            PlanItem(
+                "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
+            ),
+            PlanItem(
+                "Generate planning artifacts (dry run ok here): "
+                f"python {ctx.display_path(plan_script)} --brief '{ctx.display_path(ctx.brief_path)}' "
+                f"--out '{ctx.display_path(ctx.project_dir / 'PLAN.md')}'.",
+                command=(
+                    f"python {ctx.display_path(plan_script)} --brief '{ctx.brief_path}' "
+                    f"--out '{ctx.project_dir / 'PLAN.md'}'"
+                ),
+                artifacts=[_artifact(plan_script)],
+            ),
+            PlanItem(
+                "Validate DAG topology prior to generation:",
+                command=(
+                    f"python {ctx.display_path(validator_script)} --input "
+                    f"'{ctx.project_dir / 'PLAN.tasks.json'}'"
+                ),
+                artifacts=[_artifact(validator_script)],
+            ),
+            PlanItem(
+                "Inspect PLAN.md lanes and resolve dependencies/blocked tasks before coding.",
+            ),
+        ],
+    )
+
+
+def stack_preflight_stage(ctx: PlanContext) -> PlanStep:
+    doctor_script = ctx.script_path("doctor.py")
+    generator_script = ctx.script_path("generate_client_project.py")
+    selector_script = ctx.script_path("select_stacks.py")
+    compliance_flag = ctx.config.get("compliance") or ""
+    auth_flag = ctx.config.get("auth") or ctx.spec.auth
+    deploy_flag = ctx.config.get("deploy") or ctx.spec.deploy
+    return PlanStep(
+        title="Stack Preflight & Generation Prep",
+        items=[
+            PlanItem(
+                "Tooling doctor & template discovery: "
+                f"python {ctx.display_path(doctor_script)} --strict && "
+                f"./{ctx.display_path(generator_script)} --list-templates --name \"$NAME\" "
+                "--industry \"$INDUSTRY\" --project-type \"$PROJECT_TYPE\".",
+                command=(
+                    f"python {doctor_script} --strict && "
+                    f"{generator_script} --list-templates --name '{ctx.name}' "
+                    f"--industry '{ctx.spec.industry}' --project-type '{ctx.spec.project_type}'"
+                ),
+                artifacts=[_artifact(doctor_script), _artifact(generator_script)],
+            ),
+            PlanItem(
+                "Preflight stack selection and capture evidence: "
+                f"python {ctx.display_path(selector_script)} --industry '{ctx.spec.industry}' "
+                f"--project-type '{ctx.spec.project_type}' --frontend '{ctx.spec.frontend}' "
+                f"--backend '{ctx.spec.backend}' --database '{ctx.spec.database}' "
+                f"--output '{ctx.display_path(ctx.project_dir / 'selection.json')}' "
+                f"--summary '{ctx.display_path(ctx.project_dir / 'evidence' / 'stack-selection.md')}' "
+                f"{('--compliance ' + compliance_flag) if compliance_flag else ''}".strip(),
+                command=(
+                    f"python {selector_script} --industry '{ctx.spec.industry}' "
+                    f"--project-type '{ctx.spec.project_type}' --frontend '{ctx.spec.frontend}' "
+                    f"--backend '{ctx.spec.backend}' --database '{ctx.spec.database}' "
+                    f"--output '{ctx.project_dir / 'selection.json'}' "
+                    f"--summary '{ctx.project_dir / 'evidence' / 'stack-selection.md'}' "
+                    f"{('--compliance ' + compliance_flag) if compliance_flag else ''}".strip()
+                ),
+                artifacts=[_artifact(selector_script)],
+            ),
+            PlanItem(
+                "If select_stacks exits with code 3, resolve engine version mismatches before continuing.",
+            ),
+            PlanItem(
+                "Preview scaffold (no writes): "
+                f"./{ctx.display_path(generator_script)} --dry-run --workers 8 --yes --name '{ctx.name}' "
+                f"--industry '{ctx.spec.industry}' --project-type '{ctx.spec.project_type}' "
+                f"--frontend '{ctx.spec.frontend}' --backend '{ctx.spec.backend}' --database '{ctx.spec.database}' "
+                f"{('--auth ' + auth_flag) if ctx.requires_auth else ''} "
+                f"{('--deploy ' + deploy_flag) if ctx.requires_deploy else ''} "
+                f"{('--compliance ' + compliance_flag) if ctx.requires_compliance else ''} "
+                f"--output-dir '{ctx.output_root}'",
+                command=(
+                    f"{generator_script} --dry-run --workers 8 --yes --name '{ctx.name}' "
+                    f"--industry '{ctx.spec.industry}' --project-type '{ctx.spec.project_type}' "
+                    f"--frontend '{ctx.spec.frontend}' --backend '{ctx.spec.backend}' --database '{ctx.spec.database}' "
+                    f"{('--auth ' + auth_flag) if ctx.requires_auth else ''} "
+                    f"{('--deploy ' + deploy_flag) if ctx.requires_deploy else ''} "
+                    f"{('--compliance ' + compliance_flag) if ctx.requires_compliance else ''} "
+                    f"--output-dir '{ctx.output_root}'"
+                ),
+                artifacts=[_artifact(generator_script)],
+            ),
+        ],
+    )
+
+
+def generation_stage(ctx: PlanContext) -> PlanStep:
+    generator_script = ctx.script_path("generate_client_project.py")
+    return PlanStep(
+        title="Full Scaffold Generation & Bootstrap (queued automation)",
+        items=[
+            PlanItem(
+                "When ready, run the one-shot generator (stops on any failure): "
+                f"NAME={ctx.name} INDUSTRY={ctx.spec.industry} PROJECT_TYPE={ctx.spec.project_type} "
+                f"FE={ctx.spec.frontend} BE={ctx.spec.backend} DB={ctx.spec.database} OUTPUT_ROOT={ctx.output_root} make lifecycle",
+            ),
+            PlanItem(
+                f"Inspect generated project at {ctx.display_path(ctx.project_dir)}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
+            ),
+            PlanItem(
+                "Capture any generator logs or selection evidence for audit.",
+            ),
+            PlanItem(
+                "Validate that scaffold output exists before continuing.",
+                artifacts=[_artifact(ctx.project_dir)],
+            ),
+        ],
+    )
+
+
+def artifact_validation_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="Generated Artifact Verification",
+        items=[
+            PlanItem(
+                "Ensure PLAN.md and PLAN.tasks.json exist in the generated project.",
+                artifacts=[
+                    _artifact(ctx.project_dir / "PLAN.md"),
+                    _artifact(ctx.project_dir / "PLAN.tasks.json"),
+                ],
+            ),
+            PlanItem(
+                "Ensure evidence/stack-selection.md is captured for compliance traceability.",
+                artifacts=[_artifact(ctx.project_dir / "evidence" / "stack-selection.md")],
+            ),
+            PlanItem(
+                "Confirm dist/ and reports/ directories were emitted by the lifecycle generator.",
+                artifacts=[
+                    _artifact(ctx.project_dir / "dist"),
+                    _artifact(ctx.project_dir / "reports"),
+                ],
+            ),
+        ],
+        condition=lambda c: c.project_dir.exists(),
+    )
+
+
+def frontend_stage(ctx: PlanContext, frontend_lane: Iterable[str]) -> PlanStep:
+    return PlanStep(
+        title="Frontend Implementation Sequence (execute in project workspace)",
+        items=[
+            PlanItem(
+                f"Work inside {ctx.display_path(ctx.project_dir / 'frontend')} following tasks in order:",
+            ),
+            *[PlanItem(task) for task in frontend_lane],
+        ],
+        condition=lambda c: c.has_frontend,
+    )
+
+
+def backend_stage(ctx: PlanContext, backend_lane: Iterable[str]) -> PlanStep:
+    return PlanStep(
+        title="Backend & Data Implementation Sequence",
+        items=[
+            PlanItem(
+                f"Work inside {ctx.display_path(ctx.project_dir / 'backend')} (and database/ if emitted) following tasks in order:",
+            ),
+            *[PlanItem(task) for task in backend_lane],
+        ],
+        condition=lambda c: c.has_backend,
+    )
+
+
+def integration_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="Integration, Migrations, and Data Validation",
+        items=[
+            PlanItem(
+                "Create/adjust migrations, run upgrades, and reseed sample data (aligns with BE-SCH/BE-SEED/BE-MDL).",
+                condition=lambda c: c.has_database,
+            ),
+            PlanItem(
+                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types as needed.",
+                condition=lambda c: c.has_backend or c.has_frontend,
+            ),
+            PlanItem(
+                "Update MSW/Prism mocks to match live responses (FE-MOCKS).",
+                condition=lambda c: c.has_frontend,
+            ),
+            PlanItem(
+                "Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.",
+            ),
+        ],
+        condition=lambda c: c.has_backend or c.has_frontend,
+    )
+
+
+def quality_stage(ctx: PlanContext) -> PlanStep:
+    install_script = ctx.script_path("install_and_test.sh")
+    collect_script = ctx.script_path("collect_coverage.py")
+    enforce_script = ctx.script_path("enforce_gates.py")
+    return PlanStep(
+        title="Quality Automation & Gates",
+        items=[
+            PlanItem(
+                "Frontend lint & formatting: cd frontend && npm run lint && npx prettier --check 'src/**/*.{ts,tsx,js,jsx,css,scss}'.",
+                condition=lambda c: c.has_frontend,
+            ),
+            PlanItem(
+                "Frontend type check & unit tests: cd frontend && npx tsc --noEmit && npm test -- --ci --coverage.",
+                condition=lambda c: c.has_frontend,
+            ),
+            PlanItem(
+                "Backend quality: cd backend && black --check . && flake8 (Python) and/or ESLint for Node backends; run mypy when enabled.",
+                condition=lambda c: c.has_backend,
+            ),
+            PlanItem(
+                "Backend tests & coverage: cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml.",
+                condition=lambda c: c.has_backend,
+            ),
+            PlanItem(
+                f"Aggregate stack-aware tests: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} {ctx.display_path(install_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} {install_script}",
+                artifacts=[_artifact(install_script)],
+            ),
+            PlanItem(
+                f"Collect metrics: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} python {ctx.display_path(collect_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} python {collect_script}",
+                artifacts=[_artifact(collect_script)],
+            ),
+            PlanItem(
+                f"Enforce gates: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} python {ctx.display_path(enforce_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} python {enforce_script}",
+                artifacts=[_artifact(enforce_script)],
+            ),
+        ],
+    )
+
+
+def developer_experience_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="Local Verification & Developer Experience",
+        items=[
+            PlanItem(
+                "Run dev servers for experiential QA: cd frontend && npm run dev; cd backend && uvicorn app.main:app --reload (or generated entrypoint).",
+                condition=lambda c: c.has_frontend or c.has_backend,
+            ),
+            PlanItem(
+                "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
+            ),
+            PlanItem(
+                "Run make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db once health endpoints exist.",
+                condition=lambda c: c.has_frontend or c.has_backend,
+            ),
+        ],
+    )
+
+
+def compliance_stage(ctx: PlanContext) -> PlanStep:
+    package_script = ctx.script_path("build_submission_pack.sh")
+    validate_script = ctx.script_path("validate_compliance_assets.py")
+    doc_scan_script = ctx.script_path("check_compliance_docs.py")
+    return PlanStep(
+        title="Compliance, Evidence, and Packaging",
+        items=[
+            PlanItem(
+                f"Package deliverables: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} NAME={ctx.name} {ctx.display_path(package_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} NAME={ctx.name} {package_script}",
+                artifacts=[_artifact(package_script)],
+            ),
+            PlanItem(
+                f"Validate compliance assets: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} python {ctx.display_path(validate_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} python {validate_script}",
+                artifacts=[_artifact(validate_script)],
+            ),
+            PlanItem(
+                f"Optional doc scan: PROJECT_ROOT={ctx.display_path(ctx.project_dir)} python {ctx.display_path(doc_scan_script)}",
+                command=f"PROJECT_ROOT={ctx.project_dir} python {doc_scan_script}",
+                artifacts=[_artifact(doc_scan_script)],
+            ),
+            PlanItem(
+                "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
+            ),
+        ],
+        condition=lambda c: c.requires_compliance,
+    )
+
+
+def cicd_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="CI/CD Enablement",
+        items=[
+            PlanItem(
+                "Populate GitHub secrets/vars required by .github/workflows/ci-secrets-preflight.yml:",
+            ),
+            PlanItem(
+                "   secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ECS_EXECUTION_ROLE_ARN, AWS_ECS_TASK_ROLE_ARN.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
+                "   vars: AWS_REGION, APP_NAME, ECS_CLUSTER_NAME, ECS_SERVICE_NAME, ECS_DESIRED_COUNT, FRONTEND_URL_STAGING, API_URL_STAGING, DB_URL_STAGING, FRONTEND_URL_PRODUCTION, API_URL_PRODUCTION, DB_URL_PRODUCTION.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
+                "Enforce production environment protection/approvals in GitHub.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
+                "Trigger ci-secrets-preflight (push/pr/dispatch) and resolve any missing configuration.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
+                "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
+            ),
+        ],
+        condition=lambda c: c.requires_deploy,
+    )
+
+
+def deploy_stage(ctx: PlanContext) -> PlanStep:
+    health_script = ctx.script_path("health") / "check_deployment.py"
+    return PlanStep(
+        title="Deploy & Promote",
+        items=[
+            PlanItem(
+                "Staging: push to main to invoke .github/workflows/ci-deploy.yml (environment resolves to staging).",
+            ),
+            PlanItem(
+                "Review staging artifact outputs, ECS & Vercel deploys, and health verification.",
+            ),
+            PlanItem(
+                f"Run health verification: python {ctx.display_path(health_script)} --environment staging ...",
+                command=f"python {health_script} --environment staging",
+                artifacts=[_artifact(health_script)],
+            ),
+            PlanItem(
+                "Production: run GitHub Actions → “Promote to Production”, ensure approvals granted, wait for verify-and-gate + deploy-production jobs.",
+            ),
+            PlanItem(
+                "Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
+            ),
+            PlanItem(
+                "If failures occur, use scripts/rollback_backend.sh and scripts/rollback_frontend.sh via the rollback job or manually.",
+            ),
+        ],
+        condition=lambda c: c.requires_deploy,
+    )
+
+
+def observability_stage(ctx: PlanContext) -> PlanStep:
     staging_urls = {
         "frontend": "${vars.FRONTEND_URL_STAGING}",
         "api": "${vars.API_URL_STAGING}",
@@ -163,178 +540,188 @@ def main() -> int:
         "api": "${vars.API_URL_PRODUCTION}",
         "db": "${vars.DB_URL_PRODUCTION}",
     }
-
-    steps: List[Dict[str, List[str]]] = [
-        {
-            "title": "Environment & Inputs",
-            "items": [
-                "Install prerequisites: Python ≥3.11, Node.js ≥18, Docker, jq, rsync, sha256sum, git.",
-                f"Confirm brief exists at {brief_path}.",
-                (
-                    "Verify workflow.config.json values "
-                    f"(industry={industry}, project_type={project_type}, frontend={frontend}, "
-                    f"backend={backend}, database={database}, auth={auth}, deploy={deploy}, compliance={compliance})."
-                ),
-                (
-                    "Export automation variables before running lifecycle: "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root}\n"
-                    "   Optional: AUTH, DEPLOY, COMPLIANCE, NESTJS_ORM, FORCE_OUTPUT=1."
-                ),
-            ],
-        },
-        {
-            "title": "Planning & Alignment",
-            "items": [
-                "Review brief acceptance criteria, compliance asks, and stakeholder priorities.",
-                f"Generate planning artifacts for reference (dry run here only): "
-                f"python scripts/plan_from_brief.py --brief '{brief_path}' --out '{project_dir}/PLAN.md'.",
-                f"Validate DAG topology prior to generation: python scripts/validate_tasks.py "
-                f"--input '{project_dir}/PLAN.tasks.json'.",
-                "Inspect PLAN.md lanes and resolve dependencies/blocked tasks before coding.",
-            ],
-        },
-        {
-            "title": "Stack Preflight & Generation Prep",
-            "items": [
-                "Tooling doctor & template discovery: python scripts/doctor.py --strict "
-                "&& ./scripts/generate_client_project.py --list-templates --name \"$NAME\" --industry \"$INDUSTRY\" --project-type \"$PROJECT_TYPE\".",
-                (
-                    "Preflight stack selection and capture evidence: "
-                    "python scripts/select_stacks.py "
-                    f"--industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"--output '{project_dir}/selection.json' --summary '{project_dir}/evidence/stack-selection.md' "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''}"
-                ),
-                "If select_stacks exits with code 3, resolve engine version mismatches before continuing.",
-                (
-                    "Preview scaffold (no writes): ./scripts/generate_client_project.py "
-                    "--dry-run --workers 8 --yes "
-                    f"--name '{name}' --industry '{industry}' --project-type '{project_type}' "
-                    f"--frontend '{frontend}' --backend '{backend}' --database '{database}' "
-                    f"{'--auth ' + auth if auth != 'none' else ''} "
-                    f"{'--deploy ' + deploy if deploy != 'n/a' else ''} "
-                    f"{'--compliance ' + compliance if compliance != 'none' else ''} "
-                    f"--output-dir '{output_root}'"
-                ),
-            ],
-        },
-        {
-            "title": "Full Scaffold Generation & Bootstrap (queued automation)",
-            "items": [
-                (
-                    "When ready, run the one-shot generator (stops on any failure): "
-                    f"NAME={name} INDUSTRY={industry} PROJECT_TYPE={project_type} "
-                    f"FE={frontend} BE={backend} DB={database} OUTPUT_ROOT={output_root} make lifecycle"
-                ),
-                f"Inspect generated project at {project_dir}; confirm evidence/, PLAN.*, tasks.json, dist/ artifacts exist.",
-                "Capture any generator logs or selection evidence for audit.",
-            ],
-        },
-        {
-            "title": "Frontend Implementation Sequence (execute in project workspace)",
-            "items": [
-                f"Work inside {project_dir}/frontend following tasks in order:"
-            ] + frontend_lane,
-        },
-        {
-            "title": "Backend & Data Implementation Sequence",
-            "items": [
-                f"Work inside {project_dir}/backend (and database/ if emitted) following tasks in order:"
-            ] + backend_lane,
-        },
-        {
-            "title": "Integration, Migrations, and Data Validation",
-            "items": [
-                "Create/adjust Alembic migrations, run `alembic upgrade head`, and reseed sample data (aligns with BE-SCH/BE-SEED/BE-MDL).",
-                "Expose OpenAPI / typed clients once API endpoints are live; regenerate frontend types with `npx openapi-typescript` as needed.",
-                "Update MSW/Prism mocks to match live responses (FE-MOCKS).",
-                "Run smoke flows across dashboards/endpoints to confirm parity with PLAN acceptance.",
-            ],
-        },
-        {
-            "title": "Quality Automation & Gates",
-            "items": [
-                "Frontend lint & formatting: `cd frontend && npm run lint && npx prettier --check \"src/**/*.{ts,tsx,js,jsx,css,scss}\"`.",
-                "Frontend type check & unit tests: `cd frontend && npx tsc --noEmit && npm test -- --ci --coverage`.",
-                (
-                    "Backend quality: `cd backend && black --check . && flake8` "
-                    "(Python) and/or ESLint for Node backends; run `mypy app` when mypy is enabled."
-                ),
-                "Backend tests & coverage: `cd backend && pytest --cov=app --cov-report=xml:../coverage/backend-coverage.xml`.",
-                f"Aggregate stack-aware tests: `PROJECT_ROOT={project_dir} ./scripts/install_and_test.sh` (already done by lifecycle but rerun after local changes).",
-                f"Collect metrics: `PROJECT_ROOT={project_dir} python scripts/collect_coverage.py`, `collect_perf.py`, `scan_deps.py`.",
-                f"Enforce gates: `PROJECT_ROOT={project_dir} python scripts/enforce_gates.py` (blocks if thresholds in gates_config.yaml are missed).",
-            ],
-        },
-        {
-            "title": "Local Verification & Developer Experience",
-            "items": [
-                "Run dev servers for experiential QA: `cd frontend && npm run dev`; `cd backend && uvicorn app.main:app --reload` (or generated entrypoint).",
-                "Execute API/UI smoke via Postman/Newman or Playwright as applicable.",
-                f"Run `make pipeline-validate ENV=local FRONTEND_URL=http://localhost:3000 API_URL=http://localhost:8000/health DB_URL=http://localhost:8000/health/db` once health endpoints exist.",
-            ],
-        },
-        {
-            "title": "Compliance, Evidence, and Packaging",
-            "items": [
-                f"Package deliverables: `PROJECT_ROOT={project_dir} NAME={name} ./scripts/build_submission_pack.sh`.",
-                f"Validate compliance assets: `PROJECT_ROOT={project_dir} python scripts/validate_compliance_assets.py`.",
-                f"Optional doc scan: `PROJECT_ROOT={project_dir} python scripts/check_compliance_docs.py`.",
-                "Archive evidence/, dist/, coverage/, reports/ for hand-off.",
-            ],
-        },
-        {
-            "title": "CI/CD Enablement",
-            "items": [
-                "Populate GitHub secrets/vars required by .github/workflows/ci-secrets-preflight.yml:",
-                "   secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ECS_EXECUTION_ROLE_ARN, AWS_ECS_TASK_ROLE_ARN.",
-                "   vars: AWS_REGION, APP_NAME, ECS_CLUSTER_NAME, ECS_SERVICE_NAME, ECS_DESIRED_COUNT, FRONTEND_URL_STAGING, API_URL_STAGING, DB_URL_STAGING, FRONTEND_URL_PRODUCTION, API_URL_PRODUCTION, DB_URL_PRODUCTION.",
-                "Enforce production environment protection/approvals in GitHub.",
-                "Trigger ci-secrets-preflight (push/pr/dispatch) and resolve any missing configuration.",
-                "Review ci-lint/ci-test/ci-nox outputs to ensure repo-level checks pass.",
-            ],
-        },
-        {
-            "title": "Deploy & Promote",
-            "items": [
-                "Staging: push to main to invoke .github/workflows/ci-deploy.yml (environment resolves to staging).",
-                "Review staging artifact outputs, ECS & Vercel deploys, and health verification (`python scripts/health/check_deployment.py --environment staging ...`).",
-                "Production: run GitHub Actions → “Promote to Production”, ensure approvals granted, wait for verify-and-gate + deploy-production jobs.",
-                f"Post deploy: download reports/production-pipeline-validation.json and confirm smoke + newman tests passed.",
-                "If failures occur, use scripts/rollback_backend.sh and scripts/rollback_frontend.sh via the rollback job or manually.",
-            ],
-        },
-        {
-            "title": "Observability & Continuous Ops",
-            "items": [
+    return PlanStep(
+        title="Observability & Continuous Ops",
+        items=[
+            PlanItem(
                 "Schedule/monitor nightly-observability workflow; ensure staging/production URL vars stay current.",
-                f"Use `make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']}` for ad-hoc validation.",
-                f"Use `make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']}` post-promotion.",
+            ),
+            PlanItem(
+                f"Use make pipeline-validate ENV=staging FRONTEND_URL={staging_urls['frontend']} API_URL={staging_urls['api']} DB_URL={staging_urls['db']} for ad-hoc validation.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
+                f"Use make pipeline-validate ENV=production FRONTEND_URL={prod_urls['frontend']} API_URL={prod_urls['api']} DB_URL={prod_urls['db']} post-promotion.",
+                condition=lambda c: c.requires_deploy,
+            ),
+            PlanItem(
                 "Feed reports/ and evidence/ into dashboards or MCP tools for ongoing compliance.",
-            ],
-        },
-        {
-            "title": "Final Delivery & Retrospective",
-            "items": [
-                f"Hand off dist/{name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
-                f"Document residual risks or follow-ups in {project_dir}/reports/ or IMPLEMENTATION_SUMMARY.md.",
+                condition=lambda c: c.requires_compliance,
+            ),
+        ],
+        condition=lambda c: c.requires_deploy or c.requires_compliance,
+    )
+
+
+def final_delivery_stage(ctx: PlanContext) -> PlanStep:
+    return PlanStep(
+        title="Final Delivery & Retrospective",
+        items=[
+            PlanItem(
+                f"Hand off dist/{ctx.name}-submission, PLAN.md, PLAN.tasks.json, selection.json, and compliance logs.",
+                artifacts=[
+                    _artifact(ctx.project_dir / "dist" / f"{ctx.name}-submission"),
+                    _artifact(ctx.project_dir / "PLAN.md"),
+                    _artifact(ctx.project_dir / "PLAN.tasks.json"),
+                ],
+                condition=lambda c: c.project_dir.exists(),
+            ),
+            PlanItem(
+                f"Document residual risks or follow-ups in {ctx.display_path(ctx.project_dir / 'reports')} or IMPLEMENTATION_SUMMARY.md.",
+            ),
+            PlanItem(
                 "Capture implementation retrospective and update workflow.config.json/workflow docs for future engagements.",
-            ],
-        },
+            ),
+        ],
+    )
+
+
+def build_steps(ctx: PlanContext, frontend_lane: Iterable[str], backend_lane: Iterable[str]) -> List[PlanStep]:
+    return [
+        environment_stage(ctx),
+        planning_stage(ctx),
+        stack_preflight_stage(ctx),
+        generation_stage(ctx),
+        artifact_validation_stage(ctx),
+        frontend_stage(ctx, frontend_lane),
+        backend_stage(ctx, backend_lane),
+        integration_stage(ctx),
+        quality_stage(ctx),
+        developer_experience_stage(ctx),
+        compliance_stage(ctx),
+        cicd_stage(ctx),
+        deploy_stage(ctx),
+        observability_stage(ctx),
+        final_delivery_stage(ctx),
     ]
 
 
+# ---------------------------------------------------------------------------
+# CLI implementation
 
-    for step_idx, step in enumerate(steps, 1):
-        print(f"{step_idx}. {step['title']}")
-        for item_idx, item in enumerate(step["items"], 1):
-            print(f"   {step_idx}.{item_idx} {item}")
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
+    ap.add_argument("--name", help="Client/project name override")
+    ap.add_argument("--config", default="workflow.config.json")
+    ap.add_argument("--output-root", default="../_generated")
+    ap.add_argument("--execute", action="store_true", help="Execute commands and report statuses")
+    return ap.parse_args()
+
+
+def load_config(path: Path) -> Dict:
+    if not path.exists():
+        raise FileNotFoundError(f"config not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def ensure_brief_exists(path: Path) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"brief not found: {path}")
+
+
+def format_lane(lane: List[Dict]) -> List[str]:
+    entries = []
+    for idx, t in enumerate(lane, 1):
+        blockers = ", ".join(t["blocked_by"]) if t.get("blocked_by") else "none"
+        acceptance = ", ".join(t.get("acceptance", [])) if t.get("acceptance") else "see acceptance criteria"
+        entries.append(
+            f"{t['id']}: {t['title']} (blocked_by: {blockers}; acceptance: {acceptance})"
+        )
+    return entries
+
+
+def print_steps(steps: List[PlanStep], ctx: PlanContext, execute: bool) -> int:
+    exit_code = 0
+    summary: List[Tuple[str, Status]] = []
+    step_counter = 0
+    for step in steps:
+        if not step.is_active(ctx):
+            continue
+        step_counter += 1
+        print(f"{step_counter}. {step.title}")
+        item_counter = 0
+        for item in step.items:
+            if not item.is_active(ctx):
+                continue
+            item_counter += 1
+            status, message = item.evaluate(ctx, execute)
+            if status == "error":
+                exit_code = 1
+            summary.append((message, status))
+            prefix = {
+                "ok": "[OK] ",
+                "error": "[!!] ",
+                "pending": "[cmd] ",
+                "info": "     ",
+            }.get(status, "     ")
+            print(f"   {step_counter}.{item_counter} {prefix}{message}")
         print()
 
-    return 0
+    if execute and summary:
+        print("Command summary:")
+        for message, status in summary:
+            if status in {"ok", "error", "pending"}:
+                print(f" - {status.upper():7} {message}")
+        print()
+
+    return exit_code
+
+
+def main() -> int:
+    args = parse_args()
+
+    cfg_path = ROOT / args.config
+    try:
+        cfg = load_config(cfg_path)
+    except FileNotFoundError as exc:
+        print(f"[plan] {exc}", file=sys.stderr)
+        return 2
+
+    name = args.name or os.environ.get("NAME") or cfg.get("name")
+    if not name:
+        print("[plan] NAME is required (pass --name, export NAME, or set workflow.config.json)", file=sys.stderr)
+        return 2
+
+    brief_path = ROOT / "docs" / "briefs" / name / "brief.md"
+    try:
+        ensure_brief_exists(brief_path)
+    except FileNotFoundError as exc:
+        print(f"[plan] {exc}", file=sys.stderr)
+        return 2
+
+    spec = BriefParser(str(brief_path)).parse()
+    lanes = build_plan(spec, cfg)
+
+    output_root = Path(args.output_root)
+    project_dir = (output_root / name).resolve()
+
+    frontend_lane = format_lane(lanes.get("frontend", []))
+    backend_lane = format_lane(lanes.get("backend", []))
+
+    ctx = PlanContext(
+        name=name,
+        config=cfg,
+        spec=spec,
+        brief_path=brief_path,
+        output_root=output_root,
+        project_dir=project_dir,
+    )
+
+    steps = build_steps(ctx, frontend_lane, backend_lane)
+    return print_steps(steps, ctx, args.execute)
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/tests/test_pre_lifecycle_plan.py
+++ b/tests/test_pre_lifecycle_plan.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from project_generator.core.brief_parser import ScaffoldSpec
+
+from scripts.lifecycle_tasks import build_plan
+from scripts.pre_lifecycle_plan import (
+    PlanContext,
+    PlanItem,
+    build_steps,
+)
+
+
+def make_spec(**overrides) -> ScaffoldSpec:
+    base = dict(
+        name="demo",
+        industry="saas",
+        project_type="fullstack",
+        frontend="nextjs",
+        backend="fastapi",
+        database="postgres",
+        auth="auth0",
+        deploy="aws",
+        compliance=["soc2"],
+        features=["analytics"],
+        separate_repos=True,
+    )
+    base.update(overrides)
+    return ScaffoldSpec(**base)
+
+
+def test_build_plan_respects_capabilities():
+    spec = make_spec(backend="none", database="none")
+    plan = build_plan(spec, {})
+    assert plan["backend"] == []
+    assert any(task["id"].startswith("FE-") for task in plan["frontend"])
+
+
+def test_build_steps_gates_compliance_and_deploy(tmp_path: Path):
+    spec = make_spec(deploy="n/a", compliance=[])
+    ctx = PlanContext(
+        name="demo",
+        config={"deploy": "n/a", "compliance": []},
+        spec=spec,
+        brief_path=tmp_path / "brief.md",
+        output_root=tmp_path,
+        project_dir=tmp_path / "project",
+    )
+    ctx.project_dir.mkdir()
+    steps = build_steps(ctx, ["task"], ["task"])
+    active_titles = [step.title for step in steps if step.is_active(ctx)]
+    assert "Compliance, Evidence, and Packaging" not in active_titles
+    assert "CI/CD Enablement" not in active_titles
+    assert "Deploy & Promote" not in active_titles
+
+
+def test_planitem_artifact_check(tmp_path: Path):
+    spec = make_spec()
+    ctx = PlanContext(
+        name="demo",
+        config={},
+        spec=spec,
+        brief_path=tmp_path / "brief.md",
+        output_root=tmp_path,
+        project_dir=tmp_path / "project",
+    )
+    ctx.project_dir.mkdir()
+    item = PlanItem("Check missing", artifacts=[lambda c: c.project_dir / "missing.txt"])
+    status, message = item.evaluate(ctx, execute=False)
+    assert status == "error"
+    assert "missing" in message
+
+
+@pytest.mark.parametrize("exit_code,expected", [(0, "ok"), (3, "error")])
+def test_planitem_execute(tmp_path: Path, exit_code: int, expected: str):
+    spec = make_spec()
+    ctx = PlanContext(
+        name="demo",
+        config={},
+        spec=spec,
+        brief_path=tmp_path / "brief.md",
+        output_root=tmp_path,
+        project_dir=tmp_path / "project",
+    )
+    ctx.project_dir.mkdir()
+    command = f"{sys.executable} -c 'import sys; sys.exit({exit_code})'"
+    item = PlanItem("Execute command", command=command)
+    status, _ = item.evaluate(ctx, execute=True)
+    assert status == expected


### PR DESCRIPTION
## Summary
- add a shared lifecycle task builder so plan generation adapts to the parsed brief and workflow configuration
- refactor the pre-lifecycle planner into modular stages with capability gating, artifact checks, and optional command execution
- update plan_from_brief to use the shared builder and add tests covering gating, artifact validation, and command execution paths

## Testing
- pytest tests/test_pre_lifecycle_plan.py

------
https://chatgpt.com/codex/tasks/task_e_68d49d47c2f4832e9d2c087c584ae10b