### PR TITLE
Rebalance SaaS dashboard grid and sticky layout

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Area,
   AreaChart,
@@ -26,7 +26,6 @@ import {
   Earth,
   Workflow,
   Activity,
-  ClipboardList,
   Sparkles,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
@@ -188,10 +187,14 @@ function SaaSModule({
 
       {/* PRIMARY BLOCK 1: PLANS + CHURN */}
       <div className="col-span-12">
-        <div className="grid grid-cols-12 gap-6">
+        <div className="grid grid-cols-12 gap-6 lg:items-stretch">
           {/* Subscription table - dominant width */}
-          <div className="col-span-12 lg:col-span-9">
-            <Card className="border border-[var(--surface-border)] h-[400px]" role="region" aria-label="Subscription plans">
+          <div className="col-span-12 lg:col-span-8">
+            <Card
+              className="flex h-full min-h-[360px] flex-col overflow-visible border border-[var(--surface-border)] bg-[var(--surface-s1)]"
+              role="region"
+              aria-label="Subscription plans"
+            >
               <div className="flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Subscription plans</h3>
@@ -259,7 +262,7 @@ function SaaSModule({
           </div>
 
           {/* Churn donut - compact width */}
-          <div className="col-span-12 lg:col-span-3">
+          <div className="col-span-12 lg:col-span-4">
             <ChartCard
               id="saas-churn"
               title="Churn health distribution"
@@ -270,8 +273,8 @@ function SaaSModule({
                 { key: 'share', label: 'Share', align: 'right' },
               ]}
             >
-              <div className="flex flex-col items-center h-[400px]">
-                <ResponsiveContainer height={250} width="100%">
+              <div className="flex h-full flex-col items-center justify-between">
+                <ResponsiveContainer height={260} width="100%">
                   <PieChart>
                     <Pie dataKey="value" data={data.churnSegments} innerRadius={60} outerRadius={100} paddingAngle={3}>
                       {data.churnSegments.map((segment) => (
@@ -283,8 +286,17 @@ function SaaSModule({
                     />
                   </PieChart>
                 </ResponsiveContainer>
-                <div className="mt-2 w-full">
-                  <Legend verticalAlign="bottom" align="center" iconSize={8} wrapperStyle={{ paddingTop: 4 }} />
+                <div className="mt-4 flex w-full items-center justify-center gap-3 overflow-x-auto pb-1 text-xs font-semibold text-slate-600">
+                  {data.churnSegments.map((segment) => (
+                    <div
+                      key={segment.id}
+                      className="inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 shadow-sm"
+                    >
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: segment.color }} aria-hidden />
+                      <span>{segment.label}</span>
+                      <span className="font-bold">{segment.value}%</span>
+                    </div>
+                  ))}
                 </div>
               </div>
             </ChartCard>
@@ -292,38 +304,11 @@ function SaaSModule({
         </div>
       </div>
 
-      <div className="col-span-12 lg:col-span-4">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Billing cycles">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Billing cycle orchestration</h3>
-              <p className="text-xs text-slate-600">Real-time close management with owner accountability.</p>
-            </div>
-            <ClipboardList className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
-          </div>
-          <ul className="mt-4 space-y-3">
-            {data.billingCycles.map((cycle) => (
-              <li key={cycle.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <div className="flex items-center justify-between text-sm text-slate-700">
-                  <span className="font-semibold text-slate-900">{cycle.label}</span>
-                  <StatusChip
-                    label={cycle.status}
-                    tone={cycle.status === 'completed' ? 'success' : cycle.status === 'processing' ? 'info' : 'warning'}
-                  />
-                </div>
-                <p className="mt-2 text-xs text-slate-500">Next run {cycle.nextRun}</p>
-                <p className="text-xs text-slate-500">Owners: {cycle.owners.join(', ')}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
-
       {/* PRIMARY BLOCK 2: MRR GROWTH (KING SECTION) */}
       <div className="col-span-12">
-        <div className="grid grid-cols-12 gap-6">
+        <div className="grid grid-cols-12 gap-6 lg:items-start">
           {/* MRR Growth Chart - Dominant */}
-          <div className="col-span-12 lg:col-span-8">
+          <div className="col-span-12 lg:col-span-8 space-y-6">
             <ChartCard
               id="saas-growth"
               title="MRR growth"
@@ -334,33 +319,37 @@ function SaaSModule({
                 { key: 'mrr', label: 'MRR ($K)', align: 'right' },
               ]}
             >
-              <div className="flex flex-col gap-4">
-                <div className="flex justify-end">
-                  <div className="flex items-center gap-2 text-xs text-slate-600">
-                    <div className="h-2 w-2 rounded-full bg-[var(--primary-500)]" />
-                    <span>MRR Growth</span>
-                  </div>
-                </div>
-                <ResponsiveContainer height={350}>
-                  <LineChart data={data.growthTrend}>
+              <div className="flex flex-col gap-6">
+                <ResponsiveContainer height={320}>
+                  <LineChart data={data.growthTrend} margin={{ left: 12, right: 12, top: 20, bottom: 12 }}>
                     <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
                     <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                    <YAxis tickLine={false} axisLine={false} />
+                    <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax) => dataMax * 1.15]} />
                     <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-                    <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={{ r: 5 }} />
+                    <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={{ r: 4 }} />
                   </LineChart>
                 </ResponsiveContainer>
+                <div className="flex flex-wrap items-center gap-3 text-xs font-semibold text-slate-600">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 shadow-sm">
+                    <span className="h-2 w-2 rounded-full bg-[var(--primary-500)]" aria-hidden />
+                    MRR growth (USD)
+                  </span>
+                  <span className="text-[11px] font-medium text-slate-500">
+                    15% headroom applied to emphasize current trajectory.
+                  </span>
+                </div>
               </div>
             </ChartCard>
-          </div>
-
-          {/* Compact Monthly Breakdown */}
-          <div className="col-span-12 lg:col-span-4">
-            <Card className="border border-[var(--surface-border)] h-[400px]" role="region" aria-label="Monthly breakdown">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            {/* Compact Monthly Breakdown */}
+            <Card
+              className="flex min-h-[200px] flex-col gap-4 overflow-visible border border-[var(--surface-border)] bg-[var(--surface-s1)]"
+              role="region"
+              aria-label="Monthly breakdown"
+            >
+              <div className="flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Monthly breakdown</h3>
-                  <p className="text-xs text-slate-600">Top 6 months</p>
+                  <p className="text-xs text-slate-600">Top six months with quick view</p>
                 </div>
                 <button
                   type="button"
@@ -369,43 +358,38 @@ function SaaSModule({
                   View all months
                 </button>
               </div>
-              <div className="overflow-hidden">
-                <table className="min-w-full" aria-label="Monthly breakdown table">
-                  <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
-                    <tr>
-                      <th className="px-4 py-3 text-left">Month</th>
-                      <th className="px-4 py-3 text-right">Net</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
-                    {data.growthTrend.slice(0, 6).map((point, index) => {
-                      const prevValue = index > 0 ? data.growthTrend[index - 1].value : 0;
-                      const growth = prevValue > 0 ? ((point.value - prevValue) / prevValue * 100) : 0;
-                      const net = point.value * 0.32; // Simplified calculation
-                      return (
-                        <tr key={point.label} className="hover:bg-[var(--primary-50)]/40">
-                          <td className="px-4 py-[11px] font-semibold text-slate-900">{point.label}</td>
-                          <td className="px-4 py-[11px] text-right">
-                            <span className={cn(
+              <table className="min-w-full" aria-label="Monthly breakdown table">
+                <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Month</th>
+                    <th className="px-4 py-3 text-right">Net</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
+                  {data.growthTrend.slice(0, 6).map((point) => {
+                    const net = point.value * 0.32;
+                    return (
+                      <tr key={point.label} className="hover:bg-[var(--primary-50)]/40">
+                        <td className="px-4 py-[11px] font-semibold text-slate-900">{point.label}</td>
+                        <td className="px-4 py-[11px] text-right">
+                          <span
+                            className={cn(
                               'text-xs font-semibold',
                               net > 0 ? 'text-[var(--success-600)]' : net < 0 ? 'text-[var(--danger-600)]' : 'text-slate-600'
-                            )}>
-                              ${net.toFixed(0)}k
-                            </span>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
+                            )}
+                          >
+                            ${net.toFixed(0)}k
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </Card>
           </div>
         </div>
       </div>
-
-
-      {/* SECONDARY INSIGHTS: GROWTH DRIVERS */}
       <div className="col-span-12">
         <div className="mb-4">
           <h2 className="text-title-lg text-slate-900">Growth Drivers</h2>
@@ -414,8 +398,12 @@ function SaaSModule({
         <div className="grid grid-cols-12 gap-6">
           {/* Affiliates growth (left) */}
           <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Affiliates growth">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            <Card
+              className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]"
+              role="region"
+              aria-label="Affiliates growth"
+            >
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Affiliates growth</h3>
                   <p className="text-xs text-slate-600">Share of total (%)</p>
@@ -436,15 +424,19 @@ function SaaSModule({
 
           {/* Top sellers (right) */}
           <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Top sellers">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            <Card
+              className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]"
+              role="region"
+              aria-label="Top sellers"
+            >
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Top sellers</h3>
                   <p className="text-xs text-slate-600">Item/SKU/Plan, Sales/Revenue, Share %</p>
                 </div>
                 <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
               </div>
-              <div className="overflow-hidden">
+              <div className="flex-1 overflow-hidden">
                 <table className="min-w-full" aria-label="Top sellers table">
                   <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                     <tr>
@@ -470,6 +462,14 @@ function SaaSModule({
                   </tbody>
                 </table>
               </div>
+              <div className="mt-3 flex justify-end">
+                <button
+                  type="button"
+                  className="inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+                >
+                  View all sellers
+                </button>
+              </div>
             </Card>
           </div>
         </div>
@@ -484,8 +484,12 @@ function SaaSModule({
         <div className="grid grid-cols-12 gap-6">
           {/* API usage (left) */}
           <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="API usage">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            <Card
+              className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]"
+              role="region"
+              aria-label="API usage"
+            >
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">API usage</h3>
                   <p className="text-xs text-slate-600">Rolling avg + peak</p>
@@ -506,15 +510,19 @@ function SaaSModule({
 
           {/* Top endpoints (right) */}
           <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Top endpoints">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            <Card
+              className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]"
+              role="region"
+              aria-label="Top endpoints"
+            >
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Top endpoints</h3>
                   <p className="text-xs text-slate-600">Endpoint, Calls, Errors %, Latency p95</p>
                 </div>
                 <Workflow className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
               </div>
-              <div className="overflow-hidden">
+              <div className="flex-1 overflow-hidden">
                 <table className="min-w-full" aria-label="Top endpoints table">
                   <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                     <tr>
@@ -549,12 +557,25 @@ function SaaSModule({
                   </tbody>
                 </table>
               </div>
+              <div className="mt-3 flex justify-end">
+                <button
+                  type="button"
+                  className="inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+                >
+                  View all endpoints
+                </button>
+              </div>
             </Card>
           </div>
         </div>
       </div>
 
-
+      <div className="col-span-12">
+        <div className="rounded-[18px] border border-dashed border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-xs text-slate-500 lg:px-6">
+          <span className="font-semibold text-slate-800">Last refresh:</span>{' '}
+          {new Date().toLocaleString()} • Data sources: billing ledger, product analytics, and API observability logs.
+        </div>
+      </div>
 
     </div>
   );
@@ -1362,6 +1383,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
   const { push } = useToast();
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
+  const headerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -1374,6 +1396,28 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
   });
 
   useLiveMetrics();
+
+  useEffect(() => {
+    const node = headerRef.current;
+    if (!node) return;
+
+    const updateVar = () => {
+      document.documentElement.style.setProperty('--dashboard-header', `${node.offsetHeight}px`);
+    };
+
+    updateVar();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateVar);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -1472,7 +1516,10 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
 
   return (
     <div className="min-h-screen bg-[var(--surface-s0)] pb-16 text-slate-900">
-      <header className="border-b border-[var(--surface-border)] bg-white/95 shadow-xl shadow-purple-500/10 backdrop-blur-xl">
+      <header
+        ref={headerRef}
+        className="border-b border-[var(--surface-border)] bg-white/95 shadow-xl shadow-purple-500/10 backdrop-blur-xl"
+      >
         <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
           <div className="flex flex-wrap items-center justify-between gap-6">
             <div className="space-y-3">
@@ -1564,32 +1611,36 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
         <div className="rounded-[24px] border border-dashed border-[var(--surface-border)] bg-[var(--surface-s1)] px-6 py-4 text-xs text-slate-500">
           Global filters persist via query params. React Query hydrates instantly, while Zustand keeps inter-module state fast.
         </div>
-        
+
         {/* Main content with right rail */}
-        <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           {/* Main content area */}
-          <div className="flex-1">
+          <section className="lg:col-span-8" aria-label="Dashboard content">
             {moduleContent}
-          </div>
-          
+          </section>
+
           {/* RIGHT RAIL: AUTOMATION WORKBENCH */}
-          <div className="sticky top-[120px] w-full space-y-6 lg:w-[320px] lg:flex-shrink-0 lg:max-h-[calc(100vh-140px)] lg:overflow-y-auto">
+          <aside
+            className="space-y-6 lg:col-span-4 lg:sticky lg:self-start"
+            style={{ top: 'calc(var(--dashboard-header, 96px) + var(--dashboard-filters, 72px) + 24px)' }}
+            aria-label="Automation workbench"
+          >
             <div className="mb-4">
               <h2 className="text-title-lg text-slate-900">Automation Workbench</h2>
               <p className="text-sm text-slate-600">Build and manage automated workflows</p>
             </div>
-            
+
             {/* Automation builder (top) */}
-            <AutomationBuilder 
+            <AutomationBuilder
               onCreate={async (automation) => {
                 console.log('Creating automation:', automation);
-              }} 
-              verticalAccent={accent} 
+              }}
+              verticalAccent={accent}
             />
-            
+
             {/* Automation backlog (middle) */}
             <Card className="border border-[var(--surface-border)]" role="region" aria-label="Automation backlog">
-              <div className="flex items-center justify-between gap-4 mb-4">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Automation backlog</h3>
                   <p className="text-xs text-slate-600">Status chips, active/paused</p>
@@ -1612,20 +1663,20 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                       />
                     </div>
                     <p className="mt-1 text-xs text-slate-500">{automation.metric}</p>
-                    <div className="mt-2 flex gap-2">
-                      <button className="text-xs text-[var(--primary-600)] hover:text-[var(--primary-700)]">
-                        {automation.status === 'active' ? 'Pause' : 'Resume'}
-                      </button>
-                      <button className="text-xs text-slate-500 hover:text-slate-700">Edit</button>
-                    </div>
+                    <button
+                      type="button"
+                      className="mt-3 inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-[var(--primary-600)] transition hover:bg-[var(--primary-50)]/70 focus-visible:focus-ring"
+                    >
+                      {automation.status === 'active' ? 'Pause automation' : 'Resume automation'}
+                    </button>
                   </div>
                 ))}
               </div>
             </Card>
-            
+
             {/* Efficiency showcases (bottom) */}
-            <Card className="border border-[var(--surface-border)]" role="region" aria-label="Efficiency showcases">
-              <div className="flex items-center justify-between gap-4 mb-4">
+            <Card className="border border-[var(--surface-border)]" role="region" aria-label="Efficiency insights">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Efficiency showcases</h3>
                   <p className="text-xs text-slate-600">Recent automation wins</p>
@@ -1642,8 +1693,30 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                   <div className="text-xs text-[var(--primary-600)]">Smart FAQ automation</div>
                 </div>
               </div>
+              {selectedModule === 'saas' && data?.saas.billingCycles?.length ? (
+                <div className="mt-5 space-y-3 border-t border-dashed border-[var(--surface-border)] pt-4">
+                  <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                    Billing cycle orchestration
+                  </h4>
+                  <ul className="space-y-3">
+                    {data.saas.billingCycles.map((cycle) => (
+                      <li key={cycle.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
+                        <div className="flex items-center justify-between text-sm text-slate-700">
+                          <span className="font-semibold text-slate-900">{cycle.label}</span>
+                          <StatusChip
+                            label={cycle.status}
+                            tone={cycle.status === 'completed' ? 'success' : cycle.status === 'processing' ? 'info' : 'warning'}
+                          />
+                        </div>
+                        <p className="mt-2 text-xs text-slate-500">Next run {cycle.nextRun}</p>
+                        <p className="text-xs text-slate-500">Owners: {cycle.owners.join(', ')}</p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
             </Card>
-          </div>
+          </aside>
         </div>
       </main>
     </div>

--- a/portfolio-dashboard/frontend/src/components/ui/AutomationBuilder.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/AutomationBuilder.tsx
@@ -101,8 +101,8 @@ export function AutomationBuilder({ onCreate, verticalAccent }: AutomationBuilde
             <span className="font-semibold text-slate-700">Conditions</span>
             <textarea
               {...register('conditions')}
-              className="rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring"
-              rows={3}
+              className="min-h-[108px] rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring resize-none"
+              rows={4}
               placeholder="If workspace plan = Scale & seat utilization < 60%"
             />
             {errors.conditions ? (
@@ -113,8 +113,8 @@ export function AutomationBuilder({ onCreate, verticalAccent }: AutomationBuilde
             <span className="font-semibold text-slate-700">Actions</span>
             <textarea
               {...register('action')}
-              className="rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring"
-              rows={3}
+              className="min-h-[108px] rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring resize-none"
+              rows={4}
               placeholder="Open CSM task, send Slack alert, launch in-app journey"
             />
             {errors.action ? (

--- a/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
@@ -83,7 +83,7 @@ export function ChartCard({
         <div role="figure" aria-labelledby={`${id}-title`} aria-describedby={ariaDescription ? `${id}-desc` : undefined}>
           {children}
         </div>
-        <div className="overflow-auto rounded-[18px] border border-dashed border-[var(--surface-border)]">
+        <div className="overflow-hidden rounded-[18px] border border-dashed border-[var(--surface-border)]">
           <table className="min-w-full divide-y divide-[var(--surface-border)]" aria-label={`${title} data table`}>
             <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
               <tr>

--- a/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
@@ -74,20 +74,32 @@ function useAnimatedMetric(value: string, duration = 400) {
 }
 
 function CountUpValue({ value, accentToken }: { value: string; accentToken: string }) {
-  const numeric = useMemo(() => parseNumericFromString(value), [value]);
-  const formattedBase = useMemo(() => {
-    if (numeric == null) return value;
-    
-    // Format with k/M abbreviations and max 2 decimals
-    if (numeric >= 1000000) {
-      return `${(numeric / 1000000).toFixed(numeric % 1000000 === 0 ? 0 : 2)}M`;
-    } else if (numeric >= 1000) {
-      return `${(numeric / 1000).toFixed(numeric % 1000 === 0 ? 0 : 2)}k`;
-    } else {
-      return numeric.toFixed(numeric % 1 === 0 ? 0 : 2);
+  const animatedValue = useMemo(() => {
+    const numeric = parseNumericFromString(value);
+    if (numeric == null) {
+      return value;
     }
-  }, [numeric, value]);
-  const animatedValue = useAnimatedMetric(formattedBase);
+
+    const compactMatch = value.match(/^([^0-9+-]*)([-+]?[\d,.]+)([kKmM]?)(.*)$/);
+    const prefix = compactMatch?.[1]?.trimStart() ?? '';
+    const magnitude = compactMatch?.[3]?.toLowerCase() ?? '';
+    const trailing = compactMatch?.[4] ?? '';
+
+    let normalized = numeric;
+    if (magnitude === 'm') {
+      normalized = numeric * 1_000_000;
+    } else if (magnitude === 'k') {
+      normalized = numeric * 1_000;
+    }
+
+    const formatted = formatCompact(normalized);
+    const suffix = trailing.trimStart().startsWith('%') ? '%' : '';
+    const base = `${prefix}${formatted}${suffix}`.trim();
+
+    return base.length > 0 ? base : value;
+  }, [value]);
+
+  const displayValue = useAnimatedMetric(animatedValue);
 
   return (
     <span
@@ -95,14 +107,14 @@ function CountUpValue({ value, accentToken }: { value: string; accentToken: stri
       style={{ color: `var(${accentToken})` }}
       aria-live="polite"
     >
-      {animatedValue}
+      {displayValue}
     </span>
   );
 }
 
 export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
   return (
-    <div className="flex gap-6 overflow-x-auto pb-4 sm:grid sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {metrics.map((metric) => {
         const Icon =
           metric.trend === 'up' ? ArrowUpRight : metric.trend === 'down' ? ArrowDownRight : Minus;
@@ -118,47 +130,45 @@ export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
             key={metric.id}
             type="button"
             onClick={() => onInspect?.(metric)}
-            className="min-h-[160px] min-w-[280px] flex-shrink-0 rounded-[20px] border border-[color:var(--surface-border)] bg-white/10 p-6 text-left shadow-lg backdrop-blur-lg transition-all duration-300 ease-out hover:-translate-y-0.5 focus-visible:focus-ring sm:min-w-0"
+            className="flex h-full min-h-[128px] flex-col justify-between rounded-[20px] border border-[color:var(--surface-border)] bg-white/10 p-5 text-left shadow-lg backdrop-blur-lg transition-all duration-300 ease-out hover:-translate-y-0.5 focus-visible:focus-ring"
             style={{
               boxShadow: '0 18px 36px rgba(79, 70, 229, 0.08)',
             }}
           >
-            <div className="flex h-full flex-col justify-between">
-              <div className="flex items-center justify-between gap-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
-                  {metric.label}
-                </p>
-                {metric.trend ? (
-                  <span
-                    className={cn('inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold', tone)}
-                    aria-label={trendCopy[metric.trend]}
-                  >
-                    <Icon className="h-3.5 w-3.5" aria-hidden />
-                    {metric.change != null ? `${metric.change > 0 ? '+' : ''}${metric.change.toFixed(1)}%` : trendCopy[metric.trend]}
-                  </span>
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+                {metric.label}
+              </p>
+              {metric.trend ? (
+                <span
+                  className={cn('inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold', tone)}
+                  aria-label={trendCopy[metric.trend]}
+                >
+                  <Icon className="h-3.5 w-3.5" aria-hidden />
+                  {metric.change != null ? `${metric.change > 0 ? '+' : ''}${metric.change.toFixed(1)}%` : trendCopy[metric.trend]}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-2 flex items-end justify-between gap-4">
+              <div className="relative flex-1">
+                <CountUpValue value={metric.value} accentToken={accentToken} />
+                {metric.description ? (
+                  <div className="group inline-block">
+                    <span className="mt-1 inline-block cursor-help text-[11px] text-slate-600" aria-describedby={`${metric.id}-def`}>
+                      {metric.description}
+                    </span>
+                    <span
+                      role="tooltip"
+                      id={`${metric.id}-def`}
+                      className="invisible absolute z-20 mt-1 max-w-[220px] rounded-[10px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-2 py-1 text-[11px] text-slate-700 shadow-sm group-hover:visible"
+                    >
+                      {metric.label} definition and calculation context.
+                    </span>
+                  </div>
                 ) : null}
               </div>
-              <div className="flex items-end justify-between gap-4">
-                <div className="relative flex-1">
-                  <CountUpValue value={metric.value} accentToken={accentToken} />
-                  {metric.description ? (
-                    <div className="group inline-block">
-                      <span className="mt-1 inline-block cursor-help text-[11px] text-slate-600" aria-describedby={`${metric.id}-def`}>
-                        {metric.description}
-                      </span>
-                      <span
-                        role="tooltip"
-                        id={`${metric.id}-def`}
-                        className="invisible absolute z-20 mt-1 max-w-[220px] rounded-[10px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-2 py-1 text-[11px] text-slate-700 shadow-sm group-hover:visible"
-                      >
-                        {metric.label} definition and calculation context.
-                      </span>
-                    </div>
-                  ) : null}
-                </div>
-                <div className="h-[36px] w-[120px] flex-shrink-0" aria-hidden>
-                  <Sparkline data={lastWindow} color={`var(${accentToken})`} height={36} variant="line" />
-                </div>
+              <div className="h-[36px] w-[120px] flex-shrink-0" aria-hidden>
+                <Sparkline data={lastWindow} color={`var(${accentToken})`} height={36} variant="line" />
               </div>
             </div>
           </button>

--- a/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, Save, RotateCcw } from 'lucide-react';
 import { useDashboardStore, type DateRange } from '@/state/dashboardStore';
 
@@ -102,6 +102,7 @@ function useSavedViews(key = 'pg-saved-views') {
 export function StickyFilterBar() {
   const { filters, setFilters, resetFilters } = useDashboardStore();
   const { views, saveView } = useSavedViews();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const params = useMemo(() => {
     const p = new URLSearchParams();
@@ -116,10 +117,35 @@ export function StickyFilterBar() {
     return p;
   }, [filters]);
 
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const updateVar = () => {
+      document.documentElement.style.setProperty('--dashboard-filters', `${node.offsetHeight}px`);
+    };
+
+    updateVar();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateVar);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
-    <div className="sticky top-0 z-10 -mx-6 border-b border-[var(--surface-border)] bg-[var(--surface-s2)]/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-[var(--surface-s2)]">
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
+    <div
+      ref={containerRef}
+      className="sticky top-0 z-10 -mx-6 border-b border-[var(--surface-border)] bg-[var(--surface-s2)]/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-[var(--surface-s2)]"
+    >
+      <div className="flex items-center justify-between gap-4 overflow-hidden">
+        <div className="flex flex-1 items-center gap-4 overflow-x-auto pb-1 pt-1 [scrollbar-width:none] sm:[scrollbar-width:auto]">
           {/* Date range (global) */}
           <Group label="Date Range">
             <Select
@@ -151,7 +177,7 @@ export function StickyFilterBar() {
           </Group>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
             className="inline-flex min-h-[36px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"


### PR DESCRIPTION
## Summary
- Realigned the SaaS subscription, churn, growth, and insights blocks to the prescribed 8/4 column grid with consistent card heights, an expanded MRR chart, compact breakdown, and a footer noting refresh metadata.
- Hardened sticky behavior by measuring header/filter heights for the right rail and relocated billing cycle orchestration into the efficiency card while keeping the workbench order intact.
- Standardized KPI card sizing/value formatting and removed nested scroll containers from chart tables to match dashboard visual rules.

## Testing
- npm run lint *(emits existing ThemeProvider dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e3a8a39c832ea18c7d5437d9d089