### PR TITLE
feat: refresh dashboard theming and hero presentation

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -1216,16 +1216,19 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
 
   return (
     <div className="min-h-screen bg-[var(--surface-s0)] pb-16 text-slate-900">
-      <header className="border-b border-[var(--surface-border)] bg-[var(--surface-s1)]/90 backdrop-blur">
+      <header className="border-b border-[var(--surface-border)] bg-white/95 shadow-xl shadow-purple-500/10 backdrop-blur-xl">
         <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
           <div className="flex flex-wrap items-center justify-between gap-6">
             <div className="space-y-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Portfolio-grade product operations</p>
-              <h1 className="text-display-lg text-slate-900">{data.hero.title}</h1>
-              <p className="max-w-3xl text-sm text-slate-600">{data.hero.description}</p>
+              <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Premium Multi-Category Dashboard</p>
+              <h1 className="text-display-lg bg-clip-text text-transparent" style={{ backgroundImage: 'var(--brand-gradient)' }}>
+                {data.hero.title}
+              </h1>
+              <p className="max-w-3xl text-base text-slate-600">{data.hero.description}</p>
               <button
                 type="button"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-[var(--primary-600)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-500)] focus-visible:focus-ring"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-full px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all duration-300 hover:-translate-y-0.5 focus-visible:focus-ring"
+                style={{ backgroundImage: 'var(--brand-gradient)' }}
                 onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
               >
                 <Sparkles className="h-4 w-4" aria-hidden />
@@ -1254,7 +1257,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                 </button>
               </div>
               <div className="rounded-[18px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-xs text-slate-500">
-                Generated at {new Date(data.generatedAt).toLocaleString()}
+                Generated at 09/26/2025, 4:14:00 AM
               </div>
             </div>
           </div>
@@ -1291,7 +1294,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl space-y-8 px-6 py-10">
+      <main className="mx-auto max-w-7xl space-y-8 rounded-[32px] bg-white/95 px-8 py-10 shadow-xl shadow-purple-500/10 backdrop-blur">
         <KPIBand metrics={moduleMetrics} accentToken={accent} />
         <div className="rounded-[24px] border border-dashed border-[var(--surface-border)] bg-[var(--surface-s1)] px-6 py-4 text-xs text-slate-500">
           Global filters persist via query params. React Query hydrates instantly, while Zustand keeps inter-module state fast.

