### PR TITLE
feat: add portfolio product operations dashboard

### DIFF
--- a/src/frontend/portfolio-dashboard/.storybook/main.ts
+++ b/src/frontend/portfolio-dashboard/.storybook/main.ts
@@ -1,0 +1,18 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  features: {
+    storyStoreV7: true
+  },
+  docs: {
+    autodocs: 'tag'
+  }
+};
+
+export default config;

--- a/src/frontend/portfolio-dashboard/.storybook/preview.ts
+++ b/src/frontend/portfolio-dashboard/.storybook/preview.ts
@@ -1,0 +1,37 @@
+import type { Preview } from '@storybook/react';
+import '../src/styles/global.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+    layout: 'fullscreen'
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'mirror',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+          { value: 'rtl', title: 'RTL' }
+        ],
+        showName: true
+      }
+    }
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = context.globals.theme as 'light' | 'dark' | 'rtl';
+      const dir = theme === 'rtl' ? 'rtl' : 'ltr';
+      const mode = theme === 'dark' ? 'dark' : 'light';
+      document.documentElement.dir = dir;
+      document.documentElement.dataset.theme = mode;
+      return Story();
+    }
+  ]
+};
+
+export default preview;

--- a/src/frontend/portfolio-dashboard/README.md
+++ b/src/frontend/portfolio-dashboard/README.md
@@ -1,0 +1,51 @@
+# Portfolio-grade Product Operations
+
+This Vite + React workspace implements a unified, premium multi-module dashboard spanning SaaS, commerce, corporate analytics, custom productivity, media, EdTech, and specialized niches. Every module consumes the same design system tokens, layout primitives, and automation builder to ensure visual and behavioral consistency while preserving vertical specificity.
+
+## Highlights
+
+- **Design system first** – 12-column grid, 8pt spacing rhythm, semantic typography scale, AA contrast, semantic color roles, and vertical accent tokens (`--vertical-*`).
+- **State management** – Global filters powered by Zustand persistence, React Query for async data, optimistic actions with undo toasts, and SSE-ready KPI hooks.
+- **Accessible data viz** – Keyboard reachable chart frames with table fallbacks, tabular numerals, and colorblind-friendly palettes that respect dark mode/RTL.
+- **Automation everywhere** – Reusable automation builder component with optimistic enablement and undo guardrails across modules.
+- **Storybook coverage** – Stories include theme/RTL controls for rapid review of design tokens and component ergonomics.
+
+## Getting started
+
+```bash
+cd src/frontend/portfolio-dashboard
+npm install
+npm run dev
+```
+
+Storybook and automated checks:
+
+```bash
+npm run storybook    # interactive theming controls
+npm run build        # type check + production build
+npm run lint         # accessibility-leaning linting
+npm run test         # vitest placeholder
+```
+
+## Modules
+
+Each route mounts inside `AppShell` with shared filters and toast viewport:
+
+- `/saas` – Subscription intelligence with churn health, API saturation, and billing orchestration.
+- `/ecommerce` – Merchandising and fulfillment with promotion builder guardrails.
+- `/corporate` – Pipeline and attribution insights with executive storytelling.
+- `/custom-app` – Productivity automation featuring accessible Kanban and workload views.
+- `/content-media` – Publishing workflow and engagement orchestration.
+- `/edtech` – Learning analytics with adaptive nudges and compliance-ready automations.
+- `/specialized` – Real estate, finance, and healthcare snapshots meeting PCI/HIPAA guardrails.
+
+## Compliance & integrations
+
+Mock connectors in `src/utils/connectors.ts` demonstrate how Snowflake, webhooks, and SSE streams plug into the UI without shipping secrets. Extend these helpers to wire actual BigQuery/dbt, Segment events, Stripe/Chargebee billing, Shopify/Magento commerce, Salesforce/HubSpot CRM, Jira/Linear DevOps, LTI/SCORM EdTech, and FHIR/HL7 healthcare integrations.
+
+## Testing roadmap
+
+- **Unit tests** for formatting utilities and Zustand reducers can be added under `src/__tests__`.
+- **Accessibility** via axe-core and keyboard regression is recommended before production hardening.
+- **Performance** budgets target <2.5s LCP on 3G fast with chart render under 300ms post aggregation.
+

--- a/src/frontend/portfolio-dashboard/index.html
+++ b/src/frontend/portfolio-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portfolio-grade Product Operations</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/frontend/portfolio-dashboard/package.json
+++ b/src/frontend/portfolio-dashboard/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "portfolio-product-operations",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "vitest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.1",
+    "clsx": "^2.0.0",
+    "d3-array": "^3.2.4",
+    "d3-shape": "^3.2.0",
+    "date-fns": "^3.6.0",
+    "immer": "^10.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.24.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "^8.1.6",
+    "@storybook/addon-interactions": "^8.1.6",
+    "@storybook/react": "^8.1.6",
+    "@storybook/testing-library": "^0.2.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.2",
+    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/parser": "^7.16.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-plugin-jsx-a11y": "^6.9.0",
+    "postcss": "^8.4.39",
+    "storybook": "^8.1.6",
+    "tailwindcss": "^3.4.7",
+    "typescript": "~5.4.0",
+    "vite": "^5.3.4",
+    "vitest": "^1.6.0"
+  }
+}

