### PR TITLE
Fix frontmatter parsing for various line endings

### DIFF
--- a/scripts/pre_lifecycle_plan.py
+++ b/scripts/pre_lifecycle_plan.py
@@ -696,11 +696,32 @@ def load_config(path: Path) -> Dict:
 
 
 def _parse_frontmatter(text: str) -> Dict[str, Any]:
+    # Normalize line endings to handle both Unix (\n) and Windows (\r\n)
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    
+    # Check for frontmatter start
     if not text.startswith("---\n"):
         return {}
-    end = text.find("\n---\n", 4)
+    
+    # Find the closing delimiter - handle both \n---\n and --- at end of file
+    end_marker = "\n---\n"
+    end = text.find(end_marker, 4)
+    
+    # If not found with newline, check if --- is at the end of the file
     if end == -1:
-        return {}
+        # Look for --- followed by newline or end of string
+        end_marker = "\n---"
+        end = text.find(end_marker, 4)
+        if end == -1:
+            # Check if the file ends with --- (no trailing newline)
+            if text.endswith("\n---"):
+                end = len(text) - 4
+            else:
+                return {}
+        else:
+            end += len(end_marker) - 1  # Include the --- but not the trailing newline
+    
+    # Extract frontmatter content (skip the opening ---\n)
     fm = text[4:end]
     meta: Dict[str, Any] = {}
     for raw_line in fm.splitlines():


### PR DESCRIPTION
## Description
- The `_parse_frontmatter` function was updated to correctly parse frontmatter in files with various line ending conventions (Unix, CRLF) and to handle cases where the closing `---` delimiter appears at the very end of the file without a trailing newline. Previously, it strictly expected `\n---\n`, leading to parsing failures in these scenarios.

## Scope
- [x] Backend
- [ ] Frontend
- [ ] DevOps/CI
- [ ] Docs

## Workflow Phase (if applicable)
- [ ] Phase 0: Bootstrap Project
- [ ] Phase 1: Create PRD
- [ ] Phase 2: Generate Tasks
- [ ] Phase 3: Sync Tasks
- [x] Phase 4: Process Tasks
- [ ] Phase 5: Quality Control
- [ ] Phase 6: Implementation Retrospective

## Checklist
- [x] Tasks updated (state/acceptance)
- [x] Tests added/updated
- [ ] Lints pass locally
- [ ] Gates considered (coverage/vulns/perf)
- [ ] Docs/README updated if applicable
- [ ] Workflow documentation updated (if workflow changes)
- [ ] Template packs updated (if template changes)
- [ ] CI/CD pipeline tested
- [ ] Compliance requirements met

## Screenshots / Evidence
- (optional)

## Risks & Mitigations
- Risk:
- Mitigation:

---
<a href="https://cursor.com/background-agent?bcId=bc-fe0d42bb-9d74-4594-861b-f263bc1aba1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe0d42bb-9d74-4594-861b-f263bc1aba1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

