### PR TITLE
Align SaaS dashboard with final 12-column layout

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -26,7 +26,6 @@ import {
   Earth,
   Workflow,
   Activity,
-  ClipboardList,
   Sparkles,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
@@ -174,92 +173,95 @@ function SaaSModule({
   }));
 
   const growthRows = data.growthTrend.map((point) => ({ month: point.label, mrr: point.value }));
-  const apiRows = data.apiUsageTrend.map((point) => ({ week: point.label, usage: point.value }));
+  const monthlyBreakdown = data.growthTrend.slice(0, 6).map((point) => ({
+    month: point.label,
+    net: point.value * 0.32,
+  }));
+  const thousandFormatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 0,
+  });
 
   return (
-    <div className="grid grid-cols-12 gap-6" id="saas-panel" role="tabpanel" aria-labelledby="saas">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Subscription intelligence & API operations"
-          subtitle="SaaS platform"
-          accent={accent}
-        />
-      </div>
+    <div className="space-y-6" id="saas-panel" role="tabpanel" aria-labelledby="saas">
+      <SectionHeader
+        title="Subscription intelligence & API operations"
+        subtitle="SaaS platform"
+        accent={accent}
+      />
 
-      {/* PRIMARY BLOCK 1: PLANS + CHURN */}
-      <div className="col-span-12">
-        <div className="grid grid-cols-12 gap-6">
-          {/* Subscription table - dominant width */}
-          <div className="col-span-12 lg:col-span-9">
-            <Card className="border border-[var(--surface-border)] h-[400px]" role="region" aria-label="Subscription plans">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <h3 className="text-title-sm text-slate-900">Subscription plans</h3>
-                  <p className="text-xs text-slate-600">
-                    Plan, Price/Seat, Active subs, Allocated API, Overages, Churn %, Net expansion %
-                  </p>
-                </div>
-                <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-12 xl:col-span-8">
+          <Card
+            className="flex h-full min-h-[384px] flex-col overflow-visible border border-[var(--surface-border)] bg-[var(--surface-s1)]"
+            role="region"
+            aria-label="Subscription plans"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-title-sm text-slate-900">Subscription plans</h3>
+                <p className="text-xs text-slate-600">Plan, Price/Seat, Active subs, Allocated API, Overages, Churn %, Net expansion %</p>
               </div>
-              <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-                <table className="min-w-full" aria-label="Subscription plans table">
-                  <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
-                    <tr>
-                      <th className="px-4 py-3 text-left">Plan</th>
-                      <th className="px-4 py-3 text-right">Price/Seat</th>
-                      <th className="px-4 py-3 text-right">Active subs</th>
-                      <th className="px-4 py-3 text-right">Allocated API</th>
-                      <th className="px-4 py-3 text-right">Overages</th>
-                      <th className="px-4 py-3 text-right">Churn %</th>
-                      <th className="px-4 py-3 text-right">Net expansion %</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
-                    {data.subscriptionPlans.map((plan) => (
-                      <tr key={plan.id} className="hover:bg-[var(--primary-50)]/40">
-                        <td className="px-4 py-[11px]">
-                          <div className="flex items-center gap-2">
-                            <span className="font-semibold text-slate-900">{plan.name}</span>
-                            {plan.badge ? (
-                              <span className="rounded-full bg-[var(--primary-50)] px-2 py-0.5 text-[11px] font-semibold text-[var(--primary-600)]">
-                                {plan.badge}
-                              </span>
-                            ) : null}
-                          </div>
-                        </td>
-                        <td className="px-4 py-[11px] text-right">{plan.price}</td>
-                        <td className="px-4 py-[11px] text-right">{plan.activeUsers.toLocaleString()}</td>
-                        <td className="px-4 py-[11px] text-right">{plan.apiAllocation}</td>
-                        <td className="px-4 py-[11px] text-right">$0</td>
-                        <td className="px-4 py-[11px] text-right">{plan.churn}</td>
-                        <td className="px-4 py-[11px] text-right">+12.5%</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                  <tfoot className="bg-[var(--surface-s0)] text-xs text-slate-600">
-                    <tr>
-                      <td className="px-4 py-3 font-semibold text-slate-900">Totals</td>
-                      <td className="px-4 py-3 text-right">—</td>
-                      <td className="px-4 py-3 text-right">{data.subscriptionPlans.reduce((a, p) => a + p.activeUsers, 0).toLocaleString()}</td>
-                      <td className="px-4 py-3 text-right">—</td>
-                      <td className="px-4 py-3 text-right">—</td>
-                      <td className="px-4 py-3 text-right">—</td>
-                      <td className="px-4 py-3 text-right">—</td>
-                    </tr>
-                    <tr>
-                      <td colSpan={7} className="px-4 py-2 text-right">
-                        <span className="text-[11px] text-slate-500">Last updated </span>
-                        <span className="text-[11px] font-semibold text-slate-800">{new Date().toLocaleDateString()}</span>
+              <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+            </div>
+            <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
+              <table className="min-w-full" aria-label="Subscription plans table">
+                <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Plan</th>
+                    <th className="px-4 py-3 text-right">Price/Seat</th>
+                    <th className="px-4 py-3 text-right">Active subs</th>
+                    <th className="px-4 py-3 text-right">Allocated API</th>
+                    <th className="px-4 py-3 text-right">Overages</th>
+                    <th className="px-4 py-3 text-right">Churn %</th>
+                    <th className="px-4 py-3 text-right">Net expansion %</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
+                  {data.subscriptionPlans.map((plan) => (
+                    <tr key={plan.id} className="hover:bg-[var(--primary-50)]/40">
+                      <td className="px-4 py-[11px]">
+                        <div className="flex items-center gap-2">
+                          <span className="font-semibold text-slate-900">{plan.name}</span>
+                          {plan.badge ? (
+                            <span className="rounded-full bg-[var(--primary-50)] px-2 py-0.5 text-[11px] font-semibold text-[var(--primary-600)]">
+                              {plan.badge}
+                            </span>
+                          ) : null}
+                        </div>
                       </td>
+                      <td className="px-4 py-[11px] text-right">{plan.price}</td>
+                      <td className="px-4 py-[11px] text-right">{plan.activeUsers.toLocaleString()}</td>
+                      <td className="px-4 py-[11px] text-right">{plan.apiAllocation}</td>
+                      <td className="px-4 py-[11px] text-right">$0</td>
+                      <td className="px-4 py-[11px] text-right">{plan.churn}</td>
+                      <td className="px-4 py-[11px] text-right">+12.5%</td>
                     </tr>
-                  </tfoot>
-                </table>
-              </div>
-            </Card>
-          </div>
-
-          {/* Churn donut - compact width */}
-          <div className="col-span-12 lg:col-span-3">
+                  ))}
+                </tbody>
+                <tfoot className="bg-[var(--surface-s0)] text-xs text-slate-600">
+                  <tr>
+                    <td className="px-4 py-3 font-semibold text-slate-900">Totals</td>
+                    <td className="px-4 py-3 text-right">—</td>
+                    <td className="px-4 py-3 text-right">{data.subscriptionPlans.reduce((a, p) => a + p.activeUsers, 0).toLocaleString()}</td>
+                    <td className="px-4 py-3 text-right">—</td>
+                    <td className="px-4 py-3 text-right">—</td>
+                    <td className="px-4 py-3 text-right">—</td>
+                    <td className="px-4 py-3 text-right">—</td>
+                  </tr>
+                  <tr>
+                    <td colSpan={7} className="px-4 py-2 text-right">
+                      <span className="text-[11px] text-slate-500">Last updated </span>
+                      <span className="text-[11px] font-semibold text-slate-800">{new Date().toLocaleDateString()}</span>
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </Card>
+        </div>
+        <div className="col-span-12 xl:col-span-4">
+          <div className="h-full min-h-[384px]">
             <ChartCard
               id="saas-churn"
               title="Churn health distribution"
@@ -270,10 +272,10 @@ function SaaSModule({
                 { key: 'share', label: 'Share', align: 'right' },
               ]}
             >
-              <div className="flex flex-col items-center h-[400px]">
-                <ResponsiveContainer height={250} width="100%">
+              <div className="flex h-full flex-col justify-between gap-4">
+                <ResponsiveContainer height={240} width="100%">
                   <PieChart>
-                    <Pie dataKey="value" data={data.churnSegments} innerRadius={60} outerRadius={100} paddingAngle={3}>
+                    <Pie dataKey="value" data={data.churnSegments} innerRadius={64} outerRadius={108} paddingAngle={3}>
                       {data.churnSegments.map((segment) => (
                         <Cell key={segment.id} fill={segment.color} stroke="#1f2937" strokeWidth={1.5} />
                       ))}
@@ -283,8 +285,14 @@ function SaaSModule({
                     />
                   </PieChart>
                 </ResponsiveContainer>
-                <div className="mt-2 w-full">
-                  <Legend verticalAlign="bottom" align="center" iconSize={8} wrapperStyle={{ paddingTop: 4 }} />
+                <div className="flex flex-nowrap items-center justify-between gap-3 overflow-x-auto pb-1 text-xs font-semibold text-slate-600">
+                  {data.churnSegments.map((segment) => (
+                    <div key={segment.id} className="inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 shadow-sm">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: segment.color }} aria-hidden />
+                      <span>{segment.label}</span>
+                      <span className="font-bold">{segment.value}%</span>
+                    </div>
+                  ))}
                 </div>
               </div>
             </ChartCard>
@@ -292,130 +300,92 @@ function SaaSModule({
         </div>
       </div>
 
-      <div className="col-span-12 lg:col-span-4">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Billing cycles">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Billing cycle orchestration</h3>
-              <p className="text-xs text-slate-600">Real-time close management with owner accountability.</p>
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-12">
+          <ChartCard
+            id="saas-growth"
+            title="MRR growth"
+            description="Pre-aggregated monthly recurring revenue"
+            rows={growthRows}
+            columns={[
+              { key: 'month', label: 'Month' },
+              { key: 'mrr', label: 'MRR ($K)', align: 'right' },
+            ]}
+          >
+            <div className="flex flex-col gap-5">
+              <ResponsiveContainer height={320}>
+                <LineChart data={data.growthTrend} margin={{ left: 12, right: 12, top: 24, bottom: 12 }}>
+                  <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax) => dataMax * 1.18]} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={{ r: 4 }} />
+                </LineChart>
+              </ResponsiveContainer>
+              <div className="flex flex-wrap items-center gap-3 text-xs font-semibold text-slate-600">
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 shadow-sm">
+                  <span className="h-2 w-2 rounded-full bg-[var(--primary-500)]" aria-hidden />
+                  MRR growth (USD)
+                </span>
+                <span className="text-[11px] font-medium text-slate-500">18% headroom applied to highlight run-rate momentum.</span>
+              </div>
             </div>
-            <ClipboardList className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
-          </div>
-          <ul className="mt-4 space-y-3">
-            {data.billingCycles.map((cycle) => (
-              <li key={cycle.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <div className="flex items-center justify-between text-sm text-slate-700">
-                  <span className="font-semibold text-slate-900">{cycle.label}</span>
-                  <StatusChip
-                    label={cycle.status}
-                    tone={cycle.status === 'completed' ? 'success' : cycle.status === 'processing' ? 'info' : 'warning'}
-                  />
-                </div>
-                <p className="mt-2 text-xs text-slate-500">Next run {cycle.nextRun}</p>
-                <p className="text-xs text-slate-500">Owners: {cycle.owners.join(', ')}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
-
-      {/* PRIMARY BLOCK 2: MRR GROWTH (KING SECTION) */}
-      <div className="col-span-12">
-        <div className="grid grid-cols-12 gap-6">
-          {/* MRR Growth Chart - Dominant */}
-          <div className="col-span-12 lg:col-span-8">
-            <ChartCard
-              id="saas-growth"
-              title="MRR growth"
-              description="Pre-aggregated monthly recurring revenue"
-              rows={growthRows}
-              columns={[
-                { key: 'month', label: 'Month' },
-                { key: 'mrr', label: 'MRR ($K)', align: 'right' },
-              ]}
-            >
-              <div className="flex flex-col gap-4">
-                <div className="flex justify-end">
-                  <div className="flex items-center gap-2 text-xs text-slate-600">
-                    <div className="h-2 w-2 rounded-full bg-[var(--primary-500)]" />
-                    <span>MRR Growth</span>
-                  </div>
-                </div>
-                <ResponsiveContainer height={350}>
-                  <LineChart data={data.growthTrend}>
-                    <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-                    <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                    <YAxis tickLine={false} axisLine={false} />
-                    <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-                    <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={{ r: 5 }} />
-                  </LineChart>
-                </ResponsiveContainer>
+          </ChartCard>
+        </div>
+        <div className="col-span-12">
+          <Card className="flex flex-col gap-4 border border-[var(--surface-border)] bg-[var(--surface-s1)]" role="region" aria-label="Monthly breakdown">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-title-sm text-slate-900">Monthly breakdown</h3>
+                <p className="text-xs text-slate-600">Top six months without additional scrolling</p>
               </div>
-            </ChartCard>
-          </div>
-
-          {/* Compact Monthly Breakdown */}
-          <div className="col-span-12 lg:col-span-4">
-            <Card className="border border-[var(--surface-border)] h-[400px]" role="region" aria-label="Monthly breakdown">
-              <div className="flex items-center justify-between gap-4 mb-4">
-                <div>
-                  <h3 className="text-title-sm text-slate-900">Monthly breakdown</h3>
-                  <p className="text-xs text-slate-600">Top 6 months</p>
-                </div>
-                <button
-                  type="button"
-                  className="inline-flex min-h-[36px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
-                >
-                  View all months
-                </button>
-              </div>
-              <div className="overflow-hidden">
-                <table className="min-w-full" aria-label="Monthly breakdown table">
-                  <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
-                    <tr>
-                      <th className="px-4 py-3 text-left">Month</th>
-                      <th className="px-4 py-3 text-right">Net</th>
+              <button
+                type="button"
+                className="inline-flex min-h-[36px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+              >
+                View all months
+              </button>
+            </div>
+            <div className="overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
+              <table className="min-w-full text-sm text-slate-700" aria-label="Monthly breakdown table">
+                <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Month</th>
+                    <th className="px-4 py-3 text-right">Net</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
+                  {monthlyBreakdown.map((entry) => (
+                    <tr key={entry.month} className="hover:bg-[var(--primary-50)]/40">
+                      <td className="px-4 py-[11px] font-semibold text-slate-900">{entry.month}</td>
+                      <td className="px-4 py-[11px] text-right">
+                        <span
+                          className={cn(
+                            'text-xs font-semibold',
+                            entry.net > 0 ? 'text-[var(--success-600)]' : entry.net < 0 ? 'text-[var(--danger-600)]' : 'text-slate-600'
+                          )}
+                        >
+                          ${thousandFormatter.format(entry.net)}k
+                        </span>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
-                    {data.growthTrend.slice(0, 6).map((point, index) => {
-                      const prevValue = index > 0 ? data.growthTrend[index - 1].value : 0;
-                      const growth = prevValue > 0 ? ((point.value - prevValue) / prevValue * 100) : 0;
-                      const net = point.value * 0.32; // Simplified calculation
-                      return (
-                        <tr key={point.label} className="hover:bg-[var(--primary-50)]/40">
-                          <td className="px-4 py-[11px] font-semibold text-slate-900">{point.label}</td>
-                          <td className="px-4 py-[11px] text-right">
-                            <span className={cn(
-                              'text-xs font-semibold',
-                              net > 0 ? 'text-[var(--success-600)]' : net < 0 ? 'text-[var(--danger-600)]' : 'text-slate-600'
-                            )}>
-                              ${net.toFixed(0)}k
-                            </span>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
-          </div>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
         </div>
       </div>
 
-
-      {/* SECONDARY INSIGHTS: GROWTH DRIVERS */}
-      <div className="col-span-12">
-        <div className="mb-4">
-          <h2 className="text-title-lg text-slate-900">Growth Drivers</h2>
-          <p className="text-sm text-slate-600">Key metrics driving MRR growth</p>
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-title-lg text-slate-900">Growth drivers</h2>
+          <p className="text-sm text-slate-600">Key metrics feeding new MRR</p>
         </div>
         <div className="grid grid-cols-12 gap-6">
-          {/* Affiliates growth (left) */}
-          <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Affiliates growth">
-              <div className="flex items-center justify-between gap-4 mb-4">
+          <div className="col-span-12 md:col-span-6">
+            <Card className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]" role="region" aria-label="Affiliates growth">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Affiliates growth</h3>
                   <p className="text-xs text-slate-600">Share of total (%)</p>
@@ -433,20 +403,18 @@ function SaaSModule({
               </ResponsiveContainer>
             </Card>
           </div>
-
-          {/* Top sellers (right) */}
-          <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Top sellers">
-              <div className="flex items-center justify-between gap-4 mb-4">
+          <div className="col-span-12 md:col-span-6">
+            <Card className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]" role="region" aria-label="Top sellers">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Top sellers</h3>
                   <p className="text-xs text-slate-600">Item/SKU/Plan, Sales/Revenue, Share %</p>
                 </div>
                 <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
               </div>
-              <div className="overflow-hidden">
+              <div className="flex-1 overflow-hidden">
                 <table className="min-w-full" aria-label="Top sellers table">
-                  <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                  <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                     <tr>
                       <th className="px-4 py-2 text-left">Item/SKU/Plan</th>
                       <th className="px-4 py-2 text-right">Sales/Revenue</th>
@@ -470,22 +438,28 @@ function SaaSModule({
                   </tbody>
                 </table>
               </div>
+              <div className="mt-3 flex justify-end">
+                <button
+                  type="button"
+                  className="inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+                >
+                  View all sellers
+                </button>
+              </div>
             </Card>
           </div>
         </div>
       </div>
 
-      {/* SECONDARY INSIGHTS: API HEALTH */}
-      <div className="col-span-12">
-        <div className="mb-4">
-          <h2 className="text-title-lg text-slate-900">API Health</h2>
-          <p className="text-sm text-slate-600">Monitor API performance and endpoint health</p>
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-title-lg text-slate-900">API health</h2>
+          <p className="text-sm text-slate-600">Monitor usage, errors, and latency</p>
         </div>
         <div className="grid grid-cols-12 gap-6">
-          {/* API usage (left) */}
-          <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="API usage">
-              <div className="flex items-center justify-between gap-4 mb-4">
+          <div className="col-span-12 md:col-span-6">
+            <Card className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]" role="region" aria-label="API usage">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">API usage</h3>
                   <p className="text-xs text-slate-600">Rolling avg + peak</p>
@@ -503,20 +477,18 @@ function SaaSModule({
               </ResponsiveContainer>
             </Card>
           </div>
-
-          {/* Top endpoints (right) */}
-          <div className="col-span-12 lg:col-span-6">
-            <Card className="border border-[var(--surface-border)] h-[320px]" role="region" aria-label="Top endpoints">
-              <div className="flex items-center justify-between gap-4 mb-4">
+          <div className="col-span-12 md:col-span-6">
+            <Card className="flex h-full min-h-[240px] flex-col border border-[var(--surface-border)]" role="region" aria-label="Top endpoints">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Top endpoints</h3>
                   <p className="text-xs text-slate-600">Endpoint, Calls, Errors %, Latency p95</p>
                 </div>
                 <Workflow className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
               </div>
-              <div className="overflow-hidden">
+              <div className="flex-1 overflow-hidden">
                 <table className="min-w-full" aria-label="Top endpoints table">
-                  <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                  <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                     <tr>
                       <th className="px-4 py-2 text-left">Endpoint</th>
                       <th className="px-4 py-2 text-right">Calls</th>
@@ -549,17 +521,33 @@ function SaaSModule({
                   </tbody>
                 </table>
               </div>
+              <div className="mt-3 flex justify-end">
+                <button
+                  type="button"
+                  className="inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+                >
+                  View all endpoints
+                </button>
+              </div>
             </Card>
           </div>
         </div>
       </div>
 
-
-
+      <Card padding="sm" className="border border-[var(--surface-border)] bg-[var(--surface-s1)]" role="contentinfo">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-600">
+          <span>
+            Last refresh:{' '}
+            <span className="font-semibold text-slate-800">
+              {new Date().toLocaleString('en-US', { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
+            </span>
+          </span>
+          <span>Sources: Billing system • Product analytics • CRM</span>
+        </div>
+      </Card>
     </div>
   );
 }
-
 function CommerceModule({
   data,
   accent,
@@ -1473,7 +1461,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
   return (
     <div className="min-h-screen bg-[var(--surface-s0)] pb-16 text-slate-900">
       <header className="border-b border-[var(--surface-border)] bg-white/95 shadow-xl shadow-purple-500/10 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
+        <div className="mx-auto flex max-w-[1280px] flex-col gap-6 px-6 py-8">
           <div className="flex flex-wrap items-center justify-between gap-6">
             <div className="space-y-3">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Premium Multi-Category Dashboard</p>
@@ -1559,26 +1547,29 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl space-y-8 rounded-[32px] bg-white/95 px-8 py-10 shadow-xl shadow-purple-500/10 backdrop-blur">
+      <main className="mx-auto max-w-[1280px] space-y-8 rounded-[32px] bg-white/95 px-6 py-10 shadow-xl shadow-purple-500/10 backdrop-blur">
         <KPIBand metrics={moduleMetrics} accentToken={accent} />
         <div className="rounded-[24px] border border-dashed border-[var(--surface-border)] bg-[var(--surface-s1)] px-6 py-4 text-xs text-slate-500">
           Global filters persist via query params. React Query hydrates instantly, while Zustand keeps inter-module state fast.
         </div>
-        
+
         {/* Main content with right rail */}
-        <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="grid gap-6 xl:grid-cols-12">
           {/* Main content area */}
-          <div className="flex-1">
+          <div className="xl:col-span-8">
             {moduleContent}
           </div>
-          
+
           {/* RIGHT RAIL: AUTOMATION WORKBENCH */}
-          <div className="sticky top-[120px] w-full space-y-6 lg:w-[320px] lg:flex-shrink-0 lg:max-h-[calc(100vh-140px)] lg:overflow-y-auto">
+          <aside
+            className="space-y-6 xl:col-span-4 xl:sticky"
+            style={{ top: 'calc(var(--dashboard-header, 96px) + var(--dashboard-filters, 72px) + 16px)' }}
+          >
             <div className="mb-4">
               <h2 className="text-title-lg text-slate-900">Automation Workbench</h2>
               <p className="text-sm text-slate-600">Build and manage automated workflows</p>
             </div>
-            
+
             {/* Automation builder (top) */}
             <AutomationBuilder 
               onCreate={async (automation) => {
@@ -1589,7 +1580,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
             
             {/* Automation backlog (middle) */}
             <Card className="border border-[var(--surface-border)]" role="region" aria-label="Automation backlog">
-              <div className="flex items-center justify-between gap-4 mb-4">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Automation backlog</h3>
                   <p className="text-xs text-slate-600">Status chips, active/paused</p>
@@ -1612,12 +1603,12 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                       />
                     </div>
                     <p className="mt-1 text-xs text-slate-500">{automation.metric}</p>
-                    <div className="mt-2 flex gap-2">
-                      <button className="text-xs text-[var(--primary-600)] hover:text-[var(--primary-700)]">
-                        {automation.status === 'active' ? 'Pause' : 'Resume'}
-                      </button>
-                      <button className="text-xs text-slate-500 hover:text-slate-700">Edit</button>
-                    </div>
+                    <button
+                      type="button"
+                      className="mt-3 inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold text-[var(--primary-600)] transition hover:bg-[var(--primary-50)]/70 focus-visible:focus-ring"
+                    >
+                      {automation.status === 'active' ? 'Pause automation' : 'Resume automation'}
+                    </button>
                   </div>
                 ))}
               </div>
@@ -1625,7 +1616,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
             
             {/* Efficiency showcases (bottom) */}
             <Card className="border border-[var(--surface-border)]" role="region" aria-label="Efficiency showcases">
-              <div className="flex items-center justify-between gap-4 mb-4">
+              <div className="mb-4 flex items-center justify-between gap-4">
                 <div>
                   <h3 className="text-title-sm text-slate-900">Efficiency showcases</h3>
                   <p className="text-xs text-slate-600">Recent automation wins</p>
@@ -1643,7 +1634,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                 </div>
               </div>
             </Card>
-          </div>
+          </aside>
         </div>
       </main>
     </div>

--- a/portfolio-dashboard/frontend/src/components/ui/AutomationBuilder.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/AutomationBuilder.tsx
@@ -101,8 +101,8 @@ export function AutomationBuilder({ onCreate, verticalAccent }: AutomationBuilde
             <span className="font-semibold text-slate-700">Conditions</span>
             <textarea
               {...register('conditions')}
-              className="rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring"
-              rows={3}
+              className="min-h-[108px] rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring resize-none"
+              rows={4}
               placeholder="If workspace plan = Scale & seat utilization < 60%"
             />
             {errors.conditions ? (
@@ -113,8 +113,8 @@ export function AutomationBuilder({ onCreate, verticalAccent }: AutomationBuilde
             <span className="font-semibold text-slate-700">Actions</span>
             <textarea
               {...register('action')}
-              className="rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring"
-              rows={3}
+              className="min-h-[108px] rounded-[14px] border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-sm text-slate-700 focus-visible:focus-ring resize-none"
+              rows={4}
               placeholder="Open CSM task, send Slack alert, launch in-app journey"
             />
             {errors.action ? (

--- a/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
@@ -83,7 +83,7 @@ export function ChartCard({
         <div role="figure" aria-labelledby={`${id}-title`} aria-describedby={ariaDescription ? `${id}-desc` : undefined}>
           {children}
         </div>
-        <div className="overflow-auto rounded-[18px] border border-dashed border-[var(--surface-border)]">
+        <div className="overflow-x-auto rounded-[18px] border border-dashed border-[var(--surface-border)]">
           <table className="min-w-full divide-y divide-[var(--surface-border)]" aria-label={`${title} data table`}>
             <thead className="sticky top-0 z-10 bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
               <tr>

--- a/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
@@ -118,8 +118,8 @@ export function StickyFilterBar() {
 
   return (
     <div className="sticky top-0 z-10 -mx-6 border-b border-[var(--surface-border)] bg-[var(--surface-s2)]/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-[var(--surface-s2)]">
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
+      <div className="flex items-center justify-between gap-4 overflow-hidden">
+        <div className="flex flex-1 items-center gap-4 overflow-x-auto pb-1 pt-1 [scrollbar-width:none] sm:[scrollbar-width:auto]">
           {/* Date range (global) */}
           <Group label="Date Range">
             <Select
@@ -151,7 +151,7 @@ export function StickyFilterBar() {
           </Group>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
             className="inline-flex min-h-[36px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"


### PR DESCRIPTION
## Summary
- Rebuild the SaaS module around an 8/4 split so plans, churn, growth, drivers, and API panels share uniform heights, compact tables, and a footer note that meets the final hierarchy.
- Resize the dashboard canvas to a centered 1280px grid and swap the main body to an xl 12-column layout with a sticky right rail block for the automation workbench.
- Limit chart data tables to horizontal overflow only to eliminate nested vertical scrolling in compact list cards.

## Testing
- npm run lint *(warns about existing ThemeProvider dependency check)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e3a8a39c832ea18c7d5437d9d089