### PR TITLE
feat: add portfolio-grade product operations frontend

### DIFF
--- a/src/frontend/.storybook/main.ts
+++ b/src/frontend/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-essentials", "@storybook/addon-interactions", "@storybook/addon-styling"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {}
+  },
+  docs: {
+    autodocs: "tag"
+  }
+};
+
+export default config;

--- a/src/frontend/.storybook/preview.ts
+++ b/src/frontend/.storybook/preview.ts
@@ -1,0 +1,21 @@
+import type { Preview } from "@storybook/react";
+import { ThemeProvider } from "../src/theme/ThemeProvider";
+import "../src/index.css";
+
+const preview: Preview = {
+  parameters: {
+    controls: { expanded: true },
+    layout: "fullscreen"
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div style={{ padding: "32px", background: "var(--surface-s0)", minHeight: "100vh" }}>
+          <Story />
+        </div>
+      </ThemeProvider>
+    )
+  ]
+};
+
+export default preview;

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -1,0 +1,20 @@
+# Portfolio-grade Product Operations Frontend
+
+This Vite + React workspace implements the unified multi-vertical dashboard described in the portfolio-grade product operations brief. It provides:
+
+- Design tokens for light/dark themes, semantic palettes, and vertical accents with 8pt spacing rhythm and typography scale.
+- Shared components (KPI cards, charts, filter chips, tables, automation builder, toasts) with WCAG AA focus handling.
+- Module pages for SaaS, E-commerce, Corporate Analytics, Custom App, Media, EdTech, Real Estate, Finance, and Healthcare verticals using shared UX primitives.
+- Zustand global filters, React Query integration, and an EventSource mock for live metrics.
+- Storybook configuration with theming decorator and seed script examples.
+
+## Scripts
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run storybook
+```
+
+> The workspace is dependency-isolated from the monorepo root. Run the commands from `src/frontend`.

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio-grade Product Operations</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "portfolio-grade-product-operations",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "storybook": "storybook dev -p 6006",
+    "build:storybook": "storybook build"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.56.2",
+    "@tanstack/react-query-devtools": "^5.56.2",
+    "clsx": "^2.1.0",
+    "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
+    "d3-time-format": "^4.1.0",
+    "intl-messageformat": "^10.5.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
+    "recharts": "^2.12.7",
+    "zustand": "^5.0.0"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "^8.2.6",
+    "@storybook/addon-interactions": "^8.2.6",
+    "@storybook/addon-styling": "^1.5.1",
+    "@storybook/react": "^8.2.6",
+    "@storybook/react-vite": "^8.2.6",
+    "@storybook/test": "^8.2.6",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "axe-core": "^4.10.0",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.8",
+    "storybook": "^8.2.6",
+    "typescript": "^5.5.4",
+    "vite": "^5.3.4"
+  }
+}

--- a/src/frontend/scripts/seed.ts
+++ b/src/frontend/scripts/seed.ts
@@ -1,0 +1,13 @@
+// Example seed script describing how module fixtures could be pushed to an API.
+// In a real environment this would call backend endpoints with authenticated requests.
+// Here we simply log the payload to demonstrate schema usage.
+import { fixtures } from "../src/data/fixtures";
+
+const payload = Object.entries(fixtures).map(([moduleId, fixture]) => ({
+  moduleId,
+  kpis: fixture.kpis,
+  tables: Object.keys(fixture.tables),
+  charts: Object.keys(fixture.charts)
+}));
+
+console.log(JSON.stringify({ seeds: payload }, null, 2));

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+import AppLayout from "./layouts/AppLayout";
+import SaaSModule from "./modules/SaaSModule";
+import EcommerceModule from "./modules/EcommerceModule";
+import AnalyticsModule from "./modules/AnalyticsModule";
+import CustomAppModule from "./modules/CustomAppModule";
+import MediaModule from "./modules/MediaModule";
+import EdtechModule from "./modules/EdtechModule";
+import RealEstateModule from "./modules/RealEstateModule";
+import FinanceModule from "./modules/FinanceModule";
+import HealthcareModule from "./modules/HealthcareModule";
+
+const App: React.FC = () => {
+  return (
+    <AppLayout>
+      <Routes>
+        <Route path="/" element={<Navigate to="/saas" replace />} />
+        <Route path="/saas" element={<SaaSModule />} />
+        <Route path="/ecommerce" element={<EcommerceModule />} />
+        <Route path="/analytics" element={<AnalyticsModule />} />
+        <Route path="/custom-app" element={<CustomAppModule />} />
+        <Route path="/media" element={<MediaModule />} />
+        <Route path="/edtech" element={<EdtechModule />} />
+        <Route path="/real-estate" element={<RealEstateModule />} />
+        <Route path="/finance" element={<FinanceModule />} />
+        <Route path="/healthcare" element={<HealthcareModule />} />
+      </Routes>
+    </AppLayout>
+  );
+};
+
+export default App;

--- a/src/frontend/src/components/DataTable.tsx
+++ b/src/frontend/src/components/DataTable.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from "react";
+import { clsx } from "clsx";
+
+type SortDirection = "asc" | "desc" | "none";
+
+export interface Column<T> {
+  key: keyof T & string;
+  label: string;
+  align?: "start" | "end";
+  render?: (value: T[keyof T], item: T) => React.ReactNode;
+}
+
+interface DataTableProps<T> {
+  id: string;
+  columns: Column<T>[];
+  data: T[];
+  sortable?: boolean;
+  dense?: boolean;
+}
+
+export function DataTable<T extends Record<string, unknown>>({ id, columns, data, sortable = true, dense }: DataTableProps<T>) {
+  const [sortKey, setSortKey] = useState<string>("");
+  const [direction, setDirection] = useState<SortDirection>("none");
+
+  const sortedData = useMemo(() => {
+    if (!sortable || !sortKey || direction === "none") {
+      return data;
+    }
+    const sorted = [...data].sort((a, b) => {
+      const aValue = a[sortKey];
+      const bValue = b[sortKey];
+      if (aValue === bValue) return 0;
+      if (aValue == null) return -1;
+      if (bValue == null) return 1;
+      if (typeof aValue === "number" && typeof bValue === "number") {
+        return direction === "asc" ? aValue - bValue : bValue - aValue;
+      }
+      return direction === "asc"
+        ? String(aValue).localeCompare(String(bValue))
+        : String(bValue).localeCompare(String(aValue));
+    });
+    return sorted;
+  }, [data, direction, sortKey, sortable]);
+
+  const handleSort = (key: string) => {
+    if (!sortable) return;
+    if (key !== sortKey) {
+      setSortKey(key);
+      setDirection("asc");
+    } else {
+      setDirection((prev) => (prev === "asc" ? "desc" : prev === "desc" ? "none" : "asc"));
+    }
+  };
+
+  return (
+    <div style={{ borderRadius: "16px", border: "1px solid var(--border-color)", overflow: "hidden", background: "var(--surface-s1)" }}>
+      <table id={id} role="table" style={{ width: "100%", borderCollapse: "separate", borderSpacing: 0 }}>
+        <thead>
+          <tr role="row" style={{ background: "var(--surface-s2)" }}>
+            {columns.map((column) => {
+              const isActive = column.key === sortKey;
+              const ariaSort = !sortable || direction === "none" || !isActive ? "none" : direction;
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  role="columnheader"
+                  aria-sort={ariaSort}
+                  style={{
+                    textAlign: column.align === "end" ? "right" : "left",
+                    padding: dense ? "12px 16px" : "16px 24px",
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    color: "var(--text-secondary)",
+                    cursor: sortable ? "pointer" : "default",
+                    userSelect: "none"
+                  }}
+                  onClick={() => handleSort(column.key)}
+                >
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+                    {column.label}
+                    {sortable && (
+                      <span aria-hidden="true" className={clsx("sort-indicator", { active: isActive })}>
+                        {isActive ? (direction === "asc" ? "▲" : direction === "desc" ? "▼" : "–") : ""}
+                      </span>
+                    )}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedData.map((row, rowIndex) => (
+            <tr
+              key={rowIndex}
+              role="row"
+              style={{ borderBottom: "1px solid var(--border-color)", height: dense ? "40px" : "44px" }}
+            >
+              {columns.map((column) => (
+                <td
+                  key={column.key}
+                  role="cell"
+                  style={{
+                    textAlign: column.align === "end" ? "right" : "left",
+                    padding: dense ? "12px 16px" : "16px 24px",
+                    fontSize: "14px",
+                    lineHeight: "20px",
+                    fontFeatureSettings: "'tnum' 1, 'lnum' 1"
+                  }}
+                >
+                  {column.render ? column.render(row[column.key], row) : (row[column.key] as React.ReactNode)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ padding: "12px 24px", display: "flex", justifyContent: "flex-end", gap: "12px" }}>
+        <button type="button" onClick={() => downloadData(sortedData, id, "csv")} className="focus-ring" style={exportButtonStyle}>
+          Export CSV
+        </button>
+        <button type="button" onClick={() => downloadData(sortedData, id, "json")} className="focus-ring" style={exportButtonStyle}>
+          Export JSON
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const exportButtonStyle: React.CSSProperties = {
+  borderRadius: "8px",
+  padding: "8px 12px",
+  border: "1px solid var(--border-color)",
+  background: "var(--surface-s1)",
+  cursor: "pointer"
+};
+
+function downloadData<T>(data: T[], id: string, format: "csv" | "json") {
+  const content = format === "json" ? JSON.stringify(data, null, 2) : convertToCsv(data);
+  const blob = new Blob([content], { type: format === "json" ? "application/json" : "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${id}.${format}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function convertToCsv<T>(data: T[]) {
+  if (!data.length) return "";
+  const headers = Object.keys(data[0] as Record<string, unknown>);
+  const rows = data.map((row) =>
+    headers
+      .map((header) => {
+        const value = (row as Record<string, unknown>)[header];
+        if (value == null) return "";
+        return typeof value === "string" ? `"${value.replace(/"/g, '""')}"` : value;
+      })
+      .join(",")
+  );
+  return [headers.join(","), ...rows].join("\n");
+}

--- a/src/frontend/src/components/Drawer.tsx
+++ b/src/frontend/src/components/Drawer.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+interface DrawerProps {
+  title: string;
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const Drawer: React.FC<DrawerProps> = ({ title, open, onClose, children }) => {
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.6)",
+        display: "flex",
+        justifyContent: "flex-end",
+        zIndex: 1200
+      }}
+    >
+      <aside
+        style={{
+          width: "min(480px, 100%)",
+          background: "var(--surface-s1)",
+          height: "100%",
+          borderRadius: "24px 0 0 24px",
+          boxShadow: "var(--shadow-elevation)",
+          display: "flex",
+          flexDirection: "column"
+        }}
+      >
+        <header style={{ padding: "24px", borderBottom: "1px solid var(--border-color)", display: "flex", justifyContent: "space-between" }}>
+          <h2 style={{ margin: 0, fontSize: "22px", lineHeight: "28px" }}>{title}</h2>
+          <button type="button" onClick={onClose} className="focus-ring" style={{ border: "none", background: "transparent", cursor: "pointer" }}>
+            Close
+          </button>
+        </header>
+        <div style={{ padding: "24px", overflowY: "auto", flex: 1 }}>{children}</div>
+      </aside>
+    </div>
+  );
+};