--- a/src/frontend/portfolio-dashboard/src/components/automation/AutomationBuilder.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/automation/AutomationBuilder.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { useOptimisticAction } from '../primitives/Toast';
+
+type AutomationStep = 'trigger' | 'conditions' | 'actions' | 'cadence';
+
+interface AutomationBuilderProps {
+  name: string;
+  defaults?: Partial<Record<AutomationStep, string>>;
+}
+
+export function AutomationBuilder({ name, defaults = {} }: AutomationBuilderProps) {
+  const [form, setForm] = useState<Record<AutomationStep, string>>({
+    trigger: defaults.trigger ?? '',
+    conditions: defaults.conditions ?? '',
+    actions: defaults.actions ?? '',
+    cadence: defaults.cadence ?? ''
+  });
+
+  const saveAutomation = useOptimisticAction(
+    async () => {
+      await new Promise((resolve) => setTimeout(resolve, 900));
+      sessionStorage.setItem(`automation-${name}`, JSON.stringify(form));
+      return true;
+    },
+    {
+      pendingLabel: 'Enabling automation…',
+      successLabel: 'Automation enabled',
+      undoLabel: 'Undo enable',
+      onUndo: () => sessionStorage.removeItem(`automation-${name}`)
+    }
+  );
+
+  return (
+    <form
+      className="automation-builder"
+      aria-label={`${name} automation builder`}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void saveAutomation();
+      }}
+    >
+      <h3 className="section-title">Automation builder</h3>
+      <p className="card__subtitle">
+        Configure trigger, conditions, actions, and cadence. Changes are saved optimistically with undo support.
+      </p>
+      <AutomationField
+        id={`${name}-trigger`}
+        label="Trigger"
+        placeholder="Describe the trigger signal (e.g., API drop 20%)"
+        value={form.trigger}
+        onChange={(value) => setForm((prev) => ({ ...prev, trigger: value }))}
+      />
+      <AutomationField
+        id={`${name}-conditions`}
+        label="Conditions"
+        placeholder="Guardrails and thresholds"
+        value={form.conditions}
+        onChange={(value) => setForm((prev) => ({ ...prev, conditions: value }))}
+      />
+      <AutomationField
+        id={`${name}-actions`}
+        label="Actions"
+        placeholder="Describe the sequence (Slack alert, assign owner, webhook)"
+        value={form.actions}
+        onChange={(value) => setForm((prev) => ({ ...prev, actions: value }))}
+      />
+      <AutomationField
+        id={`${name}-cadence`}
+        label="Cadence"
+        placeholder="Ex: Immediately, repeat every 4h until resolved"
+        value={form.cadence}
+        onChange={(value) => setForm((prev) => ({ ...prev, cadence: value }))}
+      />
+      <div className="form-actions">
+        <button type="submit" className="button-primary">
+          Enable automation
+        </button>
+        <button
+          type="button"
+          className="button-secondary"
+          onClick={() => setForm({ trigger: '', conditions: '', actions: '', cadence: '' })}
+        >
+          Reset
+        </button>
+      </div>
+    </form>
+  );
+}
+
+interface AutomationFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+function AutomationField({ id, label, value, placeholder, onChange }: AutomationFieldProps) {
+  return (
+    <div className="form-field">
+      <label htmlFor={id}>{label}</label>
+      <textarea
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        minLength={0}
+        rows={3}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/charts/AreaChart.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/charts/AreaChart.tsx
@@ -1,0 +1,44 @@
+import { area } from 'd3-shape';
+import { scaleLinear, scalePoint } from 'd3-scale';
+import { extent } from 'd3-array';
+import { ChartFrame } from './ChartFrame';
+import { ChartPoint } from '../../data/fixtures';
+import { DataTable } from '../primitives/DataTable';
+
+interface AreaChartProps {
+  title: string;
+  description: string;
+  series: ChartPoint[];
+  gradientId: string;
+  verticalAccent?: string;
+}
+
+export function AreaChart({ title, description, series, gradientId, verticalAccent }: AreaChartProps) {
+  const xScale = scalePoint()
+    .domain(series.map((point) => point.label))
+    .range([0, 600]);
+  const yExtent = extent(series.map((point) => point.value)) as [number, number];
+  const yScale = scaleLinear().domain([0, (yExtent?.[1] ?? 0) * 1.2]).range([200, 0]);
+  const areaGenerator = area<ChartPoint>()
+    .x((point) => xScale(point.label) ?? 0)
+    .y0(200)
+    .y1((point) => yScale(point.value));
+
+  return (
+    <ChartFrame
+      title={title}
+      description={description}
+      table={<DataTable columns={['Label', 'Value']} rows={series.map((point) => [point.label, point.value.toFixed(1)])} />}
+    >
+      <svg className="chart-svg" viewBox="0 0 640 240" role="presentation" focusable={false}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={verticalAccent ?? 'var(--color-info-500)'} stopOpacity={0.4} />
+            <stop offset="100%" stopColor={verticalAccent ?? 'var(--color-info-500)'} stopOpacity={0.05} />
+          </linearGradient>
+        </defs>
+        <path d={areaGenerator(series) ?? ''} fill={`url(#${gradientId})`} stroke={verticalAccent ?? 'var(--color-info-500)'} strokeWidth={2} />
+      </svg>
+    </ChartFrame>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/charts/BarChart.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/charts/BarChart.tsx
@@ -1,0 +1,43 @@
+import { scaleBand, scaleLinear } from 'd3-scale';
+import { ChartPoint } from '../../data/fixtures';
+import { ChartFrame } from './ChartFrame';
+import { DataTable } from '../primitives/DataTable';
+
+interface BarChartProps {
+  title: string;
+  description: string;
+  series: ChartPoint[];
+  palette: string[];
+}
+
+export function BarChart({ title, description, series, palette }: BarChartProps) {
+  const xScale = scaleBand()
+    .domain(series.map((point) => point.label))
+    .range([0, 640])
+    .padding(0.24);
+  const yScale = scaleLinear()
+    .domain([0, Math.max(...series.map((point) => point.value)) * 1.2])
+    .range([240, 0]);
+
+  return (
+    <ChartFrame
+      title={title}
+      description={description}
+      table={<DataTable columns={['Label', 'Value']} rows={series.map((point) => [point.label, point.value.toFixed(1)])} />}
+    >
+      <svg className="chart-svg" viewBox="0 0 640 240" role="presentation" focusable={false}>
+        {series.map((point, index) => (
+          <rect
+            key={point.label}
+            x={xScale(point.label)}
+            y={yScale(point.value)}
+            width={xScale.bandwidth()}
+            height={240 - yScale(point.value)}
+            fill={palette[index % palette.length]}
+            rx={6}
+          />
+        ))}
+      </svg>
+    </ChartFrame>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/charts/ChartFrame.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/charts/ChartFrame.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+interface ChartFrameProps {
+  title: string;
+  description: string;
+  legend?: ReactNode;
+  table: ReactNode;
+  children: ReactNode;
+}
+
+export function ChartFrame({ title, description, legend, table, children }: ChartFrameProps) {
+  return (
+    <figure className="card chart-container" role="group" aria-label={title} tabIndex={0}>
+      <div className="card__header">
+        <div>
+          <h3 className="card__title">{title}</h3>
+          <p className="card__subtitle">{description}</p>
+        </div>
+        {legend}
+      </div>
+      <div className="chart-svg" role="img" aria-label={description}>
+        {children}
+      </div>
+      {table}
+    </figure>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/charts/DonutChart.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/charts/DonutChart.tsx
@@ -1,0 +1,49 @@
+import { pie, arc } from 'd3-shape';
+import { ChartPoint } from '../../data/fixtures';
+import { ChartFrame } from './ChartFrame';
+import { DataTable } from '../primitives/DataTable';
+
+interface DonutChartProps {
+  title: string;
+  description: string;
+  series: ChartPoint[];
+  palette: string[];
+}
+
+export function DonutChart({ title, description, series, palette }: DonutChartProps) {
+  const pieGenerator = pie<ChartPoint>().value((point) => point.value);
+  const arcs = pieGenerator(series);
+  const arcGenerator = arc<typeof arcs[number]>().innerRadius(60).outerRadius(110).padAngle(0.02);
+
+  return (
+    <ChartFrame
+      title={title}
+      description={description}
+      table={<DataTable columns={['Label', 'Value', 'Share']} rows={series.map((point) => [point.label, point.value.toFixed(1), `${((point.value / series.reduce((sum, entry) => sum + entry.value, 0)) * 100).toFixed(1)}%`])} />}
+      legend={
+        <div className="chart-legend">
+          {series.map((point, index) => (
+            <span className="chart-legend__item" key={point.label}>
+              <span className="chart-legend__swatch" style={{ background: palette[index % palette.length] }} />
+              {point.label}
+            </span>
+          ))}
+        </div>
+      }
+    >
+      <svg className="chart-svg" viewBox="0 0 240 240" role="presentation" focusable={false}>
+        <g transform="translate(120,120)">
+          {arcs.map((segment, index) => (
+            <path
+              key={segment.data.label}
+              d={arcGenerator(segment) ?? undefined}
+              fill={palette[index % palette.length]}
+              stroke="var(--surface-S1)"
+              strokeWidth={2}
+            />
+          ))}
+        </g>
+      </svg>
+    </ChartFrame>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/charts/LineChart.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/charts/LineChart.tsx
@@ -1,0 +1,42 @@
+import { line } from 'd3-shape';
+import { scaleLinear, scalePoint } from 'd3-scale';
+import { extent } from 'd3-array';
+import { ChartFrame } from './ChartFrame';
+import { ChartPoint } from '../../data/fixtures';
+import { DataTable } from '../primitives/DataTable';
+
+interface LineChartProps {
+  title: string;
+  description: string;
+  series: ChartPoint[];
+  tone?: 'primary' | 'vertical';
+  verticalAccent?: string;
+}
+
+export function LineChart({ title, description, series, tone = 'primary', verticalAccent }: LineChartProps) {
+  const xScale = scalePoint()
+    .domain(series.map((point) => point.label))
+    .range([0, 600]);
+  const yExtent = extent(series.map((point) => point.value)) as [number, number];
+  const yScale = scaleLinear().domain([0, (yExtent?.[1] ?? 0) * 1.2]).range([200, 0]);
+  const pathGenerator = line<ChartPoint>()
+    .x((point) => xScale(point.label) ?? 0)
+    .y((point) => yScale(point.value));
+
+  const stroke = tone === 'vertical' && verticalAccent ? verticalAccent : 'var(--color-primary-500)';
+
+  return (
+    <ChartFrame
+      title={title}
+      description={description}
+      table={<DataTable columns={['Label', 'Value']} rows={series.map((point) => [point.label, point.value.toFixed(1)])} />}
+    >
+      <svg className="chart-svg" viewBox="0 0 640 240" role="presentation" focusable={false}>
+        <path d={pathGenerator(series) ?? ''} fill="none" stroke={stroke} strokeWidth={3} strokeLinecap="round" />
+        {series.map((point) => (
+          <circle key={point.label} cx={xScale(point.label) ?? 0} cy={yScale(point.value)} r={5} fill={stroke} />
+        ))}
+      </svg>
+    </ChartFrame>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/layout/AppShell.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/layout/AppShell.tsx
@@ -1,0 +1,66 @@
+import { NavLink, useLocation } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { ThemeToggle } from './ThemeToggle';
+import { useGlobalFilters } from '../../state/filtersStore';
+import { FilterChips } from '../primitives/FilterChips';
+import { ToastViewport } from '../primitives/Toast';
+import { VerticalAccentBar } from './VerticalAccentBar';
+
+export interface ModuleRoute {
+  path: string;
+  label: string;
+  accent: string;
+}
+
+interface AppShellProps {
+  children: ReactNode;
+  modules: readonly ({ path: string; label: string; accent: string })[];
+}
+
+export function AppShell({ children, modules }: AppShellProps) {
+  const location = useLocation();
+  const { filters, setFilter } = useGlobalFilters();
+  const activeModule = modules.find((module) => location.pathname.includes(module.path));
+
+  return (
+    <div className="app-shell" data-accent={activeModule?.accent ?? 'saas'}>
+      <VerticalAccentBar accent={activeModule?.accent ?? 'saas'} />
+      <header className="app-shell__header" role="banner">
+        <div>
+          <h1 className="headline">Portfolio-grade Product Operations</h1>
+          <p className="subtitle">Unified intelligence across SaaS, commerce, analytics, and more.</p>
+        </div>
+        <ThemeToggle />
+      </header>
+      <nav className="app-shell__nav" aria-label="Module navigation">
+        <ul>
+          {modules.map((module) => (
+            <li key={module.path}>
+              <NavLink
+                to={`/${module.path}`}
+                className={({ isActive }) => (isActive ? 'nav-link is-active' : 'nav-link')}
+              >
+                {module.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <section className="app-shell__filters" aria-label="Global filters">
+        <FilterChips
+          filters={filters}
+          onFilterChange={(key, value) => setFilter(key, value)}
+          options={{
+            dateRange: ['Last 7 days', 'Last 30 days', 'Quarter to date'],
+            segment: ['All segments', 'Enterprise', 'Mid-market', 'SMB'],
+            channel: ['All channels', 'Web', 'Mobile', 'Partner']
+          }}
+        />
+      </section>
+      <main className="app-shell__main" role="main">
+        {children}
+      </main>
+      <ToastViewport />
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/layout/ThemeToggle.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+  }, [theme]);
+
+  return (
+    <button
+      type="button"
+      className="ghost-button"
+      onClick={() => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))}
+      aria-label="Toggle light and dark theme"
+    >
+      {theme === 'light' ? '🌞 Light' : '🌙 Dark'}
+    </button>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/layout/VerticalAccentBar.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/layout/VerticalAccentBar.tsx
@@ -1,0 +1,7 @@
+interface VerticalAccentBarProps {
+  accent: string;
+}
+
+export function VerticalAccentBar({ accent }: VerticalAccentBarProps) {
+  return <div className="vertical-accent" aria-hidden="true" data-accent={accent} />;
+}

--- a/src/frontend/portfolio-dashboard/src/components/primitives/DataTable.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/primitives/DataTable.tsx
@@ -1,0 +1,31 @@
+interface DataTableProps {
+  columns: string[];
+  rows: (string | number)[][];
+  caption?: string;
+}
+
+export function DataTable({ columns, rows, caption }: DataTableProps) {
+  return (
+    <table className="chart-table" role="table">
+      {caption && <caption>{caption}</caption>}
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th scope="col" key={column}>
+              {column}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={index}>
+            {row.map((cell, cellIndex) => (
+              <td key={cellIndex}>{cell}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/primitives/FilterChips.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/primitives/FilterChips.tsx
@@ -1,0 +1,46 @@
+import { clsx } from 'clsx';
+
+export interface FilterState {
+  [key: string]: string;
+}
+
+interface FilterChipsProps {
+  filters: FilterState;
+  options: Record<string, string[]>;
+  onFilterChange: (key: string, value: string) => void;
+}
+
+export function FilterChips({ filters, options, onFilterChange }: FilterChipsProps) {
+  return (
+    <div className="chip-rail" role="group" aria-label="Filters">
+      {Object.entries(options).map(([filterKey, values]) => (
+        <div key={filterKey} className="chip-group">
+          <span className="chip-label" id={`chip-${filterKey}`}>
+            {startCase(filterKey)}
+          </span>
+          <div className="chip-options" role="radiogroup" aria-labelledby={`chip-${filterKey}`}>
+            {values.map((value) => (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={filters[filterKey] === value}
+                className={clsx('chip', filters[filterKey] === value && 'is-active')}
+                onClick={() => onFilterChange(filterKey, value)}
+              >
+                {value}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function startCase(value: string) {
+  return value
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/[-_]/g, ' ')
+    .replace(/^./, (str) => str.toUpperCase());
+}

--- a/src/frontend/portfolio-dashboard/src/components/primitives/KpiCard.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/primitives/KpiCard.tsx
@@ -1,0 +1,20 @@
+import { KPI, formatKpiValue } from '../../data/fixtures';
+
+interface KpiCardProps {
+  kpi: KPI;
+}
+
+export function KpiCard({ kpi }: KpiCardProps) {
+  return (
+    <article className="kpi-card" role="group" aria-label={kpi.label}>
+      <h3 className="kpi-card__title">{kpi.label}</h3>
+      <p className="kpi-card__value">{formatKpiValue(kpi)}</p>
+      <div className="kpi-card__meta">
+        <span className={kpi.deltaDirection === 'up' ? 'delta-positive' : 'delta-negative'}>
+          {kpi.deltaDirection === 'up' ? '▲' : '▼'} {kpi.delta.toFixed(1)}%
+        </span>
+        <span>{kpi.basis}</span>
+      </div>
+    </article>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/primitives/Skeleton.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/primitives/Skeleton.tsx
@@ -1,0 +1,18 @@
+import { clsx } from 'clsx';
+
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  rounded?: boolean;
+}
+
+export function Skeleton({ width = '100%', height = '1rem', rounded = true }: SkeletonProps) {
+  return (
+    <div
+      className={clsx('skeleton', rounded && 'skeleton--rounded')}
+      style={{ width, height }}
+      role="status"
+      aria-label="Loading"
+    />
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/components/primitives/Toast.tsx
+++ b/src/frontend/portfolio-dashboard/src/components/primitives/Toast.tsx
@@ -1,0 +1,96 @@
+import { ReactNode, useEffect, useId } from 'react';
+import { create } from 'zustand';
+
+interface ToastItem {
+  id: string;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}
+
+interface ToastStore {
+  toasts: ToastItem[];
+  addToast: (toast: Omit<ToastItem, 'id'>) => string;
+  dismissToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  addToast: (toast) => {
+    const id = crypto.randomUUID();
+    set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }));
+    return id;
+  },
+  dismissToast: (id) => set((state) => ({ toasts: state.toasts.filter((toast) => toast.id !== id) }))
+}));
+
+export function ToastViewport() {
+  const toasts = useToastStore((state) => state.toasts);
+  const dismissToast = useToastStore((state) => state.dismissToast);
+  return (
+    <div className="toast-viewport" role="region" aria-live="assertive" aria-label="Notifications">
+      {toasts.map((toast) => (
+        <div key={toast.id} className="toast" role="status">
+          <div>
+            <p className="toast__title">{toast.title}</p>
+            {toast.description && <p className="toast__description">{toast.description}</p>}
+          </div>
+          {toast.action}
+          <button type="button" className="ghost-button" onClick={() => dismissToast(toast.id)}>
+            Close
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface UseOptimisticActionOptions {
+  pendingLabel?: string;
+  successLabel?: string;
+  errorLabel?: string;
+  undoLabel?: string;
+  onUndo?: () => void;
+}
+
+export function useOptimisticAction<T>(
+  action: () => Promise<T>,
+  {
+    pendingLabel = 'Saving…',
+    successLabel = 'Saved',
+    errorLabel = 'Something went wrong',
+    undoLabel = 'Undo',
+    onUndo
+  }: UseOptimisticActionOptions
+) {
+  const addToast = useToastStore((state) => state.addToast);
+  const dismissToast = useToastStore((state) => state.dismissToast);
+  const toastId = useId();
+
+  useEffect(() => {
+    return () => {
+      dismissToast(toastId);
+    };
+  }, [dismissToast, toastId]);
+
+  return async () => {
+    addToast({ id: toastId, title: pendingLabel });
+    try {
+      const result = await action();
+      dismissToast(toastId);
+      addToast({
+        title: successLabel,
+        action: onUndo ? (
+          <button type="button" className="link-button" onClick={onUndo}>
+            {undoLabel}
+          </button>
+        ) : undefined
+      });
+      return result;
+    } catch (error) {
+      dismissToast(toastId);
+      addToast({ title: errorLabel });
+      throw error;
+    }
+  };
+}

--- a/src/frontend/portfolio-dashboard/src/data/fixtures.ts
+++ b/src/frontend/portfolio-dashboard/src/data/fixtures.ts
@@ -1,0 +1,103 @@
+import { addDays, format } from 'date-fns';
+import { range } from 'd3-array';
+
+export interface KPI {
+  label: string;
+  value: number;
+  delta: number;
+  deltaDirection: 'up' | 'down';
+  basis: string;
+  formatter: 'currency' | 'number' | 'percent' | 'duration';
+}
+
+export function formatKpiValue(kpi: KPI): string {
+  const numberFormat = new Intl.NumberFormat('en-US', {
+    style: kpi.formatter === 'currency' ? 'currency' : 'decimal',
+    currency: kpi.formatter === 'currency' ? 'USD' : undefined,
+    maximumFractionDigits: kpi.formatter === 'percent' ? 1 : 0,
+    minimumFractionDigits: kpi.formatter === 'percent' ? 1 : 0
+  });
+
+  if (kpi.formatter === 'duration') {
+    const minutes = Math.floor(kpi.value);
+    const seconds = Math.round((kpi.value % 1) * 60);
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  if (kpi.formatter === 'percent') {
+    return `${numberFormat.format(kpi.value)}%`;
+  }
+
+  return numberFormat.format(kpi.value);
+}
+
+export const saasKpis: KPI[] = [
+  { label: 'Monthly Recurring Revenue', value: 842000, delta: 4.2, deltaDirection: 'up', basis: 'vs prior month', formatter: 'currency' },
+  { label: 'Active Workspaces', value: 1265, delta: 2.1, deltaDirection: 'up', basis: 'vs prior month', formatter: 'number' },
+  { label: 'API Consumption (30 day)', value: 97200000, delta: 6.8, deltaDirection: 'up', basis: 'requests', formatter: 'number' },
+  { label: 'Net Revenue Retention', value: 116.4, delta: -1.2, deltaDirection: 'down', basis: 'vs target', formatter: 'percent' }
+];
+
+export const ecommerceKpis: KPI[] = [
+  { label: 'Gross Merchandise Volume', value: 2450000, delta: 3.6, deltaDirection: 'up', basis: 'vs last week', formatter: 'currency' },
+  { label: 'Orders (7-day)', value: 14820, delta: -2.4, deltaDirection: 'down', basis: 'vs last week', formatter: 'number' },
+  { label: 'Average Order Value', value: 178, delta: 4.1, deltaDirection: 'up', basis: 'vs last week', formatter: 'currency' },
+  { label: 'Return rate', value: 8.6, delta: -0.6, deltaDirection: 'down', basis: 'vs last week', formatter: 'percent' }
+];
+
+export const corporateKpis: KPI[] = [
+  { label: 'Qualified pipeline', value: 13800000, delta: 6.2, deltaDirection: 'up', basis: 'vs target', formatter: 'currency' },
+  { label: 'Monthly unique visitors', value: 620000, delta: 12.4, deltaDirection: 'up', basis: 'vs prior month', formatter: 'number' },
+  { label: 'M→SQL conversion', value: 18.2, delta: 1.4, deltaDirection: 'up', basis: 'percentage', formatter: 'percent' },
+  { label: 'Sales cycle (days)', value: 42, delta: -3.5, deltaDirection: 'down', basis: 'vs baseline', formatter: 'number' }
+];
+
+export const contentMediaKpis: KPI[] = [
+  { label: 'Monthly plays/reads', value: 1840000, delta: 9.6, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+  { label: 'Avg watch time', value: 6.35, delta: 0.4, deltaDirection: 'up', basis: 'minutes', formatter: 'duration' },
+  { label: 'Subscriber growth', value: 18400, delta: 3.1, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+  { label: 'Engagement score', value: 72, delta: 2.3, deltaDirection: 'up', basis: 'index', formatter: 'number' }
+];
+
+export const edtechKpis: KPI[] = [
+  { label: 'Active learners', value: 48200, delta: 5.4, deltaDirection: 'up', basis: 'vs term start', formatter: 'number' },
+  { label: 'Completion rate', value: 86.2, delta: 2.3, deltaDirection: 'up', basis: 'vs prior term', formatter: 'percent' },
+  { label: 'Avg quiz score', value: 84.6, delta: 1.2, deltaDirection: 'up', basis: 'vs prior term', formatter: 'percent' },
+  { label: 'Certificates issued', value: 16240, delta: 4.8, deltaDirection: 'up', basis: 'vs prior term', formatter: 'number' }
+];
+
+export const specializedKpis: Record<string, KPI[]> = {
+  realEstate: [
+    { label: 'Active listings', value: 684, delta: 8.3, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+    { label: 'Qualified inquiries', value: 1820, delta: 3.5, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+    { label: 'Avg response time', value: 2.4, delta: -0.2, deltaDirection: 'down', basis: 'hrs', formatter: 'number' }
+  ],
+  finance: [
+    { label: 'Expense vs budget', value: 94.2, delta: -1.4, deltaDirection: 'down', basis: 'percentage', formatter: 'percent' },
+    { label: 'Close readiness', value: 87, delta: 2.4, deltaDirection: 'up', basis: 'index', formatter: 'number' },
+    { label: 'AP cycle time', value: 14, delta: -1.2, deltaDirection: 'down', basis: 'days', formatter: 'number' }
+  ],
+  healthcare: [
+    { label: 'Patient satisfaction', value: 92.4, delta: 1.1, deltaDirection: 'up', basis: 'score', formatter: 'percent' },
+    { label: 'No-show rate', value: 3.4, delta: -0.4, deltaDirection: 'down', basis: 'vs last month', formatter: 'percent' },
+    { label: 'Avg wait time', value: 8.2, delta: -1.0, deltaDirection: 'down', basis: 'minutes', formatter: 'number' }
+  ]
+};
+
+export interface ChartPoint {
+  label: string;
+  value: number;
+  secondaryValue?: number;
+}
+
+export function generateTimeSeries(days = 30, startValue = 1000, variance = 0.1): ChartPoint[] {
+  const today = new Date();
+  return range(days).map((offset) => {
+    const date = addDays(today, -days + offset);
+    const jitter = (Math.random() - 0.5) * variance * startValue;
+    return {
+      label: format(date, 'MMM dd'),
+      value: Math.max(startValue + jitter + offset * variance * 10, 0)
+    };
+  });
+}

--- a/src/frontend/portfolio-dashboard/src/data/seeds.ts
+++ b/src/frontend/portfolio-dashboard/src/data/seeds.ts
@@ -1,0 +1,15 @@
+import { saasKpis, ecommerceKpis, corporateKpis, contentMediaKpis, edtechKpis, specializedKpis } from './fixtures';
+
+export function seedAllTenants() {
+  return {
+    tenants: ['Acme SaaS', 'Nova Commerce', 'Apex Analytics', 'Orbit Media', 'Campus One', 'CareNet'],
+    kpis: {
+      saas: saasKpis,
+      ecommerce: ecommerceKpis,
+      corporate: corporateKpis,
+      media: contentMediaKpis,
+      edtech: edtechKpis,
+      specialized: specializedKpis
+    }
+  };
+}

--- a/src/frontend/portfolio-dashboard/src/hooks/useLiveKpis.ts
+++ b/src/frontend/portfolio-dashboard/src/hooks/useLiveKpis.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { KPI } from '../data/fixtures';
+
+export function useLiveKpis(initial: KPI[]) {
+  const [kpis, setKpis] = useState(initial);
+
+  useEffect(() => {
+    let animationFrame: number;
+    const controller = new AbortController();
+
+    function handleTick() {
+      setKpis((current) =>
+        current.map((kpi) => ({
+          ...kpi,
+          value: Math.max(kpi.value * (1 + (Math.random() - 0.5) * 0.001), 0)
+        }))
+      );
+      animationFrame = requestAnimationFrame(handleTick);
+    }
+
+    animationFrame = requestAnimationFrame(handleTick);
+
+    const eventSource = new EventSource('/api/kpis', { withCredentials: false });
+    eventSource.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as KPI[];
+        setKpis(payload);
+      } catch (error) {
+        console.error('Failed to parse KPI payload', error);
+      }
+    };
+
+    eventSource.onerror = () => {
+      eventSource.close();
+    };
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      controller.abort();
+      eventSource.close();
+    };
+  }, []);
+
+  return kpis;
+}

--- a/src/frontend/portfolio-dashboard/src/main.tsx
+++ b/src/frontend/portfolio-dashboard/src/main.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './routes/App';
+import { DesignSystemProvider } from './providers/DesignSystemProvider';
+import './styles/global.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 60_000
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <DesignSystemProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </DesignSystemProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/src/frontend/portfolio-dashboard/src/modules/ContentMediaModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/ContentMediaModule.tsx
@@ -1,0 +1,105 @@
+import { contentMediaKpisExtended } from './moduleKpis';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { LineChart } from '../components/charts/LineChart';
+import { DataTable } from '../components/primitives/DataTable';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+
+const topStories = [
+  ['AI in 2024', 'Video', '7 days', '142', 'Published'],
+  ['Climate pulse', 'Podcast', '14 days', '98', 'In review'],
+  ['Retail revival', 'Article', '30 days', '86', 'Ready'],
+  ['Creator economics', 'Livestream', '3 days', '112', 'Blocked']
+];
+
+const publishingQueue = [
+  { title: 'Emerging markets briefing', status: 'ready' },
+  { title: 'Sports weekly digest', status: 'in-review' },
+  { title: 'Highlights generator beta', status: 'blocked' }
+];
+
+export function ContentMediaModule() {
+  const kpis = useLiveKpis(contentMediaKpisExtended);
+  const engagementTrend = kpis.map((kpi, index) => ({ label: kpi.label, value: kpi.value * (1 + index * 0.02) }));
+
+  return (
+    <div className="dashboard-grid" data-accent="media">
+      <section className="kpi-band" aria-label="Content engagement KPIs">
+        {kpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <LineChart
+        title="Engagement trend"
+        description="Watch time and reads momentum with markers for campaign spikes."
+        series={engagementTrend}
+        tone="vertical"
+        verticalAccent="var(--vertical-media)"
+      />
+
+      <div className="card col-6" role="region" aria-labelledby="top-stories">
+        <div className="card__header">
+          <h2 id="top-stories" className="card__title">
+            Top performing stories
+          </h2>
+        </div>
+        <DataTable columns={['Title', 'Format', 'Window', 'Engagement', 'Status']} rows={topStories} />
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="publishing-queue">
+        <div className="card__header">
+          <h2 id="publishing-queue" className="card__title">
+            Publishing queue
+          </h2>
+        </div>
+        <ul className="card-list">
+          {publishingQueue.map((item) => (
+            <li key={item.title}>
+              {item.title}
+              <span className="status-chip" data-tone={statusTone(item.status)}>{item.status}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="media-automations">
+        <div className="card__header">
+          <h2 id="media-automations" className="card__title">
+            Automation orchestration
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Editorial control tower <span className="status-chip" data-tone="success">Live</span></li>
+          <li>Semantic auto-tagging <span className="status-chip" data-tone="warning">Training</span></li>
+          <li>Highlight reel generator <span className="status-chip" data-tone="info">Queued</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-6">
+        <AutomationBuilder
+          name="media"
+          defaults={{
+            trigger: 'Content hits engagement score < 60 or compliance risk flagged',
+            conditions: 'Respect embargo windows and rights management.',
+            actions: 'Auto-tag → Route to editor → Generate highlight reel → Publish to channels',
+            cadence: 'Check every 30 minutes with on-demand rerun.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function statusTone(status: string) {
+  switch (status) {
+    case 'ready':
+      return 'success';
+    case 'in-review':
+      return 'info';
+    case 'blocked':
+      return 'danger';
+    default:
+      return 'info';
+  }
+}

--- a/src/frontend/portfolio-dashboard/src/modules/CorporateAnalyticsModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/CorporateAnalyticsModule.tsx
@@ -1,0 +1,129 @@
+import { corporateKpis, generateTimeSeries } from '../data/fixtures';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { BarChart } from '../components/charts/BarChart';
+import { LineChart } from '../components/charts/LineChart';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+
+const funnelStages = [
+  { label: 'Visitors', value: 1820000 },
+  { label: 'Marketing qualified', value: 126000 },
+  { label: 'Sales qualified', value: 48200 },
+  { label: 'Opportunities', value: 12840 },
+  { label: 'Closed won', value: 4620 }
+];
+
+const executiveInsights = [
+  { statement: 'Performance max campaigns driving 34% of SQLs', tags: ['Acquisition', 'Paid'] },
+  { statement: 'Sales cycle compressing 3.5 days after MEDDIC training rollout', tags: ['Enablement'] },
+  { statement: 'Attribution guardrails paused 4 underperforming creatives', tags: ['Efficiency'] }
+];
+
+const leadMix = [
+  { label: 'Organic', value: 34 },
+  { label: 'Paid social', value: 22 },
+  { label: 'Paid search', value: 18 },
+  { label: 'Events', value: 12 },
+  { label: 'Partners', value: 9 },
+  { label: 'Other', value: 5 }
+];
+
+export function CorporateAnalyticsModule() {
+  const kpis = useLiveKpis(corporateKpis);
+  const salesCycle = generateTimeSeries(10, 46, 0.08);
+
+  return (
+    <div className="dashboard-grid" data-accent="corporate">
+      <section className="kpi-band" aria-label="Corporate analytics KPIs">
+        {kpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <LineChart
+        title="Conversion funnel"
+        description="Visitors to closed won by stage with accessible breakdown."
+        series={funnelStages.map((stage, index) => ({ label: stage.label, value: stage.value * Math.pow(0.82, index) }))}
+        tone="vertical"
+        verticalAccent="var(--vertical-corporate)"
+      />
+
+      <BarChart
+        title="Lead source mix"
+        description="Share of SQLs across major channels."
+        series={leadMix.map((item) => ({ label: item.label, value: item.value }))}
+        palette={["#6E59D9", "#3C66F5", "#22D3EE", "#F59E0B", "#34D399", "#64748B"]}
+      />
+
+      <div className="card col-4" role="region" aria-labelledby="executive-insights">
+        <div className="card__header">
+          <h2 id="executive-insights" className="card__title">
+            Executive insights
+          </h2>
+        </div>
+        <ul className="card-list">
+          {executiveInsights.map((insight) => (
+            <li key={insight.statement}>
+              <p className="card__subtitle">{insight.statement}</p>
+              <div className="chart-legend">
+                {insight.tags.map((tag) => (
+                  <span key={tag} className="badge">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card col-4" role="region" aria-labelledby="modeling">
+        <div className="card__header">
+          <h2 id="modeling" className="card__title">
+            Modeling assumptions
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Multi-touch attribution blending rule-based and Shapley data-driven share.</li>
+          <li>Predictive lead scoring uses intent + firmographic fit with on-demand recalibration.</li>
+          <li>All outputs cached with lineage; downloadable CSV/JSON for audit.</li>
+        </ul>
+      </div>
+
+      <div className="card col-4" role="region" aria-labelledby="automation-corporate">
+        <div className="card__header">
+          <h2 id="automation-corporate" className="card__title">
+            Automations
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Intent surge → ABM bump <span className="status-chip" data-tone="info">Live</span></li>
+          <li>Lifecycle SLA timers <span className="status-chip" data-tone="warning">2 at risk</span></li>
+          <li>Attribution guardrails <span className="status-chip" data-tone="success">Healthy</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-6">
+        <AutomationBuilder
+          name="corporate"
+          defaults={{
+            trigger: 'Predictive score exceeds 82 with high intent signals',
+            conditions: 'Ensure SDR coverage within 2 hours; block duplicates.',
+            actions: 'Auto-route to SDR → Book meeting via Calendly → Notify AE in Slack',
+            cadence: 'Immediate with 2 follow-up nudges at 4h and 24h.'
+          }}
+        />
+      </div>
+
+      <div className="col-6">
+        <LineChart
+          title="Sales cycle velocity"
+          description="Average days to close for the past 10 cohorts."
+          series={salesCycle}
+          tone="vertical"
+          verticalAccent="var(--vertical-corporate)"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/modules/CustomAppModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/CustomAppModule.tsx
@@ -1,0 +1,142 @@
+import { customAppKpis } from './moduleKpis';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+
+const lanes = [
+  { name: 'Backlog', count: 18 },
+  { name: 'In progress', count: 12 },
+  { name: 'Review', count: 6 },
+  { name: 'Done', count: 22 }
+];
+
+const ideas = [
+  'Shared automations library with role permissions',
+  'AI summary on completed rituals',
+  'Dependency graph export',
+  'API triggered board snapshots'
+];
+
+const workload = [
+  { label: 'Design', value: 18 },
+  { label: 'Engineering', value: 26 },
+  { label: 'QA', value: 9 },
+  { label: 'Product', value: 14 }
+];
+
+export function CustomAppModule() {
+  const kpis = useLiveKpis(customAppKpis);
+
+  return (
+    <div className="dashboard-grid" data-accent="custom">
+      <section className="kpi-band" aria-label="Productivity suite KPIs">
+        {kpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <div className="card col-6" role="region" aria-labelledby="kanban-board">
+        <div className="card__header">
+          <h2 id="kanban-board" className="card__title">
+            Kanban delivery board
+          </h2>
+        </div>
+        <div role="list" aria-label="Kanban lanes" className="card-list">
+          {lanes.map((lane) => (
+            <div key={lane.name} role="listitem" tabIndex={0} className="card">
+              <div className="card__header">
+                <h3 className="card__title">{lane.name}</h3>
+                <span className="badge">{lane.count} cards</span>
+              </div>
+              <p className="card__subtitle">
+                Keyboard drag and drop supported. Press space to lift, arrows to move, enter to drop.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="idea-intake">
+        <div className="card__header">
+          <h2 id="idea-intake" className="card__title">
+            Idea backlog intake
+          </h2>
+        </div>
+        <ul className="card-list">
+          {ideas.map((idea) => (
+            <li key={idea}>{idea}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="workload-distribution">
+        <div className="card__header">
+          <h2 id="workload-distribution" className="card__title">
+            Workload distribution
+          </h2>
+        </div>
+        <ul className="card-list">
+          {workload.map((bucket) => (
+            <li key={bucket.label}>
+              {bucket.label}
+              <div className="chart-legend__item">
+                <span className="chart-legend__swatch" style={{ background: 'var(--vertical-custom)' }} />
+                {bucket.value} active items
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card col-3" role="region" aria-labelledby="automation-custom">
+        <div className="card__header">
+          <h2 id="automation-custom" className="card__title">
+            Automations
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Sprint rituals <span className="status-chip" data-tone="success">Scheduled</span></li>
+          <li>Workload rebalancing <span className="status-chip" data-tone="warning">2 flagged</span></li>
+          <li>DevOps hooks <span className="status-chip" data-tone="info">PR sync live</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-3" role="region" aria-labelledby="recurring-task">
+        <div className="card__header">
+          <h2 id="recurring-task" className="card__title">
+            Create recurring task
+          </h2>
+        </div>
+        <form className="card-list">
+          <label htmlFor="task-name">Task</label>
+          <input id="task-name" placeholder="Prep sprint review" required />
+          <label htmlFor="task-cadence">Cadence</label>
+          <select id="task-cadence">
+            <option>Weekly</option>
+            <option>Bi-weekly</option>
+            <option>Monthly</option>
+          </select>
+          <label htmlFor="task-owner">Owner</label>
+          <input id="task-owner" placeholder="Assign team or role" />
+          <div className="form-actions">
+            <button type="submit" className="button-primary">
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card col-6">
+        <AutomationBuilder
+          name="custom"
+          defaults={{
+            trigger: 'Stale cards > 5 days in review lane',
+            conditions: 'Notify only once per day. Skip if deployment blocked.',
+            actions: 'Ping assignee → Add to daily standup agenda → Escalate after 48h',
+            cadence: 'Check every 30 minutes via webhook events.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/modules/EcommerceModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/EcommerceModule.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from 'react';
+import { ecommerceKpis, generateTimeSeries } from '../data/fixtures';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { BarChart } from '../components/charts/BarChart';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+import { DataTable } from '../components/primitives/DataTable';
+
+const topProducts = [
+  ['Trail Runner', '$182,000', '5.6%', '1,240', '▲'],
+  ['All-weather Parka', '$164,000', '6.4%', '820', '▲'],
+  ['Everyday Tee', '$128,400', '3.2%', '2,430', '→'],
+  ['Studio Legging', '$94,200', '4.6%', '560', '▼']
+];
+
+const operationsHealth = [
+  ['Fulfillment SLA', '96%', 'success'],
+  ['Payment health', '99.4%', 'success'],
+  ['Support backlog', '132', 'warning']
+];
+
+export function EcommerceModule() {
+  const kpis = useLiveKpis(ecommerceKpis);
+  const salesTrends = useMemo(() => generateTimeSeries(12, 420, 0.12), []);
+
+  return (
+    <div className="dashboard-grid" data-accent="commerce">
+      <section className="kpi-band" aria-label="Commerce KPIs">
+        {kpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <div className="card col-6" role="region" aria-labelledby="top-products">
+        <div className="card__header">
+          <h2 id="top-products" className="card__title">
+            Top products leaderboard
+          </h2>
+          <p className="card__subtitle">Revenue, conversion, inventory cover, and trend direction.</p>
+        </div>
+        <DataTable columns={['Product', 'Revenue', 'Conversion', 'Inventory', 'Trend']} rows={topProducts} />
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="promotion-builder">
+        <div className="card__header">
+          <h2 id="promotion-builder" className="card__title">
+            Seasonal promotion builder
+          </h2>
+        </div>
+        <form className="card-list" noValidate>
+          <div className="form-field">
+            <label htmlFor="campaign-name">Campaign name</label>
+            <input id="campaign-name" name="campaign-name" required placeholder="Winter VIP drop" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="audience">Audience</label>
+            <select id="audience" name="audience" required>
+              <option value="vip">VIP</option>
+              <option value="loyal">Loyalty tier</option>
+              <option value="prospect">High intent prospects</option>
+            </select>
+          </div>
+          <div className="form-field">
+            <label htmlFor="incentive">Incentive</label>
+            <input id="incentive" name="incentive" required placeholder="Free express shipping + 20%" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="message">Message</label>
+            <textarea id="message" name="message" rows={3} required placeholder="Preview omnichannel message" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="ab-split">A/B Split</label>
+            <input id="ab-split" name="ab-split" type="number" min={0} max={100} defaultValue={50} />
+          </div>
+          <div className="form-field">
+            <label htmlFor="throttle">Throttling guardrail</label>
+            <input id="throttle" name="throttle" placeholder="Pause if inventory cover < 7 days" />
+          </div>
+          <div className="form-actions">
+            <button type="submit" className="button-primary">
+              Launch promotion
+            </button>
+            <button type="button" className="button-secondary">
+              Preview
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <BarChart
+        title="Sales trends"
+        description="Week-over-week merchandise revenue performance."
+        series={salesTrends.map((point) => ({ label: point.label, value: point.value }))}
+        palette={["#E45A3F", "#F59E0B", "#3C66F5"]}
+      />
+
+      <div className="card col-4" role="region" aria-labelledby="automation-commerce">
+        <div className="card__header">
+          <h2 id="automation-commerce" className="card__title">
+            Automation orchestration
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Abandoned cart series <span className="status-chip" data-tone="warning">AOV tiered</span></li>
+          <li>Inventory auto-replenish <span className="status-chip" data-tone="info">12 SKUs queued</span></li>
+          <li>VIP delight <span className="status-chip" data-tone="success">Active</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-4" role="region" aria-labelledby="operational-health">
+        <div className="card__header">
+          <h2 id="operational-health" className="card__title">
+            Operational health
+          </h2>
+        </div>
+        <ul className="card-list">
+          {operationsHealth.map(([label, value, tone]) => (
+            <li key={label}>
+              {label} <span className="status-chip" data-tone={tone}>{value}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card col-4">
+        <AutomationBuilder
+          name="commerce"
+          defaults={{
+            trigger: 'Inventory days of cover below 6 for top 100 SKUs',
+            conditions: 'Skip if PO already in-flight, throttle by supplier capacity.',
+            actions: 'Create PO in ERP → Notify planner → Pause paid campaigns for impacted SKUs',
+            cadence: 'Check every hour during business days.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/modules/EdTechModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/EdTechModule.tsx
@@ -1,0 +1,78 @@
+import { edTechKpisExtended } from './moduleKpis';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { DataTable } from '../components/primitives/DataTable';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+import { BarChart } from '../components/charts/BarChart';
+
+const programPerformance = [
+  ['Intro to Analytics', '1,240', '82%', '88'],
+  ['Cloud Security', '980', '74%', '92'],
+  ['Product Ops', '860', '68%', '84'],
+  ['Design Systems', '720', '86%', '90']
+];
+
+const studentActivity = [
+  { label: 'Mon', value: 82 },
+  { label: 'Tue', value: 96 },
+  { label: 'Wed', value: 74 },
+  { label: 'Thu', value: 88 },
+  { label: 'Fri', value: 64 },
+  { label: 'Sat', value: 48 },
+  { label: 'Sun', value: 36 }
+];
+
+export function EdTechModule() {
+  const kpis = useLiveKpis(edTechKpisExtended);
+
+  return (
+    <div className="dashboard-grid" data-accent="edtech">
+      <section className="kpi-band" aria-label="Learning KPIs">
+        {kpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <div className="card col-6" role="region" aria-labelledby="program-performance">
+        <div className="card__header">
+          <h2 id="program-performance" className="card__title">
+            Program performance
+          </h2>
+        </div>
+        <DataTable columns={['Course', 'Enrollment', 'Completion', 'Avg score']} rows={programPerformance} />
+      </div>
+
+      <BarChart
+        title="Student activity heatmap"
+        description="Relative activity intensity per day with keyboard traversal."
+        series={studentActivity}
+        palette={["#6F4CBB", "#3C66F5", "#22D3EE", "#34D399", "#F59E0B"]}
+      />
+
+      <div className="card col-4" role="region" aria-labelledby="edtech-automations">
+        <div className="card__header">
+          <h2 id="edtech-automations" className="card__title">
+            Automation orchestration
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Auto certificates <span className="status-chip" data-tone="success">Live</span></li>
+          <li>Inactivity nudges <span className="status-chip" data-tone="warning">5 queued</span></li>
+          <li>Mentor rotation <span className="status-chip" data-tone="info">Balancing</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-8">
+        <AutomationBuilder
+          name="edtech"
+          defaults={{
+            trigger: 'Learner inactive for 5 days or mastery dip detected',
+            conditions: 'Respect FERPA preferences; avoid duplicate nudges.',
+            actions: 'Send in-app reminder → Notify mentor → Queue adaptive review set',
+            cadence: 'Evaluate daily with weekend catch-up sweeps.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/modules/SaaSModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/SaaSModule.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import { saasKpis, generateTimeSeries } from '../data/fixtures';
+import { useLiveKpis } from '../hooks/useLiveKpis';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { DonutChart } from '../components/charts/DonutChart';
+import { LineChart } from '../components/charts/LineChart';
+import { AreaChart } from '../components/charts/AreaChart';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+import { DataTable } from '../components/primitives/DataTable';
+
+const churnHealth = [
+  { label: 'Healthy', value: 68 },
+  { label: 'Monitor', value: 22 },
+  { label: 'Critical', value: 10 }
+];
+
+const subscriptionPlans = [
+  ['Scale', '$1,200', '250 seats', '91%', '88%', '6%'],
+  ['Growth', '$620', '120 seats', '82%', '76%', '9%'],
+  ['Starter', '$240', '40 seats', '67%', '54%', '14%']
+];
+
+export function SaaSModule() {
+  const liveKpis = useLiveKpis(saasKpis);
+  const mrrGrowth = useMemo(() => generateTimeSeries(16, 780, 0.08), []);
+  const apiUsage = useMemo(() => generateTimeSeries(16, 72, 0.12), []);
+
+  return (
+    <div className="dashboard-grid" data-accent="saas">
+      <section className="kpi-band" aria-label="Subscription KPIs">
+        {liveKpis.map((kpi) => (
+          <KpiCard key={kpi.label} kpi={kpi} />
+        ))}
+      </section>
+
+      <div className="card col-8" role="region" aria-labelledby="subscription-plans">
+        <div className="card__header">
+          <h2 id="subscription-plans" className="card__title">
+            Subscription plans
+          </h2>
+          <p className="card__subtitle">Plan composition, activation health, allocation, and churn risk.</p>
+        </div>
+        <DataTable
+          columns={["Plan", "Price", "Seats", "Activation", "Allocation", "Churn"]}
+          rows={subscriptionPlans}
+        />
+      </div>
+
+      <DonutChart
+        title="Churn health"
+        description="Breakdown of healthy, monitor, and critical cohorts."
+        series={churnHealth}
+        palette={["#1C3AB0", "#F59E0B", "#B91C1C"]}
+      />
+
+      <LineChart
+        title="MRR growth"
+        description="Trailing 16-week MRR performance with optimistically updated values."
+        series={mrrGrowth}
+        tone="vertical"
+        verticalAccent="var(--vertical-saas)"
+      />
+
+      <AreaChart
+        title="API usage saturation"
+        description="Normalized usage across major endpoints vs allocation."
+        series={apiUsage}
+        gradientId="api-usage"
+        verticalAccent="var(--vertical-saas)"
+      />
+
+      <div className="card col-4" role="region" aria-labelledby="billing-cycle">
+        <div className="card__header">
+          <h2 id="billing-cycle" className="card__title">
+            Billing cycle orchestration
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Card expiry sweep <span className="status-chip" data-tone="warning">9 expiring</span></li>
+          <li>Dunning workflow <span className="status-chip" data-tone="info">Retrying</span></li>
+          <li>Monthly close checklist <span className="status-chip" data-tone="success">On track</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-4" role="region" aria-labelledby="churn-playbook">
+        <div className="card__header">
+          <h2 id="churn-playbook" className="card__title">
+            Churn recovery playbook
+          </h2>
+        </div>
+        <form className="card-list" aria-describedby="churn-guidance">
+          <p id="churn-guidance" className="card__subtitle">
+            Templates orchestrate multi-channel outreach. Guardrails enforce seat utilization thresholds.
+          </p>
+          <label htmlFor="template-select">Template</label>
+          <select id="template-select">
+            <option>Predictive churn outreach</option>
+            <option>API regression follow-up</option>
+            <option>Seat underuse activation</option>
+          </select>
+          <label htmlFor="fallback-owner">Fallback owner</label>
+          <input id="fallback-owner" type="text" placeholder="Select escalation owner" />
+          <label htmlFor="trigger-threshold">Trigger threshold</label>
+          <input id="trigger-threshold" type="number" min={0} max={100} placeholder="NRR dip (%)" />
+          <label htmlFor="message-preview">Message preview</label>
+          <textarea id="message-preview" rows={3} placeholder="Preview localized outreach copy" />
+          <div className="form-actions">
+            <button type="submit" className="button-primary">
+              Launch playbook
+            </button>
+            <button type="button" className="button-secondary">
+              Save draft
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card col-4" role="region" aria-labelledby="automation-panel">
+        <div className="card__header">
+          <h2 id="automation-panel" className="card__title">
+            Automation orchestration
+          </h2>
+        </div>
+        <ul className="card-list">
+          <li>Billing reconciliation <span className="status-chip" data-tone="success">Enabled</span></li>
+          <li>Churn signals &rarr; CSM task <span className="status-chip" data-tone="warning">Threshold 12%</span></li>
+          <li>Burst protection <span className="status-chip" data-tone="info">Monitoring</span></li>
+        </ul>
+      </div>
+
+      <div className="card col-8">
+        <AutomationBuilder
+          name="saas"
+          defaults={{
+            trigger: 'NRR dips below 110% or API usage drops 15% week-over-week',
+            conditions: 'Exclude enterprise tier. Confirm payment method healthy.',
+            actions: 'Create CSM task → Slack channel ping → Email workspace admin with localized template',
+            cadence: 'Immediately. Re-evaluate every 24 hours for 5 days.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/modules/SpecializedNichesModule.tsx
+++ b/src/frontend/portfolio-dashboard/src/modules/SpecializedNichesModule.tsx
@@ -1,0 +1,113 @@
+import { specializedKpis } from '../data/fixtures';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { DonutChart } from '../components/charts/DonutChart';
+import { AreaChart } from '../components/charts/AreaChart';
+import { DataTable } from '../components/primitives/DataTable';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+
+const listings = [
+  ['Marina tower penthouse', 'Active', '6 offers'],
+  ['SoHo loft', 'In negotiation', '3 offers'],
+  ['Austin tech campus', 'New', '2 tours'],
+  ['Mountain lodge', 'Under contract', '1 offer']
+];
+
+const appointments = [
+  ['Cardiology', '32', 'HIPAA compliant', '2 reschedules'],
+  ['Oncology', '26', 'HIPAA compliant', '0 reschedules'],
+  ['Pediatrics', '44', 'HIPAA compliant', '5 reschedules']
+];
+
+const expenseVsBudget = [
+  { label: 'Q1', value: 92 },
+  { label: 'Q2', value: 96 },
+  { label: 'Q3', value: 101 },
+  { label: 'Q4', value: 88 }
+];
+
+const roiBreakdown = [
+  { label: 'Acquisition', value: 42 },
+  { label: 'Retention', value: 28 },
+  { label: 'Expansion', value: 22 },
+  { label: 'Other', value: 8 }
+];
+
+export function SpecializedNichesModule() {
+  return (
+    <div className="dashboard-grid" data-accent="specialized">
+      <section className="kpi-band" aria-label="Specialized KPIs">
+        {Object.entries(specializedKpis).map(([vertical, kpis]) => (
+          <div key={vertical} className="card">
+            <h3 className="card__title">{titleCase(vertical)}</h3>
+            <div className="card-list">
+              {kpis.map((kpi) => (
+                <KpiCard key={kpi.label} kpi={kpi} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <AreaChart
+        title="Market momentum"
+        description="Listings volume vs inquiries trend."
+        series={expenseVsBudget.map((item, index) => ({ label: item.label, value: item.value * (index + 1) * 10 }))}
+        gradientId="market-momentum"
+        verticalAccent="var(--vertical-specialized)"
+      />
+
+      <DonutChart
+        title="ROI breakdown"
+        description="Contribution by initiative with AA contrast palette."
+        series={roiBreakdown}
+        palette={["#4C86B7", "#34D399", "#F59E0B", "#EF4444"]}
+      />
+
+      <div className="card col-6" role="region" aria-labelledby="listings">
+        <div className="card__header">
+          <h2 id="listings" className="card__title">
+            Listings & inquiries
+          </h2>
+        </div>
+        <DataTable columns={['Listing', 'Status', 'Activity']} rows={listings} />
+      </div>
+
+      <div className="card col-6" role="region" aria-labelledby="appointments">
+        <div className="card__header">
+          <h2 id="appointments" className="card__title">
+            Healthcare appointments
+          </h2>
+        </div>
+        <DataTable columns={['Department', 'Appointments', 'Compliance', 'Reschedules']} rows={appointments} />
+      </div>
+
+      <div className="card col-6">
+        <AutomationBuilder
+          name="specialized-real-estate"
+          defaults={{
+            trigger: 'New listing hits high-momentum micro-market',
+            conditions: 'Check agent availability; enforce compliance disclosures.',
+            actions: 'Notify agent → Launch listing nurture drip → Monitor responses',
+            cadence: 'Every hour with immediate kickoff on upload.'
+          }}
+        />
+      </div>
+
+      <div className="card col-6">
+        <AutomationBuilder
+          name="specialized-healthcare"
+          defaults={{
+            trigger: 'Patient misses appointment or reschedules twice',
+            conditions: 'Respect HIPAA preferences; mask PHI in logs.',
+            actions: 'Send SMS reminder via Twilio → Offer smart reschedule → Log to audit trail',
+            cadence: 'Check daily at 6am local facility time.'
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function titleCase(value: string) {
+  return value.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());
+}

--- a/src/frontend/portfolio-dashboard/src/modules/moduleKpis.ts
+++ b/src/frontend/portfolio-dashboard/src/modules/moduleKpis.ts
@@ -1,0 +1,22 @@
+import { KPI } from '../data/fixtures';
+
+export const customAppKpis: KPI[] = [
+  { label: 'Active rituals', value: 420, delta: 6.2, deltaDirection: 'up', basis: 'vs last sprint', formatter: 'number' },
+  { label: 'Automation coverage', value: 62.4, delta: 3.8, deltaDirection: 'up', basis: 'vs last sprint', formatter: 'percent' },
+  { label: 'Cycle time', value: 4.6, delta: -0.4, deltaDirection: 'down', basis: 'days', formatter: 'number' },
+  { label: 'NPS', value: 68, delta: 2.4, deltaDirection: 'up', basis: 'rolling 30d', formatter: 'number' }
+];
+
+export const contentMediaKpisExtended: KPI[] = [
+  { label: 'Monthly plays/reads', value: 1840000, delta: 9.6, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+  { label: 'Avg watch time', value: 6.35, delta: 0.4, deltaDirection: 'up', basis: 'minutes', formatter: 'duration' },
+  { label: 'Subscriber growth', value: 18400, delta: 3.1, deltaDirection: 'up', basis: 'vs last month', formatter: 'number' },
+  { label: 'Engagement score', value: 72, delta: 2.3, deltaDirection: 'up', basis: 'index', formatter: 'number' }
+];
+
+export const edTechKpisExtended: KPI[] = [
+  { label: 'Active learners', value: 48200, delta: 5.4, deltaDirection: 'up', basis: 'vs term start', formatter: 'number' },
+  { label: 'Completion rate', value: 86.2, delta: 2.3, deltaDirection: 'up', basis: 'vs prior term', formatter: 'percent' },
+  { label: 'Avg quiz score', value: 84.6, delta: 1.2, deltaDirection: 'up', basis: 'vs prior term', formatter: 'percent' },
+  { label: 'Certificates issued', value: 16240, delta: 4.8, deltaDirection: 'up', basis: 'vs prior term', formatter: 'number' }
+];

--- a/src/frontend/portfolio-dashboard/src/providers/DesignSystemProvider.tsx
+++ b/src/frontend/portfolio-dashboard/src/providers/DesignSystemProvider.tsx
@@ -1,0 +1,14 @@
+import { ReactNode, useEffect } from 'react';
+import { designTokens, injectTheme } from '../styles/tokens';
+
+interface DesignSystemProviderProps {
+  children: ReactNode;
+}
+
+export function DesignSystemProvider({ children }: DesignSystemProviderProps) {
+  useEffect(() => {
+    injectTheme(designTokens);
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/frontend/portfolio-dashboard/src/routes/App.tsx
+++ b/src/frontend/portfolio-dashboard/src/routes/App.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { AppShell } from '../components/layout/AppShell';
+import { SaaSModule } from '../modules/SaaSModule';
+import { EcommerceModule } from '../modules/EcommerceModule';
+import { CorporateAnalyticsModule } from '../modules/CorporateAnalyticsModule';
+import { CustomAppModule } from '../modules/CustomAppModule';
+import { ContentMediaModule } from '../modules/ContentMediaModule';
+import { EdTechModule } from '../modules/EdTechModule';
+import { SpecializedNichesModule } from '../modules/SpecializedNichesModule';
+
+const moduleRoutes = [
+  { path: 'saas', label: 'SaaS', element: <SaaSModule />, accent: 'saas' },
+  { path: 'ecommerce', label: 'E-commerce', element: <EcommerceModule />, accent: 'commerce' },
+  { path: 'corporate', label: 'Corporate Analytics', element: <CorporateAnalyticsModule />, accent: 'corporate' },
+  { path: 'custom-app', label: 'Custom Web App', element: <CustomAppModule />, accent: 'custom' },
+  { path: 'content-media', label: 'Content & Media', element: <ContentMediaModule />, accent: 'media' },
+  { path: 'edtech', label: 'EdTech', element: <EdTechModule />, accent: 'edtech' },
+  { path: 'specialized', label: 'Specialized Niches', element: <SpecializedNichesModule />, accent: 'specialized' }
+] as const;
+
+export default function App() {
+  return (
+    <AppShell modules={moduleRoutes}>
+      <Routes>
+        {moduleRoutes.map((route) => (
+          <Route key={route.path} path={`/${route.path}`} element={route.element} />
+        ))}
+        <Route path="/" element={<Navigate to="/saas" replace />} />
+      </Routes>
+    </AppShell>
+  );
+}

--- a/src/frontend/portfolio-dashboard/src/state/filtersStore.ts
+++ b/src/frontend/portfolio-dashboard/src/state/filtersStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { FilterState } from '../components/primitives/FilterChips';
+
+interface FilterStore {
+  filters: FilterState;
+  setFilter: (key: string, value: string) => void;
+}
+
+const defaultFilters: FilterState = {
+  dateRange: 'Last 30 days',
+  segment: 'All segments',
+  channel: 'All channels'
+};
+
+export const useGlobalFilters = create<FilterStore>()(
+  persist(
+    (set) => ({
+      filters: defaultFilters,
+      setFilter: (key, value) =>
+        set((state) => ({
+          filters: {
+            ...state.filters,
+            [key]: value
+          }
+        }))
+    }),
+    {
+      name: 'portfolio-global-filters'
+    }
+  )
+);

--- a/src/frontend/portfolio-dashboard/src/stories/AutomationBuilder.stories.tsx
+++ b/src/frontend/portfolio-dashboard/src/stories/AutomationBuilder.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AutomationBuilder } from '../components/automation/AutomationBuilder';
+
+const meta: Meta<typeof AutomationBuilder> = {
+  title: 'Components/Automation Builder',
+  component: AutomationBuilder,
+  parameters: {
+    layout: 'fullscreen'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AutomationBuilder>;
+
+export const SaaSPlaybook: Story = {
+  args: {
+    name: 'storybook-saas',
+    defaults: {
+      trigger: 'API consumption drops 20% in 24 hours',
+      conditions: 'Exclude sandboxes, respect enterprise SLA.',
+      actions: 'Send Slack alert → Create CSM task → Fire webhook',
+      cadence: 'Run hourly until resolved'
+    }
+  }
+};

--- a/src/frontend/portfolio-dashboard/src/stories/KpiCard.stories.tsx
+++ b/src/frontend/portfolio-dashboard/src/stories/KpiCard.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { KpiCard } from '../components/primitives/KpiCard';
+import { KPI } from '../data/fixtures';
+
+const meta: Meta<typeof KpiCard> = {
+  title: 'Components/KPI Card',
+  component: KpiCard,
+  parameters: {
+    controls: { expanded: true }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof KpiCard>;
+
+const baseKpi: KPI = {
+  label: 'Monthly Recurring Revenue',
+  value: 842000,
+  delta: 4.2,
+  deltaDirection: 'up',
+  basis: 'vs prior month',
+  formatter: 'currency'
+};
+
+export const Default: Story = {
+  args: {
+    kpi: baseKpi
+  }
+};
+
+export const NegativeDelta: Story = {
+  args: {
+    kpi: { ...baseKpi, delta: -1.8, deltaDirection: 'down', value: 812000 }
+  }
+};

--- a/src/frontend/portfolio-dashboard/src/styles/global.css
+++ b/src/frontend/portfolio-dashboard/src/styles/global.css
@@ -1,0 +1,511 @@
+:root {
+  font-family: var(--font-family);
+  background-color: var(--surface-S2);
+  color: #0f172a;
+}
+
+[data-theme='dark'] body {
+  background-color: var(--surface-S1);
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--surface-S2);
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1440px;
+  margin: 0 auto;
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+
+.vertical-accent {
+  position: fixed;
+  inset-block: 0;
+  inline-size: 6px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, currentColor 12%, currentColor 88%, rgba(255, 255, 255, 0) 100%);
+  z-index: 0;
+}
+
+.vertical-accent[data-accent='saas'] { color: var(--vertical-saas); }
+.vertical-accent[data-accent='commerce'] { color: var(--vertical-commerce); }
+.vertical-accent[data-accent='corporate'] { color: var(--vertical-corporate); }
+.vertical-accent[data-accent='custom'] { color: var(--vertical-custom); }
+.vertical-accent[data-accent='media'] { color: var(--vertical-media); }
+.vertical-accent[data-accent='edtech'] { color: var(--vertical-edtech); }
+.vertical-accent[data-accent='specialized'] { color: var(--vertical-specialized); }
+
+.app-shell__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  position: sticky;
+  top: 0;
+  padding: 16px 24px;
+  background: color-mix(in srgb, var(--surface-S1) 90%, transparent);
+  border: 1px solid var(--surface-border);
+  border-radius: 16px;
+  box-shadow: var(--surface-shadow);
+  backdrop-filter: blur(12px);
+  z-index: 2;
+}
+
+.headline {
+  font: var(--font-h1);
+  margin: 0;
+}
+
+.subtitle {
+  font: var(--font-body);
+  color: rgba(15, 23, 42, 0.64);
+  margin: 8px 0 0;
+}
+
+[data-theme='dark'] .subtitle {
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.app-shell__nav ul {
+  display: flex;
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font: var(--font-body);
+  background: color-mix(in srgb, var(--surface-S1) 80%, transparent);
+  border: 1px solid transparent;
+  transition: all var(--transition-duration) var(--transition-ease);
+}
+
+.nav-link.is-active {
+  border-color: var(--surface-border);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
+}
+
+.app-shell__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chip-rail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.chip-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chip-label {
+  font: var(--font-caption);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.chip-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface-S1);
+  font: var(--font-body);
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+}
+
+.chip.is-active {
+  border-color: var(--color-primary-500);
+  color: var(--color-primary-500);
+  background: color-mix(in srgb, var(--color-primary-500) 12%, var(--surface-S1));
+}
+
+.app-shell__main {
+  display: grid;
+  gap: 24px;
+}
+
+.ghost-button {
+  border: 1px solid var(--surface-border);
+  background: var(--surface-S1);
+  color: inherit;
+  font: var(--font-body);
+  padding: 8px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--color-primary-500);
+  font: var(--font-body);
+  cursor: pointer;
+}
+
+.toast-viewport {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: grid;
+  gap: 12px;
+  width: min(360px, 100%);
+}
+
+.toast {
+  background: var(--surface-S1);
+  border-radius: 12px;
+  border: 1px solid var(--surface-border);
+  padding: 16px;
+  box-shadow: var(--surface-shadow);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.toast__title {
+  font: var(--font-h3);
+  margin: 0 0 4px;
+}
+
+.toast__description {
+  font: var(--font-body);
+  margin: 0;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.12) 0%, rgba(148, 163, 184, 0.24) 50%, rgba(148, 163, 184, 0.12) 100%);
+  animation: shimmer 1.2s infinite;
+}
+
+.skeleton--rounded {
+  border-radius: 999px;
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.dashboard-grid > * {
+  grid-column: span 12;
+}
+
+@media (min-width: 1024px) {
+  .dashboard-grid .col-8 { grid-column: span 8; }
+  .dashboard-grid .col-4 { grid-column: span 4; }
+  .dashboard-grid .col-6 { grid-column: span 6; }
+  .dashboard-grid .col-3 { grid-column: span 3; }
+}
+
+@media (max-width: 1023px) and (min-width: 768px) {
+  .dashboard-grid .col-8,
+  .dashboard-grid .col-4,
+  .dashboard-grid .col-6,
+  .dashboard-grid .col-3 {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-shell {
+    padding: 16px;
+  }
+  .dashboard-grid {
+    gap: 12px;
+  }
+  .app-shell__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .kpi-band {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 80%;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    gap: 16px;
+    padding-bottom: 8px;
+  }
+  .kpi-card {
+    scroll-snap-align: start;
+  }
+}
+
+.card {
+  background: var(--surface-S1);
+  border-radius: 16px;
+  border: 1px solid var(--surface-border);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--surface-shadow);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card__title {
+  font: var(--font-h2);
+  margin: 0;
+}
+
+.card__subtitle {
+  font: var(--font-body);
+  color: rgba(15, 23, 42, 0.64);
+  margin: 0;
+}
+
+[data-theme='dark'] .card__subtitle {
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table thead {
+  position: sticky;
+  top: 0;
+  background: var(--surface-S1);
+}
+
+.data-table th,
+.data-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--surface-border);
+  font: var(--font-body);
+}
+
+.data-table th {
+  text-align: left;
+  font: var(--font-h3);
+}
+
+.focus-ring:focus {
+  outline: 3px solid color-mix(in srgb, var(--color-primary-500) 40%, transparent);
+  outline-offset: 2px;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font: var(--font-caption);
+  border: 1px solid currentColor;
+}
+
+.status-chip[data-tone='success'] { color: var(--color-success-500); }
+.status-chip[data-tone='warning'] { color: var(--color-warning-500); }
+.status-chip[data-tone='danger'] { color: var(--color-danger-500); }
+.status-chip[data-tone='info'] { color: var(--color-info-500); }
+
+.automation-builder {
+  display: grid;
+  gap: 16px;
+}
+
+.automation-step {
+  display: grid;
+  gap: 8px;
+}
+
+.chart-container {
+  position: relative;
+}
+
+.chart-svg {
+  width: 100%;
+  height: 240px;
+}
+
+.chart-table {
+  margin-top: 12px;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.chart-table caption {
+  text-align: left;
+  font: var(--font-caption);
+  margin-bottom: 8px;
+}
+
+.chart-table th,
+.chart-table td {
+  border: 1px solid var(--surface-border);
+  padding: 8px;
+  font: var(--font-body);
+}
+
+.kpi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px;
+  border-radius: 16px;
+  background: var(--surface-S1);
+  border: 1px solid var(--surface-border);
+  min-height: 160px;
+  box-shadow: var(--surface-shadow);
+}
+
+.kpi-card__title {
+  font: var(--font-h3);
+  margin: 0;
+}
+
+.kpi-card__value {
+  font-variant-numeric: tabular-nums;
+  font: var(--font-h1);
+  margin: 0;
+}
+
+.kpi-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font: var(--font-body);
+}
+
+.delta-positive { color: var(--color-success-500); }
+.delta-negative { color: var(--color-danger-500); }
+
+.section-title {
+  font: var(--font-h2);
+  margin: 0;
+}
+
+.card-list {
+  display: grid;
+  gap: 16px;
+}
+
+.form-field {
+  display: grid;
+  gap: 8px;
+}
+
+input,
+select,
+textarea {
+  border-radius: 12px;
+  border: 1px solid var(--surface-border);
+  padding: 12px 16px;
+  font: var(--font-body);
+  background: var(--surface-S1);
+  min-height: 44px;
+}
+
+label {
+  font: var(--font-caption);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.button-primary {
+  border: none;
+  border-radius: 12px;
+  background: var(--color-primary-500);
+  color: white;
+  padding: 12px 20px;
+  font: var(--font-body);
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.button-secondary {
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 12px 20px;
+  font: var(--font-body);
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font: var(--font-caption);
+}
+
+.chart-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chart-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  border: 1px solid var(--surface-border);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font: var(--font-caption);
+  background: color-mix(in srgb, var(--color-primary-500) 12%, transparent);
+  color: var(--color-primary-500);
+}

--- a/src/frontend/portfolio-dashboard/src/styles/tokens.ts
+++ b/src/frontend/portfolio-dashboard/src/styles/tokens.ts
@@ -1,0 +1,197 @@
+export interface ColorScale {
+  [shade: number]: string;
+}
+
+export interface SemanticPalette {
+  primary: ColorScale;
+  success: ColorScale;
+  warning: ColorScale;
+  danger: ColorScale;
+  info: ColorScale;
+}
+
+export interface SurfaceTokens {
+  S0: string;
+  S1: string;
+  S2: string;
+  S3: string;
+  border: string;
+  shadow: string;
+}
+
+export interface DesignTokens {
+  typography: {
+    fontFamily: string;
+    headline1: string;
+    headline2: string;
+    headline3: string;
+    body: string;
+    caption: string;
+  };
+  spacingScale: number[];
+  palette: SemanticPalette;
+  verticalAccents: Record<string, string>;
+  surfaces: {
+    light: SurfaceTokens;
+    dark: SurfaceTokens;
+  };
+  transitions: {
+    duration: string;
+    timing: string;
+  };
+}
+
+export const designTokens: DesignTokens = {
+  typography: {
+    fontFamily: "'InterVariable', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    headline1: '700 32px/36px var(--font-family)',
+    headline2: '600 22px/28px var(--font-family)',
+    headline3: '600 16px/24px var(--font-family)',
+    body: '400 14px/20px var(--font-family)',
+    caption: '500 12px/16px var(--font-family)'
+  },
+  spacingScale: Array.from({ length: 16 }, (_, index) => index * 8),
+  palette: {
+    primary: {
+      50: '#F2F6FF',
+      100: '#D9E3FF',
+      200: '#B0C4FF',
+      300: '#809EFF',
+      400: '#5A80FF',
+      500: '#3C66F5',
+      600: '#2A4CD6',
+      700: '#1C3AB0',
+      800: '#122780',
+      900: '#0A1A59'
+    },
+    success: {
+      50: '#ECFDF5',
+      100: '#D1FAE5',
+      200: '#A7F3D0',
+      300: '#6EE7B7',
+      400: '#34D399',
+      500: '#10B981',
+      600: '#059669',
+      700: '#047857',
+      800: '#065F46',
+      900: '#064E3B'
+    },
+    warning: {
+      50: '#FFFBEB',
+      100: '#FEF3C7',
+      200: '#FDE68A',
+      300: '#FCD34D',
+      400: '#FBBF24',
+      500: '#F59E0B',
+      600: '#D97706',
+      700: '#B45309',
+      800: '#92400E',
+      900: '#78350F'
+    },
+    danger: {
+      50: '#FEF2F2',
+      100: '#FEE2E2',
+      200: '#FECACA',
+      300: '#FCA5A5',
+      400: '#F87171',
+      500: '#EF4444',
+      600: '#DC2626',
+      700: '#B91C1C',
+      800: '#991B1B',
+      900: '#7F1D1D'
+    },
+    info: {
+      50: '#ECFEFF',
+      100: '#CFFAFE',
+      200: '#A5F3FC',
+      300: '#67E8F9',
+      400: '#22D3EE',
+      500: '#06B6D4',
+      600: '#0891B2',
+      700: '#0E7490',
+      800: '#155E75',
+      900: '#164E63'
+    }
+  },
+  verticalAccents: {
+    saas: '#5A80FF',
+    commerce: '#E45A3F',
+    corporate: '#6E59D9',
+    custom: '#409C8C',
+    media: '#FF8A4C',
+    edtech: '#6F4CBB',
+    specialized: '#4C86B7'
+  },
+  surfaces: {
+    light: {
+      S0: '#0B0E1A',
+      S1: '#FFFFFF',
+      S2: '#F5F7FB',
+      S3: 'rgba(12, 28, 64, 0.08)',
+      border: 'rgba(13, 36, 64, 0.12)',
+      shadow: '0px 12px 32px rgba(12, 28, 64, 0.08)'
+    },
+    dark: {
+      S0: '#F8FBFF',
+      S1: '#0F172A',
+      S2: '#121C33',
+      S3: 'rgba(4, 12, 26, 0.64)',
+      border: 'rgba(148, 163, 184, 0.24)',
+      shadow: '0px 16px 40px rgba(2, 6, 23, 0.6)'
+    }
+  },
+  transitions: {
+    duration: '200ms',
+    timing: 'cubic-bezier(0.4, 0, 0.2, 1)'
+  }
+};
+
+function tokenCSS(customTokens: DesignTokens) {
+  const { typography, palette, verticalAccents, surfaces, transitions } = customTokens;
+  return `:root {
+    --font-family: ${typography.fontFamily};
+    --font-h1: ${typography.headline1};
+    --font-h2: ${typography.headline2};
+    --font-h3: ${typography.headline3};
+    --font-body: ${typography.body};
+    --font-caption: ${typography.caption};
+    --transition-duration: ${transitions.duration};
+    --transition-ease: ${transitions.timing};
+    --surface-S1: ${surfaces.light.S1};
+    --surface-S2: ${surfaces.light.S2};
+    --surface-S3: ${surfaces.light.S3};
+    --surface-border: ${surfaces.light.border};
+    --surface-shadow: ${surfaces.light.shadow};
+    --color-primary-500: ${palette.primary[500]};
+    --color-success-500: ${palette.success[500]};
+    --color-warning-500: ${palette.warning[500]};
+    --color-danger-500: ${palette.danger[500]};
+    --color-info-500: ${palette.info[500]};
+    --vertical-saas: ${verticalAccents.saas};
+    --vertical-commerce: ${verticalAccents.commerce};
+    --vertical-corporate: ${verticalAccents.corporate};
+    --vertical-custom: ${verticalAccents.custom};
+    --vertical-media: ${verticalAccents.media};
+    --vertical-edtech: ${verticalAccents.edtech};
+    --vertical-specialized: ${verticalAccents.specialized};
+  }
+  [data-theme="dark"] {
+    color-scheme: dark;
+    --surface-S1: ${surfaces.dark.S1};
+    --surface-S2: ${surfaces.dark.S2};
+    --surface-S3: ${surfaces.dark.S3};
+    --surface-border: ${surfaces.dark.border};
+    --surface-shadow: ${surfaces.dark.shadow};
+  }`;
+}
+
+let injected = false;
+
+export function injectTheme(tokens: DesignTokens) {
+  if (injected) return;
+  const style = document.createElement('style');
+  style.id = 'portfolio-design-tokens';
+  style.textContent = tokenCSS(tokens);
+  document.head.appendChild(style);
+  injected = true;
+}

--- a/src/frontend/portfolio-dashboard/src/utils/connectors.ts
+++ b/src/frontend/portfolio-dashboard/src/utils/connectors.ts
@@ -1,0 +1,30 @@
+export interface ConnectorResponse<T> {
+  data: T;
+  lastSynced: string;
+  status: 'ok' | 'error';
+}
+
+export async function mockSnowflakeQuery<T>(payload: T): Promise<ConnectorResponse<T>> {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  return {
+    data: payload,
+    lastSynced: new Date().toISOString(),
+    status: 'ok'
+  };
+}
+
+export async function mockWebhookDelivery(event: string) {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return {
+    event,
+    idempotencyKey: crypto.randomUUID(),
+    signature: 'sha256=mock-signature',
+    deliveredAt: new Date().toISOString()
+  };
+}
+
+export async function mockSseStream<T>(callback: (event: T) => void, events: T[]) {
+  events.forEach((event, index) => {
+    setTimeout(() => callback(event), 200 * index);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold a Vite + React workspace for the portfolio-grade product operations dashboard with shared routing, filters, and theming
- codify the design system tokens, responsive layout primitives, charts, and automation builder with optimistic toasts
- implement SaaS, commerce, analytics, productivity, media, edtech, and specialized modules plus Storybook stories and docs

## Testing
- `npm install` *(fails: registry access to @storybook/addon-essentials is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52f401730832ebd6c6c565bffc7d6