### PR TITLE
feat: auto configure pre lifecycle from brief metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,6 +321,7 @@ uv.lock
 !portfolio-dashboard/frontend/jest.config.js
 *.config.ts
 *.config.json
+!workflow.config.json
 tsconfig.json
 jsconfig.json
 tailwind.config.js

--- a/docs/briefs/portfolio-dashboard/brief.md
+++ b/docs/briefs/portfolio-dashboard/brief.md
@@ -1,3 +1,14 @@
+---
+name: portfolio-dashboard
+industry: saas
+project_type: fullstack
+frontend: nextjs
+backend: fastapi
+database: postgres
+auth: auth0
+deploy: aws
+compliance: soc2
+---
 # Project Brief: Professional Portfolio Dashboard
 
 ## Client Information

--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -614,7 +614,7 @@ def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description="Print pre-lifecycle execution plan.")
     ap.add_argument("--name", help="Client/project name override")
     ap.add_argument("--config", default="workflow.config.json")
-    ap.add_argument("--output-root", default="../_generated")
+    ap.add_argument("--output-root")
     ap.add_argument("--execute", action="store_true", help="Execute commands and report statuses")
     return ap.parse_args()
 
@@ -623,6 +623,92 @@ def load_config(path: Path) -> Dict:
     if not path.exists():
         raise FileNotFoundError(f"config not found: {path}")
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+LIST_FIELDS = {"compliance", "features"}
+LOWER_FIELDS = {"industry", "project_type", "frontend", "backend", "database", "auth", "deploy"}
+
+
+def _parse_frontmatter(text: str) -> Dict[str, str]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    meta: Dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        meta[key.strip()] = value.strip().strip("\"'")
+    return meta
+
+
+def _normalize_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = {}
+    for key, value in metadata.items():
+        key_lc = key.strip().lower()
+        if isinstance(value, str):
+            value = value.strip()
+            if key_lc in LIST_FIELDS:
+                parts = [part.strip() for part in value.split(",") if part.strip()]
+                if key_lc == "compliance":
+                    value = [part.lower() for part in parts]
+                else:
+                    value = parts
+            elif key_lc in LOWER_FIELDS:
+                value = value.lower()
+        elif isinstance(value, list) and key_lc == "compliance":
+            value = [str(part).strip().lower() for part in value]
+        normalized[key_lc] = value
+    return normalized
+
+
+def parse_metadata_from_brief(brief_path: Path) -> Dict[str, Any]:
+    if not brief_path.exists():
+        return {}
+
+    combined: Dict[str, Any] = {}
+    text = brief_path.read_text(encoding="utf-8")
+    combined.update(_parse_frontmatter(text))
+
+    metadata_json = brief_path.with_name("metadata.json")
+    if metadata_json.exists():
+        try:
+            json_metadata = json.loads(metadata_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid metadata JSON at {metadata_json}: {exc}") from exc
+        combined.update(json_metadata)
+
+    return _normalize_metadata(combined)
+
+
+def merge_workflow_config(
+    base: Dict[str, Any],
+    spec: ScaffoldSpec,
+    metadata: Dict[str, Any],
+    name: str,
+) -> Dict[str, Any]:
+    merged: Dict[str, Any] = base.copy()
+    spec_config: Dict[str, Any] = {
+        "name": spec.name,
+        "industry": spec.industry,
+        "project_type": spec.project_type,
+        "frontend": spec.frontend,
+        "backend": spec.backend,
+        "database": spec.database,
+        "auth": spec.auth,
+        "deploy": spec.deploy,
+        "compliance": spec.compliance,
+        "features": spec.features,
+    }
+    merged.update(spec_config)
+    merged.update(metadata)
+    merged["name"] = name
+    return merged
 
 
 def ensure_brief_exists(path: Path) -> None:
@@ -700,10 +786,17 @@ def main() -> int:
         print(f"[plan] {exc}", file=sys.stderr)
         return 2
 
+    try:
+        metadata_overrides = parse_metadata_from_brief(brief_path)
+    except ValueError as exc:
+        print(f"[plan] {exc}", file=sys.stderr)
+        return 2
+
     spec = BriefParser(str(brief_path)).parse()
+    cfg = merge_workflow_config(cfg, spec, metadata_overrides, name)
     lanes = build_plan(spec, cfg)
 
-    output_root = Path(args.output_root)
+    output_root = Path(args.output_root or cfg.get("output_root") or "../_generated")
     project_dir = (output_root / name).resolve()
 
     frontend_lane = format_lane(lanes.get("frontend", []))

--- a/tests/test_pre_lifecycle_plan.py
+++ b/tests/test_pre_lifecycle_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from scripts.lifecycle_tasks import build_plan
 from scripts.pre_lifecycle_plan import (
     PlanContext,
     PlanItem,
+    merge_workflow_config,
+    parse_metadata_from_brief,
     build_steps,
 )
 
@@ -91,3 +94,40 @@ def test_planitem_execute(tmp_path: Path, exit_code: int, expected: str):
     item = PlanItem("Execute command", command=command)
     status, _ = item.evaluate(ctx, execute=True)
     assert status == expected
+
+
+def test_parse_metadata_from_brief_frontmatter(tmp_path: Path):
+    brief_dir = tmp_path / "demo"
+    brief_dir.mkdir()
+    brief = brief_dir / "brief.md"
+    brief.write_text(
+        "---\nfrontend: angular\nbackend: django\ncompliance: hipaa, soc2\n---\nBody"
+    )
+
+    metadata = parse_metadata_from_brief(brief)
+    assert metadata["frontend"] == "angular"
+    assert metadata["backend"] == "django"
+    assert metadata["compliance"] == ["hipaa", "soc2"]
+
+
+def test_parse_metadata_from_brief_prefers_json(tmp_path: Path):
+    brief_dir = tmp_path / "demo"
+    brief_dir.mkdir()
+    brief = brief_dir / "brief.md"
+    brief.write_text("---\nfrontend: angular\n---\nBody")
+    (brief_dir / "metadata.json").write_text(json.dumps({"frontend": "nextjs"}))
+
+    metadata = parse_metadata_from_brief(brief)
+    assert metadata["frontend"] == "nextjs"
+
+
+def test_merge_workflow_config_prioritizes_metadata():
+    base = {"frontend": "nextjs", "backend": "fastapi", "compliance": []}
+    spec = make_spec(frontend="nextjs", backend="fastapi")
+    metadata = {"frontend": "angular", "compliance": ["hipaa"]}
+
+    merged = merge_workflow_config(base, spec, metadata, "demo")
+    assert merged["frontend"] == "angular"
+    assert merged["backend"] == "fastapi"
+    assert merged["name"] == "demo"
+    assert merged["compliance"] == ["hipaa"]

--- a/workflow.config.json
+++ b/workflow.config.json
@@ -1,0 +1,12 @@
+{
+  "name": "default",
+  "industry": "saas",
+  "project_type": "fullstack",
+  "frontend": "nextjs",
+  "backend": "fastapi",
+  "database": "postgres",
+  "auth": "auth0",
+  "deploy": "aws",
+  "compliance": [],
+  "output_root": "../_generated"
+}


### PR DESCRIPTION
## Summary
- add a committed baseline `workflow.config.json` and allow it through the ignore rules so common stack defaults are versioned
- enrich example portfolio dashboard brief with stack metadata frontmatter to drive automation
- enhance `pre_lifecycle_plan.py` to ingest brief metadata/JSON overrides, merge them with defaults, and expose helpers with tests

## Testing
- `pytest tests/test_pre_lifecycle_plan.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4fa40e6c4832eb3a0d161af3544d8