--- a/src/frontend/src/components/FilterChips.tsx
+++ b/src/frontend/src/components/FilterChips.tsx
@@ -1,0 +1,43 @@
+import { clsx } from "clsx";
+
+export interface FilterChip {
+  id: string;
+  label: string;
+  selected: boolean;
+}
+
+interface FilterChipsProps {
+  chips: FilterChip[];
+  onSelect: (id: string) => void;
+  ariaLabel: string;
+}
+
+export const FilterChips: React.FC<FilterChipsProps> = ({ chips, onSelect, ariaLabel }) => {
+  return (
+    <div role="listbox" aria-label={ariaLabel} style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+      {chips.map((chip) => (
+        <button
+          key={chip.id}
+          type="button"
+          role="option"
+          aria-selected={chip.selected}
+          onClick={() => onSelect(chip.id)}
+          className={clsx("filter-chip", { selected: chip.selected })}
+          style={{
+            borderRadius: "999px",
+            padding: "8px 16px",
+            border: chip.selected ? "1px solid transparent" : "1px solid var(--border-color)",
+            background: chip.selected ? "var(--primary-500)" : "var(--surface-s1)",
+            color: chip.selected ? "#fff" : "var(--text-primary)",
+            cursor: "pointer",
+            transition: "background 200ms ease-in-out, color 200ms ease-in-out"
+          }}
+        >
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default FilterChips;

--- a/src/frontend/src/components/GlobalFilterBar.tsx
+++ b/src/frontend/src/components/GlobalFilterBar.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { useGlobalFilters } from "../store/globalFilters";
+import { FilterChips } from "./FilterChips";
+import SegmentedTabs from "./SegmentedTabs";
+import { modules } from "../data/modules";
+
+const segments = [
+  { id: "all", label: "All" },
+  { id: "enterprise", label: "Enterprise" },
+  { id: "midmarket", label: "Mid-market" },
+  { id: "smb", label: "SMB" }
+];
+
+const dateRanges = [
+  { id: "7d", label: "Last 7 days" },
+  { id: "30d", label: "Last 30 days" },
+  { id: "90d", label: "Last 90 days" },
+  { id: "fy", label: "Fiscal YTD" }
+];
+
+export const GlobalFilterBar: React.FC = () => {
+  const { dateRange, segment, vertical, setDateRange, setSegment, setVertical } = useGlobalFilters();
+
+  const segmentChips = useMemo(
+    () => segments.map((item) => ({ ...item, selected: item.id === segment })),
+    [segment]
+  );
+
+  const dateTabs = useMemo(() => dateRanges.map((item) => ({ id: item.id, label: item.label })), []);
+
+  const verticalItems = useMemo(() => modules.map((module) => ({ id: module.id, label: module.name })), []);
+
+  return (
+    <section
+      style={{
+        background: "var(--surface-s1)",
+        borderRadius: "16px",
+        padding: "24px",
+        border: "1px solid var(--border-color)",
+        display: "grid",
+        gap: "16px"
+      }}
+      aria-label="Global filters"
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "16px", alignItems: "center", justifyContent: "space-between" }}>
+        <SegmentedTabs items={dateTabs} activeId={dateRange} onChange={(id) => setDateRange(id as never)} />
+        <div>
+          <label htmlFor="vertical-select" style={{ fontSize: "12px", color: "var(--text-secondary)" }}>
+            Vertical
+          </label>
+          <select
+            id="vertical-select"
+            value={vertical}
+            onChange={(event) => setVertical(event.target.value)}
+            style={{
+              marginLeft: "12px",
+              borderRadius: "12px",
+              border: "1px solid var(--border-color)",
+              padding: "8px 12px",
+              background: "var(--surface-s1)",
+              color: "var(--text-primary)"
+            }}
+          >
+            {verticalItems.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <FilterChips ariaLabel="Segments" chips={segmentChips} onSelect={(id) => setSegment(id)} />
+    </section>
+  );
+};
+
+export default GlobalFilterBar;

--- a/src/frontend/src/components/KpiBand.tsx
+++ b/src/frontend/src/components/KpiBand.tsx
@@ -1,0 +1,46 @@
+import KpiCard from "./KpiCard";
+
+interface KpiBandProps {
+  accent: string;
+  kpis: {
+    id: string;
+    label: string;
+    value: number;
+    type: "currency" | "number" | "percent" | "duration";
+    delta: number;
+    deltaLabel: string;
+    timeBasis: string;
+  }[];
+}
+
+export const KpiBand: React.FC<KpiBandProps> = ({ accent, kpis }) => {
+  return (
+    <div
+      className="kpi-band"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+        gap: "24px",
+        scrollSnapType: "x mandatory",
+        overflowX: "auto",
+        paddingBottom: "8px"
+      }}
+    >
+      {kpis.map((kpi) => (
+        <div key={kpi.id} style={{ scrollSnapAlign: "start" }}>
+          <KpiCard
+            title={kpi.label}
+            value={kpi.value}
+            valueType={kpi.type}
+            delta={kpi.delta}
+            deltaLabel={kpi.deltaLabel}
+            timeBasis={kpi.timeBasis}
+            accent={accent}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default KpiBand;

--- a/src/frontend/src/components/KpiCard.tsx
+++ b/src/frontend/src/components/KpiCard.tsx
@@ -1,0 +1,95 @@
+import { formatCurrency, formatDuration, formatNumber, formatPercent, formatTrend } from "../utils/formatters";
+import { clsx } from "clsx";
+
+export interface KpiCardProps {
+  title: string;
+  value: number;
+  valueType?: "currency" | "number" | "percent" | "duration";
+  delta?: number;
+  deltaLabel?: string;
+  timeBasis?: string;
+  accent?: string;
+  loading?: boolean;
+}
+
+const formatValue = (value: number, type: KpiCardProps["valueType"]) => {
+  switch (type) {
+    case "currency":
+      return formatCurrency(value);
+    case "duration":
+      return formatDuration(value);
+    case "percent":
+      return formatPercent(value);
+    default:
+      return formatNumber(value);
+  }
+};
+
+export const KpiCard: React.FC<KpiCardProps> = ({
+  title,
+  value,
+  valueType = "number",
+  delta,
+  deltaLabel,
+  timeBasis,
+  accent,
+  loading
+}) => {
+  const formattedValue = loading ? "" : formatValue(value, valueType);
+  const showDelta = typeof delta === "number";
+  const isPositive = (delta ?? 0) >= 0;
+
+  return (
+    <article
+      className="kpi-card"
+      style={{
+        background: "var(--surface-s1)",
+        borderRadius: "16px",
+        padding: "24px",
+        boxShadow: "var(--shadow-elevation)",
+        border: "1px solid var(--border-color)",
+        minHeight: "140px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px"
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h3 style={{ margin: 0, color: "var(--text-secondary)", fontSize: "14px", fontWeight: 600 }}>{title}</h3>
+        {accent && <span style={{ width: 12, height: 12, borderRadius: "50%", background: accent }} aria-hidden="true" />}
+      </div>
+      {loading ? (
+        <div role="status" aria-live="polite" aria-label={`Loading ${title}`} className="skeleton" />
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: "12px",
+            fontFeatureSettings: "'tnum' 1, 'lnum' 1"
+          }}
+        >
+          <span style={{ fontSize: "32px", lineHeight: "36px", fontWeight: 700 }}>{formattedValue}</span>
+          {showDelta && (
+            <span
+              className={clsx("delta", isPositive ? "positive" : "negative")}
+              style={{
+                fontSize: "14px",
+                fontWeight: 600,
+                color: isPositive ? "var(--success-500)" : "var(--danger-500)"
+              }}
+              aria-label={deltaLabel}
+            >
+              {formatTrend(delta!)}
+            </span>
+          )}
+        </div>
+      )}
+      {timeBasis && (
+        <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px" }}>{timeBasis}</p>
+      )}
+    </article>
+  );
+};
+
+export default KpiCard;

--- a/src/frontend/src/components/ListCard.tsx
+++ b/src/frontend/src/components/ListCard.tsx
@@ -1,0 +1,35 @@
+import StatusChip, { type StatusTone } from "./StatusChip";
+
+interface ListCardProps {
+  title: string;
+  items: { title: string; meta: string; tone?: StatusTone }[];
+}
+
+export const ListCard: React.FC<ListCardProps> = ({ title, items }) => (
+  <section
+    style={{
+      background: "var(--surface-s1)",
+      borderRadius: "16px",
+      border: "1px solid var(--border-color)",
+      padding: "24px",
+      boxShadow: "var(--shadow-elevation)",
+      display: "grid",
+      gap: "16px"
+    }}
+  >
+    <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>{title}</h3>
+    <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: "12px" }}>
+      {items.map((item) => (
+        <li key={item.title} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <p style={{ margin: 0, fontWeight: 600 }}>{item.title}</p>
+            <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px" }}>{item.meta}</p>
+          </div>
+          {item.tone && <StatusChip label={item.meta} tone={item.tone} subtle />}
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default ListCard;

--- a/src/frontend/src/components/SegmentedTabs.tsx
+++ b/src/frontend/src/components/SegmentedTabs.tsx
@@ -1,0 +1,48 @@
+import { useId } from "react";
+
+export interface SegmentedTabItem {
+  id: string;
+  label: string;
+}
+
+interface SegmentedTabsProps {
+  items: SegmentedTabItem[];
+  activeId: string;
+  onChange: (id: string) => void;
+}
+
+export const SegmentedTabs: React.FC<SegmentedTabsProps> = ({ items, activeId, onChange }) => {
+  const tablistId = useId();
+  return (
+    <div role="tablist" aria-orientation="horizontal" id={tablistId} style={{ display: "inline-flex", borderRadius: "12px", border: "1px solid var(--border-color)" }}>
+      {items.map((item) => {
+        const isActive = item.id === activeId;
+        return (
+          <button
+            key={item.id}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`${tablistId}-${item.id}`}
+            id={`${tablistId}-tab-${item.id}`}
+            type="button"
+            onClick={() => onChange(item.id)}
+            style={{
+              padding: "12px 20px",
+              background: isActive ? "var(--primary-500)" : "transparent",
+              color: isActive ? "#fff" : "var(--text-primary)",
+              border: "none",
+              borderRadius: "12px",
+              cursor: "pointer",
+              fontWeight: 600,
+              transition: "background 180ms ease-in-out"
+            }}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SegmentedTabs;

--- a/src/frontend/src/components/StatusChip.tsx
+++ b/src/frontend/src/components/StatusChip.tsx
@@ -1,0 +1,36 @@
+import { clsx } from "clsx";
+
+export type StatusTone = "success" | "warning" | "danger" | "info" | "neutral";
+
+interface StatusChipProps {
+  label: string;
+  tone?: StatusTone;
+  subtle?: boolean;
+}
+
+export const StatusChip: React.FC<StatusChipProps> = ({ label, tone = "neutral", subtle }) => {
+  const background = subtle ? `var(--${tone}-100)` : `var(--${tone}-200)`;
+  const color = subtle ? `var(--${tone}-700)` : `var(--${tone}-800)`;
+  return (
+    <span
+      className={clsx("status-chip", tone)}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        padding: "6px 12px",
+        borderRadius: "999px",
+        background,
+        color,
+        fontSize: "12px",
+        fontWeight: 600,
+        border: `1px solid var(--${tone}-300)`
+      }}
+    >
+      <span style={{ width: 8, height: 8, borderRadius: "50%", background: `var(--${tone}-500)`, boxShadow: `0 0 0 1px var(--${tone}-50)` }} aria-hidden="true" />
+      {label}
+    </span>
+  );
+};
+
+export default StatusChip;

--- a/src/frontend/src/components/ThemeSwitcher.tsx
+++ b/src/frontend/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,32 @@
+import { availableThemes, useTheme } from "../theme/ThemeProvider";
+
+export const ThemeSwitcher: React.FC = () => {
+  const { theme, setThemeId } = useTheme();
+  return (
+    <div style={{ display: "inline-flex", gap: "8px", alignItems: "center" }}>
+      <label htmlFor="theme-select" style={{ fontSize: "12px", color: "var(--text-secondary)" }}>
+        Theme
+      </label>
+      <select
+        id="theme-select"
+        value={theme.id}
+        onChange={(event) => setThemeId(event.target.value as never)}
+        style={{
+          borderRadius: "12px",
+          border: "1px solid var(--border-color)",
+          padding: "8px 12px",
+          background: "var(--surface-s1)",
+          color: "var(--text-primary)"
+        }}
+      >
+        {availableThemes.map((item) => (
+          <option key={item.id} value={item.id}>
+            {item.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default ThemeSwitcher;

--- a/src/frontend/src/components/Tooltip.tsx
+++ b/src/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+interface TooltipProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ label, children }) => {
+  const [visible, setVisible] = useState(false);
+  return (
+    <span
+      style={{ position: "relative", display: "inline-flex" }}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+    >
+      {children}
+      {visible && (
+        <span
+          role="tooltip"
+          style={{
+            position: "absolute",
+            bottom: "calc(100% + 8px)",
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: "var(--neutral-900)",
+            color: "white",
+            padding: "8px 12px",
+            borderRadius: "8px",
+            fontSize: "12px",
+            zIndex: 10,
+            boxShadow: "var(--shadow-elevation)"
+          }}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+};

--- a/src/frontend/src/components/automation/AutomationBuilder.tsx
+++ b/src/frontend/src/components/automation/AutomationBuilder.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useToast } from "../toast/ToastContext";
+
+export interface AutomationStep {
+  id: string;
+  label: string;
+  description: string;
+}
+
+interface AutomationBuilderProps {
+  triggerOptions: AutomationStep[];
+  conditionOptions: AutomationStep[];
+  actionOptions: AutomationStep[];
+  cadenceOptions: AutomationStep[];
+  onSave: (payload: AutomationPayload) => Promise<void>;
+}
+
+export interface AutomationPayload {
+  trigger: string;
+  conditions: string[];
+  actions: string[];
+  cadence: string;
+  name: string;
+}
+
+export const AutomationBuilder: React.FC<AutomationBuilderProps> = ({
+  triggerOptions,
+  conditionOptions,
+  actionOptions,
+  cadenceOptions,
+  onSave
+}) => {
+  const [name, setName] = useState("");
+  const [trigger, setTrigger] = useState(triggerOptions[0]?.id ?? "");
+  const [conditions, setConditions] = useState<string[]>([]);
+  const [actions, setActions] = useState<string[]>([]);
+  const [cadence, setCadence] = useState(cadenceOptions[0]?.id ?? "");
+  const [loading, setLoading] = useState(false);
+  const { addToast } = useToast();
+
+  const toggleSelection = (value: string, setValue: (values: string[]) => void, values: string[]) => {
+    setValue(values.includes(value) ? values.filter((id) => id !== value) : [...values, value]);
+  };
+
+  const handleSave = async () => {
+    setLoading(true);
+    const payload: AutomationPayload = { name, trigger, conditions, actions, cadence };
+    const undoId = crypto.randomUUID();
+    addToast({
+      title: "Automation saved",
+      description: "Changes will sync across modules.",
+      tone: "success",
+      actionLabel: "Undo",
+      onAction: () => {
+        window.dispatchEvent(new CustomEvent("automation:undo", { detail: { id: undoId, payload } }));
+      }
+    });
+    try {
+      await onSave(payload);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        handleSave();
+      }}
+      style={{ display: "grid", gap: "24px" }}
+    >
+      <div>
+        <label htmlFor="automation-name" style={labelStyle}>
+          Automation name
+        </label>
+        <input
+          id="automation-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          required
+          style={inputStyle}
+        />
+      </div>
+      <StepSection title="Trigger" options={triggerOptions} selected={[trigger]} onToggle={(id) => setTrigger(id)} single />
+      <StepSection title="Conditions" options={conditionOptions} selected={conditions} onToggle={(id) => toggleSelection(id, setConditions, conditions)} />
+      <StepSection title="Actions" options={actionOptions} selected={actions} onToggle={(id) => toggleSelection(id, setActions, actions)} />
+      <StepSection title="Cadence" options={cadenceOptions} selected={[cadence]} onToggle={(id) => setCadence(id)} single />
+      <button type="submit" disabled={loading} className="focus-ring" style={submitStyle}>
+        {loading ? "Saving…" : "Save automation"}
+      </button>
+    </form>
+  );
+};
+
+interface StepSectionProps {
+  title: string;
+  options: AutomationStep[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  single?: boolean;
+}
+
+const StepSection: React.FC<StepSectionProps> = ({ title, options, selected, onToggle, single }) => (
+  <fieldset style={{ border: "1px solid var(--border-color)", borderRadius: "16px", padding: "16px 20px" }}>
+    <legend style={{ fontWeight: 600, fontSize: "14px" }}>{title}</legend>
+    <div style={{ display: "grid", gap: "12px" }}>
+      {options.map((option) => {
+        const isSelected = selected.includes(option.id);
+        return (
+          <button
+            key={option.id}
+            type="button"
+            role={single ? "radio" : "checkbox"}
+            aria-checked={isSelected}
+            onClick={() => onToggle(option.id)}
+            style={{
+              borderRadius: "12px",
+              border: isSelected ? "2px solid var(--primary-500)" : "1px solid var(--border-color)",
+              background: isSelected ? "var(--primary-50)" : "var(--surface-s1)",
+              padding: "12px 16px",
+              textAlign: "left",
+              cursor: "pointer"
+            }}
+          >
+            <span style={{ display: "block", fontWeight: 600 }}>{option.label}</span>
+            <span style={{ display: "block", fontSize: "12px", color: "var(--text-secondary)" }}>{option.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  </fieldset>
+);
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "12px",
+  color: "var(--text-secondary)",
+  marginBottom: "8px"
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  borderRadius: "12px",
+  border: "1px solid var(--border-color)",
+  padding: "12px 16px",
+  background: "var(--surface-s1)",
+  color: "var(--text-primary)"
+};
+
+const submitStyle: React.CSSProperties = {
+  borderRadius: "12px",
+  padding: "14px 20px",
+  border: "none",
+  background: "var(--primary-500)",
+  color: "#fff",
+  fontWeight: 600,
+  cursor: "pointer"
+};

--- a/src/frontend/src/components/charts/AccessibleAreaChart.tsx
+++ b/src/frontend/src/components/charts/AccessibleAreaChart.tsx
@@ -1,0 +1,41 @@
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
+
+interface AccessibleAreaChartProps<T> {
+  data: T[];
+  dataKey: keyof T & string;
+  areas: { key: keyof T & string; color: string; name: string; opacity?: number }[];
+}
+
+export function AccessibleAreaChart<T extends Record<string, number | string>>({ data, dataKey, areas }: AccessibleAreaChartProps<T>) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={data} role="img" aria-label="Area chart with saturation cues">
+        <defs>
+          {areas.map((area) => (
+            <linearGradient key={area.key} id={`${area.key}-gradient`} x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stopColor={area.color} stopOpacity={area.opacity ?? 0.6} />
+              <stop offset="100%" stopColor={area.color} stopOpacity={0.05} />
+            </linearGradient>
+          ))}
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-color)" />
+        <XAxis dataKey={dataKey} stroke="var(--text-secondary)" tickLine={false} />
+        <YAxis stroke="var(--text-secondary)" tickLine={false} width={64} />
+        <Tooltip />
+        <Legend />
+        {areas.map((area) => (
+          <Area
+            key={area.key}
+            type="monotone"
+            dataKey={area.key}
+            stroke={area.color}
+            strokeWidth={3}
+            fill={`url(#${area.key}-gradient)`}
+            name={area.name}
+            activeDot={{ r: 6 }}
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/frontend/src/components/charts/AccessibleBarChart.tsx
+++ b/src/frontend/src/components/charts/AccessibleBarChart.tsx
@@ -1,0 +1,33 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+
+interface AccessibleBarChartProps<T> {
+  data: T[];
+  dataKey: keyof T & string;
+  bars: { key: keyof T & string; color: string; name: string }[];
+  stacked?: boolean;
+}
+
+export function AccessibleBarChart<T extends Record<string, number | string>>({ data, dataKey, bars, stacked }: AccessibleBarChartProps<T>) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} role="img" aria-label="Bar chart with accessible focus">
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-color)" />
+        <XAxis dataKey={dataKey} stroke="var(--text-secondary)" tickLine={false} interval={0} angle={0} height={48} />
+        <YAxis stroke="var(--text-secondary)" tickLine={false} width={64} />
+        <Tooltip />
+        <Legend />
+        {bars.map((bar) => (
+          <Bar
+            key={bar.key}
+            dataKey={bar.key}
+            name={bar.name}
+            stackId={stacked ? "stack" : undefined}
+            fill={bar.color}
+            radius={[8, 8, 0, 0]}
+            barSize={32}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/frontend/src/components/charts/AccessibleDonutChart.tsx
+++ b/src/frontend/src/components/charts/AccessibleDonutChart.tsx
@@ -1,0 +1,36 @@
+import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+
+interface AccessibleDonutChartProps<T> {
+  data: T[];
+  valueKey: keyof T & string;
+  nameKey: keyof T & string;
+  colors: string[];
+}
+
+export function AccessibleDonutChart<T extends Record<string, number | string>>({ data, valueKey, nameKey, colors }: AccessibleDonutChartProps<T>) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart role="img" aria-label="Donut chart with outer labels and focus outlines">
+        <Pie
+          data={data}
+          dataKey={valueKey}
+          nameKey={nameKey}
+          innerRadius={70}
+          outerRadius={110}
+          paddingAngle={3}
+        >
+          {data.map((entry, index) => (
+            <Cell
+              key={`${String(entry[nameKey])}-${index}`}
+              fill={colors[index % colors.length]}
+              stroke="var(--surface-s0)"
+              strokeWidth={2}
+            />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend layout="vertical" align="right" verticalAlign="middle" />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/frontend/src/components/charts/AccessibleLineChart.tsx
+++ b/src/frontend/src/components/charts/AccessibleLineChart.tsx
@@ -1,0 +1,33 @@
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
+
+interface AccessibleLineChartProps<T> {
+  data: T[];
+  dataKey: keyof T & string;
+  lines: { key: keyof T & string; color: string; name: string }[];
+}
+
+export function AccessibleLineChart<T extends Record<string, number | string>>({ data, dataKey, lines }: AccessibleLineChartProps<T>) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} role="img" aria-label="Trend line chart with keyboard support">
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-color)" />
+        <XAxis dataKey={dataKey} stroke="var(--text-secondary)" tickLine={false} />
+        <YAxis stroke="var(--text-secondary)" tickLine={false} width={64} />
+        <Tooltip cursor={{ strokeDasharray: "4 4" }} />
+        <Legend />
+        {lines.map((line) => (
+          <Line
+            key={line.key}
+            type="monotone"
+            dataKey={line.key}
+            stroke={line.color}
+            strokeWidth={3}
+            dot={{ r: 4 }}
+            activeDot={{ r: 6 }}
+            name={line.name}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/frontend/src/components/charts/ChartCard.tsx
+++ b/src/frontend/src/components/charts/ChartCard.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { DataTable } from "../DataTable";
+
+interface ChartCardProps<T extends Record<string, unknown>> {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  data: T[];
+  columns: { key: keyof T & string; label: string }[];
+  ariaDescription?: string;
+}
+
+export function ChartCard<T extends Record<string, unknown>>({
+  title,
+  description,
+  children,
+  data,
+  columns,
+  ariaDescription
+}: ChartCardProps<T>) {
+  const [showTable, setShowTable] = useState(false);
+  return (
+    <section
+      style={{
+        background: "var(--surface-s1)",
+        borderRadius: "16px",
+        padding: "24px",
+        border: "1px solid var(--border-color)",
+        boxShadow: "var(--shadow-elevation)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px"
+      }}
+      aria-label={title}
+      aria-describedby={ariaDescription ? `${title}-desc` : undefined}
+    >
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>{title}</h3>
+          {description && (
+            <p id={`${title}-desc`} style={{ margin: "4px 0 0", fontSize: "12px", color: "var(--text-secondary)" }}>
+              {description}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowTable((value) => !value)}
+          className="focus-ring"
+          style={{
+            borderRadius: "999px",
+            padding: "8px 16px",
+            border: "1px solid var(--border-color)",
+            background: "var(--surface-s1)",
+            cursor: "pointer"
+          }}
+        >
+          {showTable ? "Show chart" : "Show data table"}
+        </button>
+      </header>
+      <div role="figure" aria-label={`${title} visualization`} style={{ minHeight: "240px" }}>
+        {showTable ? (
+          <DataTable id={`${title}-table`} columns={columns} data={data} />
+        ) : (
+          children
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/frontend/src/components/toast/ToastContext.tsx
+++ b/src/frontend/src/components/toast/ToastContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useCallback, useContext, useMemo, useReducer } from "react";
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  tone?: "success" | "info" | "warning" | "danger";
+  actionLabel?: string;
+  onAction?: () => void;
+  duration?: number;
+}
+
+interface ToastState {
+  toasts: Toast[];
+}
+
+const ToastContext = createContext<{
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, "id">) => void;
+  removeToast: (id: string) => void;
+} | null>(null);
+
+const reducer = (state: ToastState, action: { type: "ADD"; toast: Toast } | { type: "REMOVE"; id: string }): ToastState => {
+  switch (action.type) {
+    case "ADD":
+      return { toasts: [...state.toasts, action.toast] };
+    case "REMOVE":
+      return { toasts: state.toasts.filter((toast) => toast.id !== action.id) };
+    default:
+      return state;
+  }
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, { toasts: [] });
+
+  const addToast = useCallback((toast: Omit<Toast, "id">) => {
+    const id = crypto.randomUUID();
+    dispatch({ type: "ADD", toast: { ...toast, id } });
+    const duration = toast.duration ?? 6000;
+    if (duration > 0) {
+      window.setTimeout(() => dispatch({ type: "REMOVE", id }), duration);
+    }
+  }, []);
+
+  const removeToast = useCallback((id: string) => dispatch({ type: "REMOVE", id }), []);
+
+  const value = useMemo(() => ({ toasts: state.toasts, addToast, removeToast }), [addToast, removeToast, state.toasts]);
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error("useToast must be used within ToastProvider");
+  return context;
+};

--- a/src/frontend/src/components/toast/ToastViewport.tsx
+++ b/src/frontend/src/components/toast/ToastViewport.tsx
@@ -1,0 +1,77 @@
+import { useToast } from "./ToastContext";
+
+export const ToastViewport: React.FC = () => {
+  const { toasts, removeToast } = useToast();
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      role="region"
+      aria-label="Notifications"
+      style={{
+        position: "fixed",
+        right: "24px",
+        bottom: "24px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        zIndex: 1000,
+        maxWidth: "320px"
+      }}
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role="status"
+          style={{
+            background: "var(--surface-s1)",
+            border: `1px solid var(--${toast.tone ?? "info"}-300)` ,
+            borderRadius: "16px",
+            padding: "16px",
+            boxShadow: "var(--shadow-elevation)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px"
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "12px" }}>
+            <div>
+              <p style={{ margin: 0, fontWeight: 600 }}>{toast.title}</p>
+              {toast.description && (
+                <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>{toast.description}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => removeToast(toast.id)}
+              style={{ border: "none", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+              aria-label="Dismiss notification"
+            >
+              ×
+            </button>
+          </div>
+          {toast.actionLabel && toast.onAction && (
+            <button
+              type="button"
+              onClick={() => {
+                toast.onAction?.();
+                removeToast(toast.id);
+              }}
+              style={{
+                alignSelf: "flex-start",
+                borderRadius: "999px",
+                padding: "8px 16px",
+                border: "none",
+                background: `var(--${toast.tone ?? "info"}-500)`,
+                color: "#fff",
+                cursor: "pointer"
+              }}
+            >
+              {toast.actionLabel}
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/frontend/src/data/fixtures.ts
+++ b/src/frontend/src/data/fixtures.ts
@@ -1,0 +1,694 @@
+import type { ModuleId } from "./modules";
+
+export interface Kpi {
+  id: string;
+  label: string;
+  value: number;
+  type: "currency" | "number" | "percent" | "duration";
+  delta: number;
+  deltaLabel: string;
+  timeBasis: string;
+}
+
+export interface TableRow extends Record<string, string | number> {}
+
+export interface ChartDatum extends Record<string, string | number> {}
+
+export interface ModuleFixture {
+  accentToken: string;
+  kpis: Kpi[];
+  tables: Record<string, { columns: { key: string; label: string; align?: "start" | "end" }[]; rows: TableRow[] }>;
+  charts: Record<string, ChartDatum[]>;
+  descriptions: Record<string, string>;
+  automations: {
+    triggers: { id: string; label: string; description: string }[];
+    conditions: { id: string; label: string; description: string }[];
+    actions: { id: string; label: string; description: string }[];
+    cadences: { id: string; label: string; description: string }[];
+  };
+  lists: Record<string, { title: string; items: { title: string; meta: string; tone?: string }[] }>;
+}
+
+export const fixtures: Record<ModuleId, ModuleFixture> = {
+  saas: {
+    accentToken: "var(--vertical-saas)",
+    kpis: [
+      { id: "mrr", label: "Monthly Recurring Revenue", value: 420000, type: "currency", delta: 0.06, deltaLabel: "Up 6% vs last month", timeBasis: "vs. prior month" },
+      { id: "workspaces", label: "Active Workspaces", value: 1280, type: "number", delta: 0.03, deltaLabel: "Up 3%", timeBasis: "30-day active" },
+      { id: "api", label: "API Consumption (30-day)", value: 7800000, type: "number", delta: -0.02, deltaLabel: "Down 2%", timeBasis: "Requests" },
+      { id: "nrr", label: "Net Revenue Retention", value: 1.12, type: "percent", delta: 0.01, deltaLabel: "Up 1 pt", timeBasis: "Rolling 12 months" }
+    ],
+    tables: {
+      plans: {
+        columns: [
+          { key: "plan", label: "Plan" },
+          { key: "price", label: "Price" },
+          { key: "seats", label: "Seats" },
+          { key: "activation", label: "Activation" },
+          { key: "allocation", label: "Allocation" },
+          { key: "churn", label: "Churn", align: "end" }
+        ],
+        rows: [
+          { plan: "Starter", price: "$49", seats: 25, activation: "92%", allocation: "88%", churn: "1.2%" },
+          { plan: "Growth", price: "$199", seats: 100, activation: "87%", allocation: "79%", churn: "2.8%" },
+          { plan: "Scale", price: "$499", seats: 500, activation: "81%", allocation: "72%", churn: "4.6%" },
+          { plan: "Enterprise", price: "Custom", seats: 2000, activation: "75%", allocation: "61%", churn: "3.2%" }
+        ]
+      }
+    },
+    charts: {
+      churnHealth: [
+        { stage: "Healthy", value: 62 },
+        { stage: "Monitor", value: 28 },
+        { stage: "Critical", value: 10 }
+      ],
+      mrrGrowth: [
+        { month: "Jan", mrr: 360000 },
+        { month: "Feb", mrr: 372000 },
+        { month: "Mar", mrr: 388000 },
+        { month: "Apr", mrr: 402000 },
+        { month: "May", mrr: 415000 },
+        { month: "Jun", mrr: 420000 }
+      ],
+      apiUsage: [
+        { day: "Mon", saturation: 64 },
+        { day: "Tue", saturation: 72 },
+        { day: "Wed", saturation: 88 },
+        { day: "Thu", saturation: 90 },
+        { day: "Fri", saturation: 76 }
+      ]
+    },
+    descriptions: {
+      churnHealth: "Current customer health segmentation with action cues.",
+      mrrGrowth: "MRR progression across the last six months.",
+      apiUsage: "API saturation compared with allocated capacity."
+    },
+    automations: {
+      triggers: [
+        { id: "api-drop", label: "API drop", description: "Detect >15% drop in daily calls" },
+        { id: "seat-underuse", label: "Seat underuse", description: "Seats <60% utilization" },
+        { id: "nrr-dip", label: "NRR dip", description: "Net retention <105%" }
+      ],
+      conditions: [
+        { id: "plan-tier", label: "Plan tier", description: "Enterprise + Scale" },
+        { id: "region", label: "Region", description: "North America" },
+        { id: "risk-score", label: "Risk score", description: ">0.7 predictive churn" }
+      ],
+      actions: [
+        { id: "csm-task", label: "Create CSM task", description: "Assign to workspace owner" },
+        { id: "email", label: "Send in-app/email nudge", description: "Share utilization tips" },
+        { id: "slack", label: "Post to Slack", description: "Notify escalation channel" }
+      ],
+      cadences: [
+        { id: "immediate", label: "Immediate", description: "Instant action" },
+        { id: "daily", label: "Daily digest", description: "Queue for daily run" },
+        { id: "weekly", label: "Weekly", description: "Bundle for weekly review" }
+      ]
+    },
+    lists: {
+      orchestration: {
+        title: "Billing cycle orchestration",
+        items: [
+          { title: "Card expirations", meta: "42 upcoming", tone: "warning" },
+          { title: "Dunning queue", meta: "18 accounts", tone: "danger" },
+          { title: "Monthly close checklist", meta: "On track", tone: "success" }
+        ]
+      },
+      playbooks: {
+        title: "Churn recovery playbook",
+        items: [
+          { title: "Template: Platform adoption", meta: "Fallback owner: Jamie" },
+          { title: "Trigger threshold", meta: "Usage saturation <65%" },
+          { title: "Preview", meta: "Warm touch email" }
+        ]
+      }
+    }
+  },
+  ecommerce: {
+    accentToken: "var(--vertical-ecommerce)",
+    kpis: [
+      { id: "gmv", label: "GMV", value: 985000, type: "currency", delta: 0.08, deltaLabel: "Up 8%", timeBasis: "vs last week" },
+      { id: "orders", label: "Orders (7-day)", value: 18240, type: "number", delta: 0.04, deltaLabel: "Up 4%", timeBasis: "Last 7 days" },
+      { id: "aov", label: "Average Order Value", value: 142, type: "currency", delta: 0.02, deltaLabel: "Up $2", timeBasis: "vs last week" },
+      { id: "returns", label: "Return rate", value: 0.064, type: "percent", delta: -0.01, deltaLabel: "Down 1 pt", timeBasis: "Rolling 30 days" }
+    ],
+    tables: {
+      topProducts: {
+        columns: [
+          { key: "product", label: "Product" },
+          { key: "category", label: "Category" },
+          { key: "revenue", label: "Revenue" },
+          { key: "conversion", label: "Conversion" },
+          { key: "inventory", label: "Inventory" },
+          { key: "trend", label: "Trend" }
+        ],
+        rows: [
+          { product: "Aurora Hoodie", category: "Apparel", revenue: "$182K", conversion: "4.8%", inventory: "32 days", trend: "▲" },
+          { product: "Trail Runner", category: "Footwear", revenue: "$145K", conversion: "3.1%", inventory: "18 days", trend: "▲" },
+          { product: "Summit Bottle", category: "Accessories", revenue: "$98K", conversion: "6.5%", inventory: "44 days", trend: "▬" }
+        ]
+      }
+    },
+    charts: {
+      salesTrend: [
+        { week: "Week 1", ecommerce: 210000 },
+        { week: "Week 2", ecommerce: 240000 },
+        { week: "Week 3", ecommerce: 260000 },
+        { week: "Week 4", ecommerce: 275000 }
+      ],
+      operationalHealth: [
+        { category: "Fulfillment SLA", status: 96 },
+        { category: "Payment health", status: 92 },
+        { category: "Support backlog", status: 18 }
+      ]
+    },
+    descriptions: {
+      salesTrend: "Stacked comparison of promo vs evergreen sales.",
+      operationalHealth: "Operational signal health across fulfillment and support."
+    },
+    automations: {
+      triggers: [
+        { id: "abandoned", label: "Abandoned cart", description: ">$200 AOV segments" },
+        { id: "inventory", label: "Inventory threshold", description: "Days of cover < 12" },
+        { id: "returns", label: "High return SKU", description: ">18% return rate" }
+      ],
+      conditions: [
+        { id: "audience", label: "Audience", description: "VIP + Loyalty" },
+        { id: "channel", label: "Channel", description: "Email + SMS" },
+        { id: "guardrail", label: "Throttling guardrail", description: "Respect stock limits" }
+      ],
+      actions: [
+        { id: "campaign", label: "Launch campaign", description: "Trigger promotion builder" },
+        { id: "sms", label: "Send SMS", description: "Twilio integration" },
+        { id: "pause", label: "Pause ads", description: "Meta/Google throttle" }
+      ],
+      cadences: [
+        { id: "burst", label: "Burst", description: "Rapid 4h cadence" },
+        { id: "daily", label: "Daily", description: "Daily sync" },
+        { id: "weekly", label: "Weekly", description: "Weekly rollup" }
+      ]
+    },
+    lists: {
+      promotionBuilder: {
+        title: "Seasonal promotion guardrails",
+        items: [
+          { title: "Campaign: Summer launch", meta: "Audience: VIP + high intent" },
+          { title: "Incentive", meta: "Buy 2 get 20%" },
+          { title: "Throttle", meta: "Inventory floor: 15 days" }
+        ]
+      },
+      automation: {
+        title: "Automation orchestration",
+        items: [
+          { title: "Abandoned cart", meta: "Live • 3 touch series", tone: "success" },
+          { title: "Inventory replenish", meta: "Paused • awaiting PO", tone: "warning" },
+          { title: "VIP delight", meta: "Draft • needs creative", tone: "info" }
+        ]
+      }
+    }
+  },
+  analytics: {
+    accentToken: "var(--vertical-analytics)",
+    kpis: [
+      { id: "pipeline", label: "Qualified pipeline", value: 12_800_000, type: "currency", delta: 0.12, deltaLabel: "Up 12%", timeBasis: "Current quarter" },
+      { id: "visitors", label: "Monthly unique visitors", value: 280000, type: "number", delta: 0.05, deltaLabel: "Up 5%", timeBasis: "Last 30 days" },
+      { id: "conversion", label: "M→SQL conversion", value: 0.18, type: "percent", delta: 0.02, deltaLabel: "Up 2 pts", timeBasis: "Rolling 90 days" },
+      { id: "cycle", label: "Sales cycle", value: 42 * 60, type: "duration", delta: -0.05, deltaLabel: "Down 5%", timeBasis: "Avg days" }
+    ],
+    tables: {
+      executive: {
+        columns: [
+          { key: "insight", label: "Insight" },
+          { key: "context", label: "Context" }
+        ],
+        rows: [
+          { insight: "ABM programs contributed 38% of pipeline", context: "B2B field events driving outsized SQLs" },
+          { insight: "Creative fatigue detected on paid social", context: "Shift 12% budget to retargeting" },
+          { insight: "Partner referrals up 22%", context: "Enablement kit adoption up" }
+        ]
+      }
+    },
+    charts: {
+      funnel: [
+        { stage: "Visitors", value: 280000 },
+        { stage: "Marketing qualified", value: 54000 },
+        { stage: "Sales qualified", value: 14200 },
+        { stage: "Opportunities", value: 6200 },
+        { stage: "Closed", value: 2100 }
+      ],
+      leadMix: [
+        { source: "Organic", share: 34 },
+        { source: "Paid", share: 26 },
+        { source: "Partners", share: 18 },
+        { source: "Events", share: 12 },
+        { source: "Product", share: 10 }
+      ]
+    },
+    descriptions: {
+      funnel: "Conversion funnel from visitors through closed won.",
+      leadMix: "Lead source mix sorted by contribution."
+    },
+    automations: {
+      triggers: [
+        { id: "intent", label: "Intent surge", description: "6sense score > 90" },
+        { id: "sla", label: "Lifecycle SLA", description: "MQL aging > 12h" },
+        { id: "attribution", label: "Attribution guardrail", description: "ROAS < 1.5" }
+      ],
+      conditions: [
+        { id: "segment", label: "Segment", description: "Enterprise" },
+        { id: "owner", label: "Owner", description: "Route to SDR pod" },
+        { id: "budget", label: "Budget", description: "Reallocate underperforming spend" }
+      ],
+      actions: [
+        { id: "route", label: "Route to SDR", description: "Assign & post to Slack" },
+        { id: "boost", label: "Boost winner", description: "Increase spend 10%" },
+        { id: "pause", label: "Pause creative", description: "Notify paid team" }
+      ],
+      cadences: [
+        { id: "instant", label: "Instant", description: "Immediately" },
+        { id: "hourly", label: "Hourly", description: "Hourly sync" },
+        { id: "daily", label: "Daily", description: "Daily digest" }
+      ]
+    },
+    lists: {
+      insights: {
+        title: "Executive insights",
+        items: [
+          { title: "Pipeline coverage 3.8x target", meta: "All segments", tone: "success" },
+          { title: "Paid social fatigue", meta: "Consider creative refresh", tone: "warning" },
+          { title: "Partner referrals climbing", meta: "Enablement kit performing" }
+        ]
+      }
+    }
+  },
+  customapp: {
+    accentToken: "var(--vertical-customapp)",
+    kpis: [
+      { id: "velocity", label: "Delivery velocity", value: 74, type: "number", delta: 0.04, deltaLabel: "Up 4%", timeBasis: "Story points/week" },
+      { id: "ideas", label: "Idea intake", value: 56, type: "number", delta: -0.12, deltaLabel: "Down 12%", timeBasis: "Last 30 days" },
+      { id: "automation", label: "Automations live", value: 18, type: "number", delta: 0.2, deltaLabel: "Up 20%", timeBasis: "Active workflows" },
+      { id: "happiness", label: "Team health", value: 0.86, type: "percent", delta: 0.03, deltaLabel: "Up 3 pts", timeBasis: "Weekly pulse" }
+    ],
+    tables: {
+      backlog: {
+        columns: [
+          { key: "idea", label: "Idea" },
+          { key: "impact", label: "Impact" },
+          { key: "effort", label: "Effort" },
+          { key: "status", label: "Status" }
+        ],
+        rows: [
+          { idea: "Unified notification center", impact: "High", effort: "Medium", status: "Ready" },
+          { idea: "AI brief assistant", impact: "Medium", effort: "Low", status: "In discovery" },
+          { idea: "Workflow templates", impact: "High", effort: "Medium", status: "Refinement" }
+        ]
+      }
+    },
+    charts: {
+      workload: [
+        { lane: "Backlog", tasks: 32 },
+        { lane: "In progress", tasks: 18 },
+        { lane: "Review", tasks: 9 },
+        { lane: "Done", tasks: 54 }
+      ]
+    },
+    descriptions: {
+      workload: "Task distribution across delivery lanes."
+    },
+    automations: {
+      triggers: [
+        { id: "ritual", label: "Sprint ritual", description: "Schedule planning & retro" },
+        { id: "workload", label: "Workload imbalance", description: ">20% delta" },
+        { id: "stale", label: "Stale ticket", description: ">5 days idle" }
+      ],
+      conditions: [
+        { id: "team", label: "Team", description: "Team Alpha" },
+        { id: "priority", label: "Priority", description: "High" },
+        { id: "devops", label: "DevOps hook", description: "PR merged" }
+      ],
+      actions: [
+        { id: "nudge", label: "Send nudge", description: "Slack message" },
+        { id: "schedule", label: "Schedule ritual", description: "Calendar invite" },
+        { id: "rebalance", label: "Suggest rebalancing", description: "Shift to available owner" }
+      ],
+      cadences: [
+        { id: "once", label: "One-time", description: "Run immediately" },
+        { id: "recurring", label: "Recurring", description: "Weekly" },
+        { id: "monthly", label: "Monthly", description: "Monthly reset" }
+      ]
+    },
+    lists: {
+      kanban: {
+        title: "Kanban lanes",
+        items: [
+          { title: "Backlog", meta: "32 cards", tone: "info" },
+          { title: "In progress", meta: "18 cards", tone: "warning" },
+          { title: "Review", meta: "9 cards" }
+        ]
+      }
+    }
+  },
+  media: {
+    accentToken: "var(--vertical-media)",
+    kpis: [
+      { id: "plays", label: "Monthly plays/reads", value: 1_800_000, type: "number", delta: 0.11, deltaLabel: "Up 11%", timeBasis: "Rolling 30 days" },
+      { id: "watch", label: "Avg watch time", value: 5 * 60 + 42, type: "duration", delta: 0.04, deltaLabel: "Up 4%", timeBasis: "mm:ss" },
+      { id: "subs", label: "Subscriber growth", value: 0.072, type: "percent", delta: 0.01, deltaLabel: "Up 1 pt", timeBasis: "vs last month" },
+      { id: "engagement", label: "Engagement score", value: 86, type: "number", delta: 0.05, deltaLabel: "Up 5%", timeBasis: "Composite" }
+    ],
+    tables: {
+      stories: {
+        columns: [
+          { key: "title", label: "Title" },
+          { key: "format", label: "Format" },
+          { key: "window", label: "Window" },
+          { key: "engagement", label: "Engagement" },
+          { key: "status", label: "Status" }
+        ],
+        rows: [
+          { title: "AI in production", format: "Video", window: "7 days", engagement: "92", status: "Ready" },
+          { title: "Supply chain deep dive", format: "Article", window: "30 days", engagement: "88", status: "In review" },
+          { title: "Leadership AMA", format: "Podcast", window: "14 days", engagement: "76", status: "Blocked" }
+        ]
+      }
+    },
+    charts: {
+      engagement: [
+        { day: "Mon", engagement: 72 },
+        { day: "Tue", engagement: 78 },
+        { day: "Wed", engagement: 88 },
+        { day: "Thu", engagement: 92 },
+        { day: "Fri", engagement: 86 }
+      ]
+    },
+    descriptions: {
+      engagement: "Engagement trend with markers for spikes."
+    },
+    automations: {
+      triggers: [
+        { id: "control", label: "Editorial control", description: "Advance statuses" },
+        { id: "tagging", label: "Auto-tagging", description: "Taxonomy enforcement" },
+        { id: "highlight", label: "Highlight reel", description: "Auto clip" }
+      ],
+      conditions: [
+        { id: "channel", label: "Channel", description: "YouTube + OTT" },
+        { id: "compliance", label: "Compliance", description: "Brand safety" },
+        { id: "rights", label: "Rights window", description: "Check expiration" }
+      ],
+      actions: [
+        { id: "publish", label: "Publish", description: "Omnichannel launch" },
+        { id: "annotate", label: "Annotate", description: "Apply taxonomy" },
+        { id: "distribute", label: "Distribute highlights", description: "Send to social" }
+      ],
+      cadences: [
+        { id: "real-time", label: "Real time", description: "On publish" },
+        { id: "hourly", label: "Hourly", description: "Hourly sync" },
+        { id: "daily", label: "Daily", description: "Daily health" }
+      ]
+    },
+    lists: {
+      queue: {
+        title: "Publishing queue",
+        items: [
+          { title: "AI in production", meta: "Ready", tone: "success" },
+          { title: "Supply chain deep dive", meta: "In review", tone: "warning" },
+          { title: "Leadership AMA", meta: "Blocked", tone: "danger" }
+        ]
+      }
+    }
+  },
+  edtech: {
+    accentToken: "var(--vertical-edtech)",
+    kpis: [
+      { id: "learners", label: "Active learners", value: 45200, type: "number", delta: 0.07, deltaLabel: "Up 7%", timeBasis: "Rolling 30 days" },
+      { id: "completion", label: "Completion rate", value: 0.78, type: "percent", delta: 0.03, deltaLabel: "Up 3 pts", timeBasis: "Course completion" },
+      { id: "quiz", label: "Avg quiz score", value: 0.84, type: "percent", delta: 0.02, deltaLabel: "Up 2 pts", timeBasis: "All quizzes" },
+      { id: "certs", label: "Certificates issued", value: 1240, type: "number", delta: 0.16, deltaLabel: "Up 16%", timeBasis: "Monthly" }
+    ],
+    tables: {
+      programs: {
+        columns: [
+          { key: "course", label: "Course" },
+          { key: "enrollment", label: "Enrollment" },
+          { key: "completion", label: "Completion" },
+          { key: "score", label: "Avg score" }
+        ],
+        rows: [
+          { course: "Data Science 201", enrollment: 3200, completion: "82%", score: "88" },
+          { course: "Cybersecurity Essentials", enrollment: 2800, completion: "74%", score: "81" },
+          { course: "Leadership Lab", enrollment: 1800, completion: "69%", score: "85" }
+        ]
+      }
+    },
+    charts: {
+      activity: [
+        { day: "Mon", active: 6200 },
+        { day: "Tue", active: 6400 },
+        { day: "Wed", active: 7100 },
+        { day: "Thu", active: 6800 },
+        { day: "Fri", active: 5900 }
+      ]
+    },
+    descriptions: {
+      activity: "Student activity intensity heatmap proxy."
+    },
+    automations: {
+      triggers: [
+        { id: "certificate", label: "Auto certificate", description: "On completion" },
+        { id: "inactivity", label: "Inactivity nudge", description: ">7 days" },
+        { id: "mentor", label: "Mentor rotation", description: "Balance load" }
+      ],
+      conditions: [
+        { id: "program", label: "Program", description: "Leadership track" },
+        { id: "cohort", label: "Cohort", description: "Spring" },
+        { id: "integrity", label: "Integrity flag", description: "Proctoring" }
+      ],
+      actions: [
+        { id: "badge", label: "Issue badge", description: "Open Badges" },
+        { id: "email", label: "Send email", description: "Mentor update" },
+        { id: "queue", label: "Add to review queue", description: "Mastery dips" }
+      ],
+      cadences: [
+        { id: "instant", label: "Instant", description: "Immediate" },
+        { id: "daily", label: "Daily", description: "Daily digest" },
+        { id: "weekly", label: "Weekly", description: "Weekly review" }
+      ]
+    },
+    lists: {
+      orchestration: {
+        title: "Automation orchestration",
+        items: [
+          { title: "Auto certificates", meta: "Live", tone: "success" },
+          { title: "Inactivity nudges", meta: "Tuning thresholds", tone: "warning" },
+          { title: "Mentor rotation", meta: "Draft" }
+        ]
+      }
+    }
+  },
+  realestate: {
+    accentToken: "var(--vertical-realestate)",
+    kpis: [
+      { id: "listings", label: "Active listings", value: 860, type: "number", delta: 0.05, deltaLabel: "Up 5%", timeBasis: "Rolling 30 days" },
+      { id: "inquiries", label: "Qualified inquiries", value: 1240, type: "number", delta: 0.09, deltaLabel: "Up 9%", timeBasis: "Per week" },
+      { id: "response", label: "Avg response time", value: 18 * 60, type: "duration", delta: -0.12, deltaLabel: "Down 12%", timeBasis: "Minutes" }
+    ],
+    tables: {
+      listings: {
+        columns: [
+          { key: "title", label: "Listing" },
+          { key: "location", label: "Location" },
+          { key: "price", label: "Price" },
+          { key: "status", label: "Status" }
+        ],
+        rows: [
+          { title: "Skyline Lofts", location: "Seattle, WA", price: "$1.2M", status: "Active" },
+          { title: "Harbor Townhomes", location: "Boston, MA", price: "$890K", status: "Under offer" },
+          { title: "Sunset Villas", location: "Austin, TX", price: "$1.05M", status: "Active" }
+        ]
+      }
+    },
+    charts: {
+      momentum: [
+        { month: "Jan", momentum: 48 },
+        { month: "Feb", momentum: 54 },
+        { month: "Mar", momentum: 60 },
+        { month: "Apr", momentum: 66 },
+        { month: "May", momentum: 72 }
+      ]
+    },
+    descriptions: {
+      momentum: "Market momentum with absorption index"
+    },
+    automations: {
+      triggers: [
+        { id: "new-lead", label: "New inquiry", description: "Notify agent" },
+        { id: "stale", label: "Stale listing", description: ">14 days" },
+        { id: "momentum", label: "Momentum drop", description: "Index < 45" }
+      ],
+      conditions: [
+        { id: "region", label: "Region", description: "West" },
+        { id: "price", label: "Price band", description: "$900K-$1.5M" },
+        { id: "team", label: "Team", description: "Luxury" }
+      ],
+      actions: [
+        { id: "assign", label: "Assign agent", description: "Notify via app" },
+        { id: "campaign", label: "Launch nurture", description: "Email drip" },
+        { id: "update", label: "Update listing", description: "Refresh creative" }
+      ],
+      cadences: [
+        { id: "instant", label: "Instant", description: "Immediate" },
+        { id: "daily", label: "Daily", description: "Daily summary" },
+        { id: "weekly", label: "Weekly", description: "Weekly review" }
+      ]
+    },
+    lists: {
+      inquiries: {
+        title: "Listings & inquiries",
+        items: [
+          { title: "Skyline Lofts", meta: "New tour scheduled", tone: "info" },
+          { title: "Harbor Townhomes", meta: "Awaiting docs", tone: "warning" },
+          { title: "Sunset Villas", meta: "High intent", tone: "success" }
+        ]
+      }
+    }
+  },
+  finance: {
+    accentToken: "var(--vertical-finance)",
+    kpis: [
+      { id: "expense", label: "Expenses", value: 4_200_000, type: "currency", delta: 0.04, deltaLabel: "Up 4%", timeBasis: "vs budget" },
+      { id: "budget", label: "Budget", value: 4_000_000, type: "currency", delta: 0.02, deltaLabel: "Up 2%", timeBasis: "YTD" },
+      { id: "roi", label: "ROI", value: 0.36, type: "percent", delta: 0.03, deltaLabel: "Up 3 pts", timeBasis: "Rolling 12 months" }
+    ],
+    tables: {
+      spend: {
+        columns: [
+          { key: "category", label: "Category" },
+          { key: "actual", label: "Actual" },
+          { key: "budget", label: "Budget" },
+          { key: "variance", label: "Variance" }
+        ],
+        rows: [
+          { category: "Cloud", actual: "$1.2M", budget: "$1.1M", variance: "+$100K" },
+          { category: "Payroll", actual: "$1.5M", budget: "$1.6M", variance: "-$100K" },
+          { category: "Marketing", actual: "$900K", budget: "$800K", variance: "+$100K" }
+        ]
+      }
+    },
+    charts: {
+      expenseTrend: [
+        { month: "Jan", actual: 320000, budget: 300000 },
+        { month: "Feb", actual: 340000, budget: 320000 },
+        { month: "Mar", actual: 360000, budget: 330000 },
+        { month: "Apr", actual: 380000, budget: 340000 },
+        { month: "May", actual: 410000, budget: 360000 }
+      ],
+      roiBreakdown: [
+        { channel: "Product", roi: 38 },
+        { channel: "Services", roi: 28 },
+        { channel: "Marketplace", roi: 22 },
+        { channel: "Other", roi: 12 }
+      ]
+    },
+    descriptions: {
+      expenseTrend: "Expense vs budget variance lines.",
+      roiBreakdown: "ROI breakdown with high contrast segments."
+    },
+    automations: {
+      triggers: [
+        { id: "month-close", label: "Month-end close", description: "Checklist orchestration" },
+        { id: "expense-ocr", label: "Expense routing", description: "OCR + policy" },
+        { id: "anomaly", label: "Anomaly detection", description: ">10% variance" }
+      ],
+      conditions: [
+        { id: "entity", label: "Entity", description: "Subsidiary" },
+        { id: "policy", label: "Policy", description: "PCI compliance" },
+        { id: "owner", label: "Owner", description: "Finance controller" }
+      ],
+      actions: [
+        { id: "notify", label: "Notify", description: "Slack + Email" },
+        { id: "reconcile", label: "Reconcile", description: "Stripe + ERP" },
+        { id: "escalate", label: "Escalate", description: "Exec review" }
+      ],
+      cadences: [
+        { id: "instant", label: "Instant", description: "Real time" },
+        { id: "daily", label: "Daily", description: "Daily ledger" },
+        { id: "weekly", label: "Weekly", description: "Weekly digest" }
+      ]
+    },
+    lists: {
+      compliance: {
+        title: "Compliance hooks",
+        items: [
+          { title: "PCI scope", meta: "In compliance", tone: "success" },
+          { title: "Audit log", meta: "12 new entries", tone: "info" }
+        ]
+      }
+    }
+  },
+  healthcare: {
+    accentToken: "var(--vertical-healthcare)",
+    kpis: [
+      { id: "patients", label: "Active patients", value: 18400, type: "number", delta: 0.05, deltaLabel: "Up 5%", timeBasis: "Rolling 30 days" },
+      { id: "satisfaction", label: "Patient satisfaction", value: 0.91, type: "percent", delta: 0.02, deltaLabel: "Up 2 pts", timeBasis: "CAHPS" },
+      { id: "throughput", label: "Avg wait", value: 12 * 60, type: "duration", delta: -0.08, deltaLabel: "Down 8%", timeBasis: "Minutes" }
+    ],
+    tables: {
+      appointments: {
+        columns: [
+          { key: "provider", label: "Provider" },
+          { key: "specialty", label: "Specialty" },
+          { key: "appointments", label: "Appointments" },
+          { key: "status", label: "Status" }
+        ],
+        rows: [
+          { provider: "Dr. Patel", specialty: "Cardiology", appointments: 42, status: "On track" },
+          { provider: "Dr. Chen", specialty: "Endocrinology", appointments: 36, status: "Slight delay" },
+          { provider: "Dr. Lopez", specialty: "Pediatrics", appointments: 58, status: "On track" }
+        ]
+      }
+    },
+    charts: {
+      marketMomentum: [
+        { month: "Jan", momentum: 62 },
+        { month: "Feb", momentum: 64 },
+        { month: "Mar", momentum: 68 },
+        { month: "Apr", momentum: 70 },
+        { month: "May", momentum: 74 }
+      ]
+    },
+    descriptions: {
+      marketMomentum: "Patient momentum and satisfaction trends."
+    },
+    automations: {
+      triggers: [
+        { id: "reminder", label: "Appointment reminder", description: "SMS/Email" },
+        { id: "reschedule", label: "Smart reschedule", description: "Two-way" },
+        { id: "csat", label: "Post-visit CSAT", description: "Send survey" }
+      ],
+      conditions: [
+        { id: "department", label: "Department", description: "Outpatient" },
+        { id: "compliance", label: "Compliance", description: "HIPAA + audit" },
+        { id: "acuity", label: "Acuity", description: "High" }
+      ],
+      actions: [
+        { id: "message", label: "Send message", description: "Twilio integration" },
+        { id: "task", label: "Create task", description: "Care team" },
+        { id: "log", label: "Log to EHR", description: "FHIR event" }
+      ],
+      cadences: [
+        { id: "immediate", label: "Immediate", description: "Real time" },
+        { id: "daily", label: "Daily", description: "Daily summary" },
+        { id: "weekly", label: "Weekly", description: "Weekly digest" }
+      ]
+    },
+    lists: {
+      compliance: {
+        title: "Compliance & safeguards",
+        items: [
+          { title: "HIPAA audit log", meta: "Up to date", tone: "success" },
+          { title: "PHI masking", meta: "Enabled", tone: "info" }
+        ]
+      }
+    }
+  }
+};

--- a/src/frontend/src/data/modules.ts
+++ b/src/frontend/src/data/modules.ts
@@ -1,0 +1,29 @@
+export type ModuleId =
+  | "saas"
+  | "ecommerce"
+  | "analytics"
+  | "customapp"
+  | "media"
+  | "edtech"
+  | "realestate"
+  | "finance"
+  | "healthcare";
+
+export interface ModuleDefinition {
+  id: ModuleId;
+  name: string;
+  path: string;
+  description: string;
+}
+
+export const modules: ModuleDefinition[] = [
+  { id: "saas", name: "SaaS Operations", path: "/saas", description: "Subscription intelligence & API ops" },
+  { id: "ecommerce", name: "E-commerce", path: "/ecommerce", description: "Merchandising, orders & fulfillment" },
+  { id: "analytics", name: "Corporate Analytics", path: "/analytics", description: "Growth marketing & pipeline" },
+  { id: "customapp", name: "Productivity Suite", path: "/custom-app", description: "Custom web app delivery" },
+  { id: "media", name: "Content & Media", path: "/media", description: "Publishing workflow & engagement" },
+  { id: "edtech", name: "EdTech", path: "/edtech", description: "Learning analytics & student success" },
+  { id: "realestate", name: "Real Estate", path: "/real-estate", description: "Listings & momentum" },
+  { id: "finance", name: "Finance", path: "/finance", description: "Expense vs budget & ROI" },
+  { id: "healthcare", name: "Healthcare", path: "/healthcare", description: "Appointments & satisfaction" }
+];

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1,0 +1,85 @@
+:root {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-feature-settings: 'tnum' 1, 'lnum' 1;
+  background: var(--surface-s0);
+  color: var(--text-primary);
+  accent-color: var(--primary-500);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--surface-s0);
+  color: var(--text-primary);
+}
+
+.skeleton {
+  width: 100%;
+  height: 32px;
+  border-radius: 12px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.08));
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+a {
+  color: inherit;
+}
+
+button, input, select, textarea {
+  font: inherit;
+}
+
+.focus-ring:focus-visible,
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+[role="button"]:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.grid-container {
+  display: grid;
+  gap: 24px;
+}
+
+@media (max-width: 1024px) {
+  .grid-container {
+    gap: 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .grid-container {
+    gap: 12px;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+:root[dir="rtl"] {
+  direction: rtl;
+}

--- a/src/frontend/src/layouts/AppLayout.tsx
+++ b/src/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,70 @@
+import { NavLink } from "react-router-dom";
+import { modules } from "../data/modules";
+import ThemeSwitcher from "../components/ThemeSwitcher";
+import GlobalFilterBar from "../components/GlobalFilterBar";
+import { ToastProvider } from "../components/toast/ToastContext";
+import { ToastViewport } from "../components/toast/ToastViewport";
+
+const navStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "8px",
+  flexWrap: "wrap"
+};
+
+const linkStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: "12px",
+  textDecoration: "none",
+  fontWeight: 600,
+  border: "1px solid transparent"
+};
+
+export const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <ToastProvider>
+      <div style={{ minHeight: "100vh", background: "var(--surface-s0)", color: "var(--text-primary)", display: "flex", flexDirection: "column" }}>
+        <header
+          style={{
+            padding: "24px",
+            borderBottom: "1px solid var(--border-color)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            background: "var(--surface-s1)"
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "16px" }}>
+            <div>
+              <h1 style={{ margin: 0, fontSize: "22px", fontWeight: 600 }}>Portfolio-grade Product Operations</h1>
+              <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "14px" }}>
+                Unified governance across SaaS, Commerce, Analytics, Media, EdTech & specialized verticals.
+              </p>
+            </div>
+            <ThemeSwitcher />
+          </div>
+          <nav aria-label="Primary navigation" style={navStyle}>
+            {modules.map((module) => (
+              <NavLink
+                key={module.id}
+                to={module.path}
+                style={({ isActive }) => ({
+                  ...linkStyle,
+                  background: isActive ? `var(--vertical-${module.id})` : "transparent",
+                  color: isActive ? "#fff" : "var(--text-primary)",
+                  borderColor: isActive ? `var(--vertical-${module.id})` : "var(--border-color)"
+                })}
+              >
+                {module.name}
+              </NavLink>
+            ))}
+          </nav>
+          <GlobalFilterBar />
+        </header>
+        <main style={{ flex: 1, padding: "32px", display: "grid", gap: "32px" }}>{children}</main>
+        <ToastViewport />
+      </div>
+    </ToastProvider>
+  );
+};
+
+export default AppLayout;

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,0 +1,36 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { BrowserRouter } from "react-router-dom";
+import { ThemeProvider } from "./theme/ThemeProvider";
+import App from "./App";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 60_000
+    }
+  }
+});
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("Root element not found");
+}
+
+const root = createRoot(container);
+root.render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
+      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
+    </QueryClientProvider>
+  </StrictMode>
+);

--- a/src/frontend/src/modules/AnalyticsModule.tsx
+++ b/src/frontend/src/modules/AnalyticsModule.tsx
@@ -1,0 +1,73 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleBarChart } from "../components/charts/AccessibleBarChart";
+import { AccessibleDonutChart } from "../components/charts/AccessibleDonutChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.analytics;
+
+export const AnalyticsModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6", display: "grid", gap: "24px" }}>
+        <ChartCard
+          title="Conversion funnel"
+          description={data.descriptions.funnel}
+          data={data.charts.funnel}
+          columns={[
+            { key: "stage", label: "Stage" },
+            { key: "value", label: "Volume" }
+          ]}
+        >
+          <AccessibleBarChart data={data.charts.funnel} dataKey="stage" bars={[{ key: "value", color: data.accentToken, name: "Volume" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 6", display: "grid", gap: "24px" }}>
+        <ChartCard
+          title="Lead source mix"
+          description={data.descriptions.leadMix}
+          data={data.charts.leadMix}
+          columns={[
+            { key: "source", label: "Source" },
+            { key: "share", label: "Share" }
+          ]}
+        >
+          <AccessibleDonutChart data={data.charts.leadMix} valueKey="share" nameKey="source" colors={["var(--vertical-analytics)", "var(--info-400)", "var(--success-400)", "var(--warning-400)", "var(--danger-400)"]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 4" }}>
+        <ListCard title={data.lists.insights.title} items={data.lists.insights.items} />
+      </section>
+      <section style={{ gridColumn: "span 8" }}>
+        <DataTable id="analytics-executive" columns={data.tables.executive.columns} data={data.tables.executive.rows} />
+      </section>
+      <section style={{ gridColumn: "span 12", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Predictive lead scoring, intent surge sync, lifecycle SLA</p>
+          </div>
+          <StatusChip label="MMM light" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 700));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default AnalyticsModule;

--- a/src/frontend/src/modules/CustomAppModule.tsx
+++ b/src/frontend/src/modules/CustomAppModule.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import KpiBand from "../components/KpiBand";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip, { type StatusTone } from "../components/StatusChip";
+
+const data = fixtures.customapp;
+
+const lanes: { id: string; title: string; tone: StatusTone }[] = [
+  { id: "backlog", title: "Backlog", tone: "info" },
+  { id: "in-progress", title: "In progress", tone: "warning" },
+  { id: "review", title: "Review", tone: "info" },
+  { id: "done", title: "Done", tone: "success" }
+];
+
+export const CustomAppModule: React.FC = () => {
+  const [focusedLane, setFocusedLane] = useState<string | null>(null);
+
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 8", display: "grid", gap: "24px" }}>
+        <div
+          role="list"
+          aria-label="Kanban delivery board"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "16px"
+          }}
+        >
+          {lanes.map((lane) => (
+            <article
+              key={lane.id}
+              role="listitem"
+              tabIndex={0}
+              onFocus={() => setFocusedLane(lane.id)}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+                  event.preventDefault();
+                  const index = lanes.findIndex((item) => item.id === lane.id);
+                  const nextIndex = event.key === "ArrowRight" ? Math.min(lanes.length - 1, index + 1) : Math.max(0, index - 1);
+                  document.getElementById(lanes[nextIndex].id)?.focus();
+                }
+              }}
+              id={lane.id}
+              style={{
+                background: "var(--surface-s1)",
+                borderRadius: "16px",
+                border: focusedLane === lane.id ? `2px solid var(--vertical-customapp)` : "1px solid var(--border-color)",
+                padding: "16px",
+                boxShadow: "var(--shadow-elevation)",
+                outline: "none",
+                display: "grid",
+                gap: "12px"
+              }}
+            >
+              <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <h3 style={{ margin: 0, fontSize: "14px", fontWeight: 600 }}>{lane.title}</h3>
+                <StatusChip label={`${data.charts.workload.find((item) => item.lane.toLowerCase().includes(lane.title.toLowerCase()))?.tasks ?? 0} cards`} tone={lane.tone as never} subtle />
+              </header>
+              <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Space to lift, arrows to move, enter to drop.</p>
+            </article>
+          ))}
+        </div>
+        <DataTable id="idea-backlog" columns={data.tables.backlog.columns} data={data.tables.backlog.rows} />
+      </section>
+      <section style={{ gridColumn: "span 4", display: "grid", gap: "24px" }}>
+        <ListCard title={data.lists.kanban.title} items={data.lists.kanban.items} />
+        <div style={{ background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "12px" }}>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Create recurring task</h3>
+          <label htmlFor="task-name" style={labelStyle}>Task name</label>
+          <input id="task-name" style={inputStyle} placeholder="Sprint review" />
+          <label htmlFor="task-cadence" style={labelStyle}>Cadence</label>
+          <select id="task-cadence" style={inputStyle}>
+            <option>Weekly</option>
+            <option>Bi-weekly</option>
+            <option>Monthly</option>
+          </select>
+          <label htmlFor="task-owner" style={labelStyle}>Owner</label>
+          <input id="task-owner" style={inputStyle} placeholder="Team lead" />
+          <button type="button" style={submitStyle}>Schedule ritual</button>
+        </div>
+      </section>
+      <section style={{ gridColumn: "span 12", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Recurring rituals, task nudges, idea triage</p>
+          </div>
+          <StatusChip label="DevOps hooks" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+const inputStyle: React.CSSProperties = {
+  borderRadius: "12px",
+  border: "1px solid var(--border-color)",
+  padding: "12px 16px",
+  background: "var(--surface-s1)",
+  color: "var(--text-primary)"
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "12px",
+  color: "var(--text-secondary)"
+};
+
+const submitStyle: React.CSSProperties = {
+  borderRadius: "12px",
+  border: "none",
+  background: "var(--vertical-customapp)",
+  color: "#fff",
+  padding: "12px 16px",
+  fontWeight: 600,
+  cursor: "pointer"
+};
+
+export default CustomAppModule;

--- a/src/frontend/src/modules/EcommerceModule.tsx
+++ b/src/frontend/src/modules/EcommerceModule.tsx
@@ -1,0 +1,127 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleBarChart } from "../components/charts/AccessibleBarChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+import { useToast } from "../components/toast/ToastContext";
+
+const data = fixtures.ecommerce;
+
+export const EcommerceModule: React.FC = () => {
+  const { addToast } = useToast();
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 4", display: "grid", gap: "24px" }}>
+        <DataTable id="ecommerce-top-products" columns={data.tables.topProducts.columns} data={data.tables.topProducts.rows} />
+        <div style={{ background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "12px" }}>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Seasonal promotion builder</h3>
+          <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Validate guardrails before activation to avoid stock-outs.</p>
+          <label htmlFor="promo-name" style={{ fontSize: "12px", color: "var(--text-secondary)", marginBottom: "4px" }}>Campaign name</label>
+          <input id="promo-name" style={{ ...inputStyle }} placeholder="Summer VIP" />
+          <label htmlFor="promo-audience" style={labelStyle}>Audience</label>
+          <select id="promo-audience" style={inputStyle}>
+            <option>VIP</option>
+            <option>High AOV</option>
+            <option>International</option>
+          </select>
+          <label htmlFor="promo-incentive" style={labelStyle}>Incentive</label>
+          <input id="promo-incentive" style={inputStyle} placeholder="Buy 2 get 20%" />
+          <label htmlFor="promo-throttle" style={labelStyle}>Throttle (min inventory days)</label>
+          <input id="promo-throttle" type="number" min={7} defaultValue={15} style={inputStyle} />
+          <button
+            type="button"
+            onClick={() =>
+              addToast({
+                title: "Promotion scheduled",
+                description: "Guardrails active across channels.",
+                tone: "success",
+                actionLabel: "Undo",
+                onAction: () => addToast({ title: "Promotion reverted", tone: "info" })
+              })
+            }
+            style={submitStyle}
+          >
+            Launch promotion
+          </button>
+        </div>
+      </section>
+      <section style={{ gridColumn: "span 4", display: "grid", gap: "24px" }}>
+        <ChartCard
+          title="Sales trends"
+          description={data.descriptions.salesTrend}
+          data={data.charts.salesTrend}
+          columns={[
+            { key: "week", label: "Week" },
+            { key: "ecommerce", label: "Revenue" }
+          ]}
+        >
+          <AccessibleBarChart data={data.charts.salesTrend} dataKey="week" bars={[{ key: "ecommerce", color: data.accentToken, name: "GMV" }]} />
+        </ChartCard>
+        <ListCard title={data.lists.promotionBuilder.title} items={data.lists.promotionBuilder.items} />
+      </section>
+      <section style={{ gridColumn: "span 4", display: "grid", gap: "24px" }}>
+        <ListCard title={data.lists.automation.title} items={data.lists.automation.items} />
+        <div style={{ background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", boxShadow: "var(--shadow-elevation)", display: "grid", gap: "16px" }}>
+          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div>
+              <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Operational health</h3>
+              <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Fulfillment SLA, payment health, support backlog</p>
+            </div>
+            <StatusChip label="Healthy" tone="success" subtle />
+          </header>
+          <AccessibleBarChart data={data.charts.operationalHealth} dataKey="category" bars={[{ key: "status", color: "var(--info-400)", name: "Health" }]} />
+        </div>
+      </section>
+      <section style={{ gridColumn: "span 12", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Abandoned cart, inventory auto-replenish, VIP delight</p>
+          </div>
+          <StatusChip label="Feature flag: Pro" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 600));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+const inputStyle: React.CSSProperties = {
+  borderRadius: "12px",
+  border: "1px solid var(--border-color)",
+  padding: "12px 16px",
+  background: "var(--surface-s1)",
+  color: "var(--text-primary)"
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "12px",
+  color: "var(--text-secondary)",
+  marginTop: "8px"
+};
+
+const submitStyle: React.CSSProperties = {
+  borderRadius: "12px",
+  padding: "12px 16px",
+  border: "none",
+  background: "var(--vertical-ecommerce)",
+  color: "#fff",
+  fontWeight: 600,
+  cursor: "pointer"
+};
+
+export default EcommerceModule;

--- a/src/frontend/src/modules/EdtechModule.tsx
+++ b/src/frontend/src/modules/EdtechModule.tsx
@@ -1,0 +1,59 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleBarChart } from "../components/charts/AccessibleBarChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.edtech;
+
+export const EdtechModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6" }}>
+        <DataTable id="program-performance" columns={data.tables.programs.columns} data={data.tables.programs.rows} />
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="Student activity heatmap"
+          description={data.descriptions.activity}
+          data={data.charts.activity}
+          columns={[
+            { key: "day", label: "Day" },
+            { key: "active", label: "Active learners" }
+          ]}
+        >
+          <AccessibleBarChart data={data.charts.activity} dataKey="day" bars={[{ key: "active", color: data.accentToken, name: "Active" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 4" }}>
+        <ListCard title={data.lists.orchestration.title} items={data.lists.orchestration.items} />
+      </section>
+      <section style={{ gridColumn: "span 8", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Auto certificate issuance, inactivity nudges, mentor rotation</p>
+          </div>
+          <StatusChip label="FERPA ready" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 650));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default EdtechModule;

--- a/src/frontend/src/modules/FinanceModule.tsx
+++ b/src/frontend/src/modules/FinanceModule.tsx
@@ -1,0 +1,81 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleLineChart } from "../components/charts/AccessibleLineChart";
+import { AccessibleDonutChart } from "../components/charts/AccessibleDonutChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.finance;
+
+export const FinanceModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="Expense vs budget"
+          description={data.descriptions.expenseTrend}
+          data={data.charts.expenseTrend}
+          columns={[
+            { key: "month", label: "Month" },
+            { key: "actual", label: "Actual" },
+            { key: "budget", label: "Budget" }
+          ]}
+        >
+          <AccessibleLineChart
+            data={data.charts.expenseTrend}
+            dataKey="month"
+            lines={[
+              { key: "actual", color: data.accentToken, name: "Actual" },
+              { key: "budget", color: "var(--info-400)", name: "Budget" }
+            ]}
+          />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="ROI breakdown"
+          description={data.descriptions.roiBreakdown}
+          data={data.charts.roiBreakdown}
+          columns={[
+            { key: "channel", label: "Channel" },
+            { key: "roi", label: "ROI" }
+          ]}
+        >
+          <AccessibleDonutChart data={data.charts.roiBreakdown} valueKey="roi" nameKey="channel" colors={[data.accentToken, "var(--success-400)", "var(--warning-400)", "var(--danger-400)"]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <DataTable id="finance-spend" columns={data.tables.spend.columns} data={data.tables.spend.rows} />
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ListCard title={data.lists.compliance.title} items={data.lists.compliance.items} />
+      </section>
+      <section style={{ gridColumn: "span 12", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Month-end close, expense routing, anomaly detection</p>
+          </div>
+          <StatusChip label="PCI scope" tone="warning" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 800));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default FinanceModule;

--- a/src/frontend/src/modules/HealthcareModule.tsx
+++ b/src/frontend/src/modules/HealthcareModule.tsx
@@ -1,0 +1,59 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleAreaChart } from "../components/charts/AccessibleAreaChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.healthcare;
+
+export const HealthcareModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6" }}>
+        <DataTable id="healthcare-appointments" columns={data.tables.appointments.columns} data={data.tables.appointments.rows} />
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="Patient momentum"
+          description={data.descriptions.marketMomentum}
+          data={data.charts.marketMomentum}
+          columns={[
+            { key: "month", label: "Month" },
+            { key: "momentum", label: "Momentum" }
+          ]}
+        >
+          <AccessibleAreaChart data={data.charts.marketMomentum} dataKey="month" areas={[{ key: "momentum", color: data.accentToken, name: "Momentum" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ListCard title={data.lists.compliance.title} items={data.lists.compliance.items} />
+      </section>
+      <section style={{ gridColumn: "span 6", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Omni-channel reminders, smart reschedule, CSAT loop</p>
+          </div>
+          <StatusChip label="HIPAA" tone="danger" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 900));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default HealthcareModule;

--- a/src/frontend/src/modules/MediaModule.tsx
+++ b/src/frontend/src/modules/MediaModule.tsx
@@ -1,0 +1,59 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleLineChart } from "../components/charts/AccessibleLineChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.media;
+
+export const MediaModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="Engagement trend"
+          description={data.descriptions.engagement}
+          data={data.charts.engagement}
+          columns={[
+            { key: "day", label: "Day" },
+            { key: "engagement", label: "Score" }
+          ]}
+        >
+          <AccessibleLineChart data={data.charts.engagement} dataKey="day" lines={[{ key: "engagement", color: data.accentToken, name: "Engagement" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <DataTable id="media-top-stories" columns={data.tables.stories.columns} data={data.tables.stories.rows} />
+      </section>
+      <section style={{ gridColumn: "span 4" }}>
+        <ListCard title={data.lists.queue.title} items={data.lists.queue.items} />
+      </section>
+      <section style={{ gridColumn: "span 8", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Control tower, auto-tagging, highlights generator</p>
+          </div>
+          <StatusChip label="Add-on" tone="warning" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 650));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default MediaModule;

--- a/src/frontend/src/modules/RealEstateModule.tsx
+++ b/src/frontend/src/modules/RealEstateModule.tsx
@@ -1,0 +1,59 @@
+import KpiBand from "../components/KpiBand";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleAreaChart } from "../components/charts/AccessibleAreaChart";
+import { DataTable } from "../components/DataTable";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import StatusChip from "../components/StatusChip";
+
+const data = fixtures.realestate;
+
+export const RealEstateModule: React.FC = () => {
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section style={{ gridColumn: "span 6" }}>
+        <DataTable id="realestate-listings" columns={data.tables.listings.columns} data={data.tables.listings.rows} />
+      </section>
+      <section style={{ gridColumn: "span 6" }}>
+        <ChartCard
+          title="Market momentum"
+          description={data.descriptions.momentum}
+          data={data.charts.momentum}
+          columns={[
+            { key: "month", label: "Month" },
+            { key: "momentum", label: "Momentum" }
+          ]}
+        >
+          <AccessibleAreaChart data={data.charts.momentum} dataKey="month" areas={[{ key: "momentum", color: data.accentToken, name: "Momentum" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 4" }}>
+        <ListCard title={data.lists.inquiries.title} items={data.lists.inquiries.items} />
+      </section>
+      <section style={{ gridColumn: "span 8", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Agent notification loop, listing nurture, momentum watcher</p>
+          </div>
+          <StatusChip label="Regional" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 700));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default RealEstateModule;

--- a/src/frontend/src/modules/SaaSModule.tsx
+++ b/src/frontend/src/modules/SaaSModule.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import KpiBand from "../components/KpiBand";
+import { DataTable } from "../components/DataTable";
+import { ChartCard } from "../components/charts/ChartCard";
+import { AccessibleDonutChart } from "../components/charts/AccessibleDonutChart";
+import { AccessibleLineChart } from "../components/charts/AccessibleLineChart";
+import { AccessibleAreaChart } from "../components/charts/AccessibleAreaChart";
+import ListCard from "../components/ListCard";
+import { AutomationBuilder } from "../components/automation/AutomationBuilder";
+import { fixtures } from "../data/fixtures";
+import { mockLiveMetricsStream, type LiveMetric } from "../services/liveMetrics";
+import StatusChip from "../components/StatusChip";
+import { useToast } from "../components/toast/ToastContext";
+
+const data = fixtures.saas;
+
+export const SaaSModule: React.FC = () => {
+  const [liveMetrics, setLiveMetrics] = useState<LiveMetric[]>([]);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    const dispose = mockLiveMetricsStream(setLiveMetrics);
+    return dispose;
+  }, []);
+
+  return (
+    <div className="grid-container" style={{ gridTemplateColumns: "repeat(12, 1fr)" }}>
+      <div style={{ gridColumn: "span 12" }}>
+        <KpiBand accent={data.accentToken} kpis={data.kpis} />
+      </div>
+      <section
+        style={{
+          gridColumn: "span 8",
+          display: "grid",
+          gap: "24px"
+        }}
+      >
+        <ChartCard
+          title="Churn health"
+          description={data.descriptions.churnHealth}
+          data={data.charts.churnHealth}
+          columns={[
+            { key: "stage", label: "Stage" },
+            { key: "value", label: "Share" }
+          ]}
+        >
+          <AccessibleDonutChart data={data.charts.churnHealth} valueKey="value" nameKey="stage" colors={["var(--success-500)", "var(--warning-400)", "var(--danger-400)"]} />
+        </ChartCard>
+        <ChartCard
+          title="MRR growth"
+          description={data.descriptions.mrrGrowth}
+          data={data.charts.mrrGrowth}
+          columns={[
+            { key: "month", label: "Month" },
+            { key: "mrr", label: "MRR" }
+          ]}
+        >
+          <AccessibleLineChart data={data.charts.mrrGrowth} dataKey="month" lines={[{ key: "mrr", color: "var(--vertical-saas)", name: "MRR" }]} />
+        </ChartCard>
+        <ChartCard
+          title="API usage saturation"
+          description={data.descriptions.apiUsage}
+          data={data.charts.apiUsage}
+          columns={[
+            { key: "day", label: "Day" },
+            { key: "saturation", label: "Saturation" }
+          ]}
+        >
+          <AccessibleAreaChart data={data.charts.apiUsage} dataKey="day" areas={[{ key: "saturation", color: "var(--info-400)", name: "Saturation" }]} />
+        </ChartCard>
+      </section>
+      <section style={{ gridColumn: "span 4", display: "grid", gap: "24px" }}>
+        <div style={{ background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", boxShadow: "var(--shadow-elevation)", display: "grid", gap: "16px" }}>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Live billing signals</h3>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: "12px" }}>
+            {liveMetrics.map((metric) => (
+              <li key={metric.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div>
+                  <p style={{ margin: 0, fontWeight: 600 }}>{metric.label}</p>
+                  <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px" }}>Updated {new Date(metric.updatedAt).toLocaleTimeString()}</p>
+                </div>
+                <span style={{ fontFeatureSettings: "'tnum' 1, 'lnum' 1", fontWeight: 600 }}>{metric.value.toFixed(0)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <ListCard title={data.lists.orchestration.title} items={data.lists.orchestration.items} />
+        <div style={{ background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", boxShadow: "var(--shadow-elevation)", display: "grid", gap: "12px" }}>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Churn recovery playbook</h3>
+          <p style={{ margin: 0, fontSize: "12px", color: "var(--text-secondary)" }}>Template, fallback owner, and threshold configured per segment.</p>
+          <button
+            type="button"
+            onClick={() =>
+              addToast({
+                title: "Playbook enabled",
+                description: "Churn recovery playbook will auto sync.",
+                tone: "info",
+                actionLabel: "Undo",
+                onAction: () => addToast({ title: "Undo successful", tone: "success" })
+              })
+            }
+            style={{
+              borderRadius: "12px",
+              border: "none",
+              background: data.accentToken,
+              color: "#fff",
+              padding: "12px 16px",
+              fontWeight: 600,
+              cursor: "pointer"
+            }}
+          >
+            Enable playbook
+          </button>
+        </div>
+      </section>
+      <section style={{ gridColumn: "span 12" }}>
+        <DataTable
+          id="saas-plans"
+          columns={data.tables.plans.columns.map((column) => ({
+            key: column.key,
+            label: column.label,
+            align: column.align
+          }))}
+          data={data.tables.plans.rows}
+        />
+      </section>
+      <section style={{ gridColumn: "span 12", background: "var(--surface-s1)", borderRadius: "16px", border: "1px solid var(--border-color)", padding: "24px", boxShadow: "var(--shadow-elevation)", display: "grid", gap: "24px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Automation orchestration</h3>
+            <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px" }}>Billing reconciliation, outreach, burst protection</p>
+          </div>
+          <StatusChip label="Feature flag: enabled" tone="info" subtle />
+        </header>
+        <AutomationBuilder
+          triggerOptions={data.automations.triggers}
+          conditionOptions={data.automations.conditions}
+          actionOptions={data.automations.actions}
+          cadenceOptions={data.automations.cadences}
+          onSave={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 800));
+          }}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default SaaSModule;

--- a/src/frontend/src/services/liveMetrics.ts
+++ b/src/frontend/src/services/liveMetrics.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+
+export interface LiveMetric {
+  id: string;
+  label: string;
+  value: number;
+  updatedAt: string;
+}
+
+export const useLiveMetrics = (endpoint: string) => {
+  const [metrics, setMetrics] = useState<LiveMetric[]>([]);
+
+  useEffect(() => {
+    let events: EventSource | null = null;
+    let reconnectTimer: number | undefined;
+
+    const connect = () => {
+      events?.close();
+      events = new EventSource(endpoint);
+
+      events.onmessage = (event) => {
+        const data = JSON.parse(event.data) as LiveMetric[];
+        setMetrics(data);
+      };
+
+      events.onerror = () => {
+        events?.close();
+        reconnectTimer = window.setTimeout(connect, 5000);
+      };
+    };
+
+    connect();
+
+    return () => {
+      if (reconnectTimer) {
+        window.clearTimeout(reconnectTimer);
+      }
+      events?.close();
+    };
+  }, [endpoint]);
+
+  return metrics;
+};
+
+export const mockLiveMetricsStream = (callback: (metrics: LiveMetric[]) => void) => {
+  const metrics: LiveMetric[] = [
+    { id: "mrr", label: "MRR", value: 420000, updatedAt: new Date().toISOString() },
+    { id: "usage", label: "API Usage", value: 78, updatedAt: new Date().toISOString() }
+  ];
+  let step = 0;
+  const interval = window.setInterval(() => {
+    step += 1;
+    const updated = metrics.map((metric, index) => ({
+      ...metric,
+      value: metric.value + Math.sin(step + index) * 10,
+      updatedAt: new Date().toISOString()
+    }));
+    callback(updated);
+  }, 4000);
+  return () => window.clearInterval(interval);
+};

--- a/src/frontend/src/store/globalFilters.ts
+++ b/src/frontend/src/store/globalFilters.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type DateRangePreset = "7d" | "30d" | "90d" | "fy";
+
+export interface GlobalFiltersState {
+  dateRange: DateRangePreset;
+  segment: string;
+  vertical: string;
+  setDateRange: (range: DateRangePreset) => void;
+  setSegment: (segment: string) => void;
+  setVertical: (vertical: string) => void;
+}
+
+export const useGlobalFilters = create<GlobalFiltersState>()(
+  persist(
+    (set) => ({
+      dateRange: "30d",
+      segment: "all",
+      vertical: "saas",
+      setDateRange: (dateRange) => set({ dateRange }),
+      setSegment: (segment) => set({ segment }),
+      setVertical: (vertical) => set({ vertical })
+    }),
+    {
+      name: "pgpo.global-filters"
+    }
+  )
+);

--- a/src/frontend/src/stories/KpiCard.stories.tsx
+++ b/src/frontend/src/stories/KpiCard.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { KpiCard } from "../components/KpiCard";
+
+const meta: Meta<typeof KpiCard> = {
+  title: "Core/KpiCard",
+  component: KpiCard,
+  args: {
+    title: "Monthly Recurring Revenue",
+    value: 420000,
+    valueType: "currency",
+    delta: 0.06,
+    deltaLabel: "Up 6% vs last month",
+    timeBasis: "vs prior month",
+    accent: "var(--vertical-saas)"
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof KpiCard>;
+
+export const Default: Story = {};

--- a/src/frontend/src/theme/ThemeProvider.tsx
+++ b/src/frontend/src/theme/ThemeProvider.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ThemeDefinition } from "./tokens";
+import { darkTheme, lightTheme, themes } from "./tokens";
+
+interface ThemeContextValue {
+  theme: ThemeDefinition;
+  toggleTheme: () => void;
+  setThemeId: (id: ThemeDefinition["id"]) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const THEME_STORAGE_KEY = "pgpo_theme";
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [themeId, setThemeId] = useState<ThemeDefinition["id"]>(() => {
+    if (typeof window === "undefined") {
+      return "light";
+    }
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as ThemeDefinition["id"] | null;
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(THEME_STORAGE_KEY, themeId);
+    }
+  }, [themeId]);
+
+  const theme = useMemo(() => (themeId === "light" ? lightTheme : darkTheme), [themeId]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute("data-theme", theme.id);
+    root.style.setProperty("color-scheme", theme.id);
+    root.style.background = theme.surfaces.s0;
+    Object.entries(theme.palette).forEach(([role, scale]) => {
+      Object.entries(scale).forEach(([step, value]) => {
+        root.style.setProperty(`--${role}-${step}`, value);
+      });
+    });
+    root.style.setProperty("--surface-s0", theme.surfaces.s0);
+    root.style.setProperty("--surface-s1", theme.surfaces.s1);
+    root.style.setProperty("--surface-s2", theme.surfaces.s2);
+    root.style.setProperty("--surface-s3", theme.surfaces.s3);
+    root.style.setProperty("--border-color", theme.surfaces.border);
+    root.style.setProperty("--shadow-elevation", theme.surfaces.shadow);
+    root.style.setProperty("--text-primary", theme.surfaces.textPrimary);
+    root.style.setProperty("--text-secondary", theme.surfaces.textSecondary);
+    root.style.setProperty("--focus-ring", theme.surfaces.focus);
+    Object.entries(theme.verticalAccents).forEach(([key, value]) => {
+      root.style.setProperty(`--vertical-${key}`, value);
+    });
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setThemeId((current) => (current === "light" ? "dark" : "light")),
+      setThemeId
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};
+
+export const availableThemes = themes;

--- a/src/frontend/src/theme/tokens.ts
+++ b/src/frontend/src/theme/tokens.ts
@@ -1,0 +1,207 @@
+export type ColorScale = {
+  50: string;
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+  600: string;
+  700: string;
+  800: string;
+  900: string;
+};
+
+export interface SemanticPalette {
+  primary: ColorScale;
+  success: ColorScale;
+  warning: ColorScale;
+  danger: ColorScale;
+  info: ColorScale;
+  neutral: ColorScale;
+}
+
+export interface SurfaceTokens {
+  s0: string;
+  s1: string;
+  s2: string;
+  s3: string;
+  border: string;
+  shadow: string;
+  textPrimary: string;
+  textSecondary: string;
+  focus: string;
+}
+
+export interface ThemeDefinition {
+  id: "light" | "dark";
+  name: string;
+  palette: SemanticPalette;
+  surfaces: SurfaceTokens;
+  chartPalettes: Record<string, string[]>;
+  verticalAccents: Record<string, string>;
+}
+
+export const spacing = (factor: number) => `${factor * 8}px`;
+
+export const typographyScale = {
+  h1: { fontSize: "32px", lineHeight: "36px", fontWeight: 700 },
+  h2: { fontSize: "22px", lineHeight: "28px", fontWeight: 600 },
+  h3: { fontSize: "16px", lineHeight: "24px", fontWeight: 600 },
+  body: { fontSize: "14px", lineHeight: "20px", fontWeight: 400 },
+  caption: { fontSize: "12px", lineHeight: "16px", fontWeight: 500 }
+};
+
+const primaryScale: ColorScale = {
+  50: "#edf5ff",
+  100: "#d1e2ff",
+  200: "#a6c7ff",
+  300: "#7caaff",
+  400: "#528bff",
+  500: "#2a6bff",
+  600: "#1f53d6",
+  700: "#153daf",
+  800: "#0d2a87",
+  900: "#06195f"
+};
+
+const successScale: ColorScale = {
+  50: "#e7f8f2",
+  100: "#c1eddc",
+  200: "#8fdcbf",
+  300: "#5dcaa3",
+  400: "#2bb886",
+  500: "#0b9e6a",
+  600: "#067c53",
+  700: "#035a3c",
+  800: "#013924",
+  900: "#001e12"
+};
+
+const warningScale: ColorScale = {
+  50: "#fff6e5",
+  100: "#ffe4b8",
+  200: "#ffc985",
+  300: "#ffae52",
+  400: "#ff9221",
+  500: "#ed7700",
+  600: "#bb5b00",
+  700: "#883f00",
+  800: "#562500",
+  900: "#2c1200"
+};
+
+const dangerScale: ColorScale = {
+  50: "#ffecef",
+  100: "#ffd0d5",
+  200: "#ff9fa8",
+  300: "#ff6e7d",
+  400: "#ff3b51",
+  500: "#e3122f",
+  600: "#b40d24",
+  700: "#830818",
+  800: "#53040e",
+  900: "#290206"
+};
+
+const infoScale: ColorScale = {
+  50: "#e7f5ff",
+  100: "#c0e5ff",
+  200: "#8cd0ff",
+  300: "#59bbff",
+  400: "#24a5ff",
+  500: "#008be6",
+  600: "#006db4",
+  700: "#004f82",
+  800: "#003251",
+  900: "#001621"
+};
+
+const neutralScale: ColorScale = {
+  50: "#f5f7fa",
+  100: "#e6e9ef",
+  200: "#cfd5df",
+  300: "#b7bece",
+  400: "#9ea5b6",
+  500: "#828a9e",
+  600: "#666e84",
+  700: "#4b5268",
+  800: "#313748",
+  900: "#1b202e"
+};
+
+export const lightTheme: ThemeDefinition = {
+  id: "light",
+  name: "Daybreak",
+  palette: {
+    primary: primaryScale,
+    success: successScale,
+    warning: warningScale,
+    danger: dangerScale,
+    info: infoScale,
+    neutral: neutralScale
+  },
+  surfaces: {
+    s0: "#f8f9fb",
+    s1: "#ffffff",
+    s2: "rgba(255, 255, 255, 0.75)",
+    s3: "rgba(13, 29, 58, 0.2)",
+    border: "rgba(49, 55, 72, 0.12)",
+    shadow: "0 12px 32px rgba(10, 32, 70, 0.12)",
+    textPrimary: neutralScale[900],
+    textSecondary: neutralScale[600],
+    focus: infoScale[400]
+  },
+  chartPalettes: {
+    default: [primaryScale[500], infoScale[400], successScale[400], warningScale[400], dangerScale[400]],
+    colorblind: ["#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#66a61e", "#e6ab02"],
+    qualitative: ["#2a6bff", "#ff8a50", "#56c271", "#f9c846", "#8b6bff", "#ff4d6d"]
+  },
+  verticalAccents: {
+    saas: "#4b8bff",
+    ecommerce: "#ff8a50",
+    analytics: "#8b6bff",
+    customapp: "#56c271",
+    media: "#f5a524",
+    edtech: "#9d5cf3",
+    realestate: "#2aa39f",
+    finance: "#1f7a8c",
+    healthcare: "#f04f5a"
+  }
+};
+
+export const darkTheme: ThemeDefinition = {
+  id: "dark",
+  name: "Midnight",
+  palette: {
+    primary: primaryScale,
+    success: successScale,
+    warning: warningScale,
+    danger: dangerScale,
+    info: infoScale,
+    neutral: neutralScale
+  },
+  surfaces: {
+    s0: "#0f172a",
+    s1: "#111c32",
+    s2: "rgba(17, 28, 50, 0.8)",
+    s3: "rgba(4, 9, 20, 0.7)",
+    border: "rgba(130, 138, 158, 0.24)",
+    shadow: "0 16px 32px rgba(0, 0, 0, 0.4)",
+    textPrimary: "#eff3ff",
+    textSecondary: "#c7cde0",
+    focus: infoScale[300]
+  },
+  chartPalettes: {
+    default: ["#88a9ff", "#ffd166", "#4ad6a7", "#ff8a50", "#ff708d"],
+    colorblind: ["#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#66a61e", "#e6ab02"],
+    qualitative: ["#5da0ff", "#ffa56a", "#6ee7b7", "#facc15", "#a78bfa", "#fb7185"]
+  },
+  verticalAccents: lightTheme.verticalAccents
+};
+
+export const themes = [lightTheme, darkTheme];
+
+export const typographyVariableNames = {
+  fontFamily: "'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif",
+  numericFontFeature: "'tnum' 1, 'lnum' 1"
+};

--- a/src/frontend/src/utils/formatters.ts
+++ b/src/frontend/src/utils/formatters.ts
@@ -1,0 +1,34 @@
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+});
+
+const numberFormatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1
+});
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1
+});
+
+const durationFormatter = new Intl.DateTimeFormat(undefined, {
+  minute: "2-digit",
+  second: "2-digit",
+  timeZone: "UTC"
+});
+
+export const formatCurrency = (value: number) => currencyFormatter.format(value);
+export const formatNumber = (value: number) => numberFormatter.format(value);
+export const formatPercent = (value: number) => percentFormatter.format(value);
+export const formatDuration = (seconds: number) => {
+  const baseDate = new Date(0);
+  baseDate.setSeconds(seconds);
+  return durationFormatter.format(baseDate);
+};
+
+export const formatTrend = (value: number) => (value > 0 ? `+${formatPercent(value)}` : formatPercent(value));

--- a/src/frontend/tsconfig.node.json
+++ b/src/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "stories", "scripts"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Vite React workspace with semantic design tokens, light/dark theming, and a shared application shell that powers the portfolio-grade dashboard experience
- build reusable KPI, data visualization, automation, toast, and live metric primitives that satisfy accessibility, export, and optimistic interaction requirements
- implement SaaS, e-commerce, analytics, productivity, media, edtech, real estate, finance, and healthcare module routes that express vertical accents while sharing the unified system

## Testing
- `npm --prefix src/frontend install` *(fails: registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52f401730832ebd6c6c565bffc7d6