--- a/portfolio-dashboard/frontend/src/app/dashboard/data.ts
+++ b/portfolio-dashboard/frontend/src/app/dashboard/data.ts
@@ -232,9 +232,9 @@ export type PortfolioDashboardResponse = {
 };
 
 const portfolioDashboard: PortfolioDashboardResponse = {
-  generatedAt: '2024-11-18T08:00:00.000Z',
+  generatedAt: '2025-09-26T04:14:00.000Z',
   hero: {
-    title: 'Portfolio-grade product operations',
+    title: 'Premium Multi-Category Dashboard',
     subtitle: 'Multi-domain dashboards built with enterprise rigor',
     description:
       'A curated showcase of SaaS, commerce, corporate, custom app, media, education, and niche solutions — all sharing one premium design system.',

--- a/portfolio-dashboard/frontend/src/app/globals.css
+++ b/portfolio-dashboard/frontend/src/app/globals.css
@@ -5,6 +5,7 @@
 @layer base {
   :root {
     color-scheme: light;
+    --brand-gradient: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
     /* Surface hierarchy */
     --surface-s0: #f3f4f7;
     --surface-s1: #ffffff;
@@ -30,15 +31,15 @@
 
     --success-50: #ecfdf5;
     --success-500: #10b981;
-    --success-600: #059669;
+    --success-600: #0f9e73;
 
     --warning-50: #fffbeb;
     --warning-500: #f59e0b;
-    --warning-600: #d97706;
+    --warning-600: #dd8a06;
 
     --danger-50: #fef2f2;
     --danger-500: #ef4444;
-    --danger-600: #dc2626;
+    --danger-600: #d92c2c;
 
     --info-50: #eef7ff;
     --info-500: #3b82f6;
@@ -56,7 +57,7 @@
     /* Typography */
     --font-body: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
     --font-size-base: 16px;
-    --font-line-height: 1.5;
+    --font-line-height: 1.6;
 
     /* Motion */
     --motion-duration: 200ms;
@@ -149,56 +150,60 @@
 @layer base {
   h1,
   .text-display-lg {
-    font-size: 32px;
-    line-height: 36px;
+    font-size: 3rem;
+    line-height: 1.1;
     font-weight: 700;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
   }
 
   h2,
   .text-display-md {
-    font-size: 22px;
-    line-height: 28px;
+    font-size: 2.4rem;
+    line-height: 1.15;
     font-weight: 600;
+    letter-spacing: -0.01em;
   }
 
   h3,
   .text-title-sm {
-    font-size: 16px;
-    line-height: 24px;
-    font-weight: 600;
+    font-size: 1.95rem;
+    line-height: 1.2;
+    font-weight: 500;
+    letter-spacing: -0.01em;
   }
 
   p,
   .text-body {
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 1rem;
+    line-height: 1.6;
     font-weight: 400;
   }
 
   small,
   .text-caption {
-    font-size: 12px;
-    line-height: 16px;
+    font-size: 0.875rem;
+    line-height: 1.4;
     font-weight: 500;
-    letter-spacing: 0.01em;
+    letter-spacing: 0.02em;
   }
 }
 
 @layer utilities {
   .glass-card {
-    background: var(--surface-s2);
-    backdrop-filter: saturate(160%) blur(28px);
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(32px);
     border-radius: var(--radius-lg);
-    border: 1px solid var(--surface-border);
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--motion-duration) var(--motion-ease),
-      box-shadow var(--motion-duration) var(--motion-ease);
+    border: 1px solid rgba(124, 58, 237, 0.2);
+    box-shadow: 0 28px 60px rgba(79, 70, 229, 0.12);
+    transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 300ms cubic-bezier(0.16, 1, 0.3, 1),
+      background-color 300ms ease;
   }
 
   .glass-card:hover {
     transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
+    box-shadow: 0 36px 80px rgba(79, 70, 229, 0.16);
+    background: rgba(255, 255, 255, 0.16);
   }
 
   .kpi-value {

--- a/portfolio-dashboard/frontend/src/components/ui/Card.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/Card.tsx
@@ -7,9 +7,9 @@ type CardProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 const paddingMap: Record<NonNullable<CardProps['padding']>, string> = {
-  sm: 'p-4',
-  md: 'p-6',
-  lg: 'p-8',
+  sm: 'px-6 py-6',
+  md: 'px-8 py-8',
+  lg: 'px-10 py-10',
 };
 
 export function Card({
@@ -21,7 +21,11 @@ export function Card({
 }: CardProps) {
   return (
     <Component
-      className={cn('glass-card relative overflow-hidden', paddingMap[padding], className)}
+      className={cn(
+        'glass-card relative overflow-hidden transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-2xl',
+        paddingMap[padding],
+        className,
+      )}
       {...props}
     >
       {children}

--- a/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
 import type { MetricCard, MetricTrend } from '@/app/dashboard/data';
 import { cn } from '@/lib/utils';
@@ -14,9 +17,78 @@ const trendCopy: Record<MetricTrend, string> = {
   steady: 'Stable',
 };
 
+function useAnimatedMetric(value: string, duration = 400) {
+  const [displayValue, setDisplayValue] = useState(value);
+
+  useEffect(() => {
+    const numericMatch = value.match(/[-+]?\d*[.,]?\d+/);
+
+    if (!numericMatch || numericMatch[0].trim() === '') {
+      setDisplayValue(value);
+      return;
+    }
+
+    const matchIndex = numericMatch.index ?? 0;
+    const numberToken = numericMatch[0];
+    const prefix = value.slice(0, matchIndex);
+    const suffix = value.slice(matchIndex + numberToken.length);
+    const target = Number(numberToken.replace(/,/g, ''));
+
+    if (!Number.isFinite(target)) {
+      setDisplayValue(value);
+      return;
+    }
+
+    const decimalPrecision = numberToken.includes('.')
+      ? (numberToken.split('.')[1]?.length ?? 0)
+      : 0;
+
+    const formatter = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: decimalPrecision,
+      maximumFractionDigits: decimalPrecision,
+    });
+
+    let animationFrame: number;
+    const start = performance.now();
+
+    const step = (timestamp: number) => {
+      const elapsed = timestamp - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const currentValue = target * eased;
+      setDisplayValue(`${prefix}${formatter.format(currentValue)}${suffix}`);
+
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(step);
+      }
+    };
+
+    setDisplayValue(`${prefix}${formatter.format(0)}${suffix}`);
+    animationFrame = requestAnimationFrame(step);
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [value, duration]);
+
+  return displayValue;
+}
+
+function CountUpValue({ value, accentToken }: { value: string; accentToken: string }) {
+  const animatedValue = useAnimatedMetric(value);
+
+  return (
+    <span
+      className="kpi-value mt-3 block text-3xl font-semibold tracking-tight transition-colors duration-300"
+      style={{ color: `var(${accentToken})` }}
+      aria-live="polite"
+    >
+      {animatedValue}
+    </span>
+  );
+}
+
 export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
   return (
-    <div className="-mx-4 flex snap-band gap-4 overflow-x-auto px-4 pb-2 pt-1 sm:mx-0 sm:px-0">
+    <div className="-mx-4 flex snap-band gap-6 overflow-x-auto px-4 pb-4 pt-2 sm:mx-0 sm:px-0">
       {metrics.map((metric) => {
         const Icon =
           metric.trend === 'up' ? ArrowUpRight : metric.trend === 'down' ? ArrowDownRight : Minus;
@@ -31,7 +103,7 @@ export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
             key={metric.id}
             type="button"
             onClick={() => onInspect?.(metric)}
-            className="snap-item min-w-[260px] flex-1 rounded-[20px] border border-[color:var(--surface-border)] bg-[var(--surface-s1)] p-5 text-left shadow-sm transition focus-visible:focus-ring"
+            className="snap-item min-w-[260px] flex-1 rounded-[20px] border border-[color:var(--surface-border)] bg-white/10 p-6 text-left shadow-lg backdrop-blur-lg transition-all duration-300 ease-out hover:-translate-y-0.5 focus-visible:focus-ring"
             style={{
               boxShadow: '0 18px 36px rgba(79, 70, 229, 0.08)',
             }}
@@ -50,12 +122,7 @@ export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
                 </span>
               ) : null}
             </div>
-            <p
-              className="kpi-value mt-3 text-3xl font-semibold"
-              style={{ color: `var(${accentToken})` }}
-            >
-              {metric.value}
-            </p>
+            <CountUpValue value={metric.value} accentToken={accentToken} />
             {metric.description ? (
               <p className="mt-2 text-xs text-slate-600">{metric.description}</p>
             ) : null}

--- a/portfolio-dashboard/frontend/src/components/ui/SegmentedTabs.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/SegmentedTabs.tsx
@@ -25,11 +25,18 @@ export function SegmentedTabs({ tabs, activeId, onChange }: SegmentedTabsProps) 
             aria-controls={`${tab.id}-panel`}
             onClick={() => onChange(tab.id)}
             className={cn(
-              'flex min-w-[160px] flex-1 items-center justify-center gap-2 rounded-[18px] px-4 py-3 text-sm font-semibold transition focus-visible:focus-ring',
+              'flex min-w-[160px] flex-1 items-center justify-center gap-2 rounded-[18px] px-4 py-3 text-sm font-semibold transition-all duration-300 focus-visible:focus-ring',
               isActive
-                ? 'bg-gradient-to-r from-[var(--primary-500)] to-[var(--primary-600)] text-white shadow-md'
-                : 'text-slate-600 hover:bg-slate-100/80'
+                ? 'text-white shadow-xl shadow-purple-500/10'
+                : 'text-slate-600 hover:-translate-y-0.5 hover:bg-slate-100/80'
             )}
+            style={
+              isActive
+                ? {
+                    backgroundImage: 'var(--brand-gradient)',
+                  }
+                : undefined
+            }
           >
             <span className="whitespace-nowrap">{tab.label}</span>
           </button>


### PR DESCRIPTION
## Summary
- retheme the dashboard hero with the premium multi-category title, fixed generation timestamp, and gradient CTAs
- introduce a 1.25x typography scale, glassmorphism surface tweaks, and smoother interactive tab styling
- add animated KPI counter metrics with premium spacing updates and richer card hover treatments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c9c10268832e856a701bf9c846a5