### PR TITLE
feat: refresh dashboard typography and hero

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -1220,7 +1220,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
         <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
           <div className="flex flex-wrap items-center justify-between gap-6">
             <div className="space-y-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Portfolio-grade product operations</p>
+              <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Premium Multi-Category Dashboard</p>
               <h1 className="text-display-lg text-slate-900">{data.hero.title}</h1>
               <p className="max-w-3xl text-sm text-slate-600">{data.hero.description}</p>
               <button
@@ -1254,7 +1254,17 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                 </button>
               </div>
               <div className="rounded-[18px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-xs text-slate-500">
-                Generated at {new Date(data.generatedAt).toLocaleString()}
+                Generated at{' '}
+                {new Date(data.generatedAt).toLocaleString('en-US', {
+                  month: '2-digit',
+                  day: '2-digit',
+                  year: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  second: '2-digit',
+                  hour12: true,
+                  timeZone: 'UTC',
+                })}
               </div>
             </div>
           </div>

--- a/portfolio-dashboard/frontend/src/app/dashboard/data.ts
+++ b/portfolio-dashboard/frontend/src/app/dashboard/data.ts
@@ -232,9 +232,9 @@ export type PortfolioDashboardResponse = {
 };
 
 const portfolioDashboard: PortfolioDashboardResponse = {
-  generatedAt: '2024-11-18T08:00:00.000Z',
+  generatedAt: '2025-09-26T04:14:00.000Z',
   hero: {
-    title: 'Portfolio-grade product operations',
+    title: 'Premium Multi-Category Dashboard',
     subtitle: 'Multi-domain dashboards built with enterprise rigor',
     description:
       'A curated showcase of SaaS, commerce, corporate, custom app, media, education, and niche solutions — all sharing one premium design system.',

--- a/portfolio-dashboard/frontend/src/app/globals.css
+++ b/portfolio-dashboard/frontend/src/app/globals.css
@@ -8,13 +8,13 @@
     /* Surface hierarchy */
     --surface-s0: #f3f4f7;
     --surface-s1: #ffffff;
-    --surface-s2: rgba(255, 255, 255, 0.84);
-    --surface-s3: rgba(15, 23, 42, 0.08);
-    --surface-border: rgba(15, 23, 42, 0.12);
-    --surface-border-strong: rgba(15, 23, 42, 0.24);
-    --shadow-sm: 0 4px 18px rgba(15, 23, 42, 0.08);
-    --shadow-md: 0 12px 32px rgba(15, 23, 42, 0.12);
-    --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.16);
+    --surface-s2: rgba(255, 255, 255, 0.92);
+    --surface-s3: rgba(79, 70, 229, 0.12);
+    --surface-border: rgba(79, 70, 229, 0.18);
+    --surface-border-strong: rgba(79, 70, 229, 0.32);
+    --shadow-sm: 0 12px 28px rgba(79, 70, 229, 0.08);
+    --shadow-md: 0 20px 48px rgba(79, 70, 229, 0.12);
+    --shadow-lg: 0 32px 72px rgba(79, 70, 229, 0.14);
 
     /* Semantic palette */
     --primary-50: #eef2ff;
@@ -22,11 +22,12 @@
     --primary-200: #c7d2fe;
     --primary-300: #a5b4fc;
     --primary-400: #818cf8;
-    --primary-500: #6366f1;
+    --primary-500: #4f46e5;
     --primary-600: #4f46e5;
     --primary-700: #4338ca;
-    --primary-800: #3730a3;
+    --primary-800: #3b32b0;
     --primary-900: #312e81;
+    --primary-gradient: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
 
     --success-50: #ecfdf5;
     --success-500: #10b981;
@@ -149,30 +150,30 @@
 @layer base {
   h1,
   .text-display-lg {
-    font-size: 32px;
-    line-height: 36px;
+    font-size: 3rem;
+    line-height: 1.15;
     font-weight: 700;
     letter-spacing: -0.01em;
   }
 
   h2,
   .text-display-md {
-    font-size: 22px;
-    line-height: 28px;
+    font-size: 2.4rem;
+    line-height: 1.2;
     font-weight: 600;
   }
 
   h3,
   .text-title-sm {
-    font-size: 16px;
-    line-height: 24px;
-    font-weight: 600;
+    font-size: 1.95rem;
+    line-height: 1.25;
+    font-weight: 500;
   }
 
   p,
   .text-body {
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 1rem;
+    line-height: 1.5;
     font-weight: 400;
   }
 
@@ -187,13 +188,12 @@
 
 @layer utilities {
   .glass-card {
-    background: var(--surface-s2);
-    backdrop-filter: saturate(160%) blur(28px);
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(24px) saturate(160%);
     border-radius: var(--radius-lg);
-    border: 1px solid var(--surface-border);
+    border: 1px solid rgba(124, 58, 237, 0.22);
     box-shadow: var(--shadow-sm);
-    transition: transform var(--motion-duration) var(--motion-ease),
-      box-shadow var(--motion-duration) var(--motion-ease);
+    transition: all 300ms cubic-bezier(0.2, 0, 0.2, 1);
   }
 
   .glass-card:hover {

--- a/portfolio-dashboard/frontend/src/components/ui/Card.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/Card.tsx
@@ -21,7 +21,11 @@ export function Card({
 }: CardProps) {
   return (
     <Component
-      className={cn('glass-card relative overflow-hidden', paddingMap[padding], className)}
+      className={cn(
+        'glass-card relative overflow-hidden shadow-xl shadow-purple-500/10 transition-all duration-300 hover:-translate-y-0.5',
+        paddingMap[padding],
+        className,
+      )}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- update global theme tokens with a premium gradient palette and new 1.25x typography scale
- enrich the shared card component with elevated glassmorphism hover depth
- rename the dashboard hero content and timestamp format to the new Premium Multi-Category spec

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c9c10268832e856a701bf9c846a5