### PR TITLE
Rebuild dashboard layouts for multi-vertical brief

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -555,118 +555,127 @@ function CommerceModule({
   data: PortfolioDashboardResponse['commerce'];
   accent: string;
 }) {
-  const salesRows = data.salesTrend.map((point) => ({ month: point.label, revenue: point.value }));
-
   return (
-    <div className="grid grid-cols-12 gap-6" id="commerce-panel" role="tabpanel" aria-labelledby="commerce">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Merchandising, orders & fulfillment"
-          subtitle="E-commerce"
-          accent={accent}
-        />
-      </div>
+    <section id="commerce-panel" role="tabpanel" aria-labelledby="commerce" className="space-y-6">
+      <SectionHeader
+        title="Merchandising, orders & fulfillment"
+        subtitle="E-commerce"
+        accent={accent}
+      />
 
-      <div className="col-span-12 lg:col-span-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Top products leaderboard">
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Top products purchased"
+        >
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Top products leaderboard</h3>
-              <p className="text-xs text-slate-600">Revenue, conversion, inventory, and trend for hero SKUs.</p>
+              <h3 className="text-title-sm text-slate-900">Top products purchased</h3>
+              <p className="text-xs text-slate-600">Revenue, conversion, inventory health.</p>
             </div>
-            <ArrowUpRight className="h-5 w-5 text-[var(--success-600)]" aria-hidden />
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Product leaderboard table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                 <tr>
-                  <th className="px-4 py-3 text-left">Product</th>
-                  <th className="px-4 py-3 text-left">Category</th>
-                  <th className="px-4 py-3 text-left">Revenue</th>
-                  <th className="px-4 py-3 text-left">Conversion</th>
-                  <th className="px-4 py-3 text-right">Inventory</th>
-                  <th className="px-4 py-3 text-right">Trend</th>
+                  <th className="px-3 py-2 text-left">Product</th>
+                  <th className="px-3 py-2 text-left">Category</th>
+                  <th className="px-3 py-2 text-right">Revenue</th>
+                  <th className="px-3 py-2 text-right">Conversion</th>
+                  <th className="px-3 py-2 text-right">Inventory</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm">
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
                 {data.topProducts.map((product) => (
-                  <tr key={product.id}>
-                    <td className="px-4 py-[11px] font-semibold text-slate-900">{product.name}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.category}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.revenue}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.conversionRate}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{product.inventory}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">
-                      {product.trend === 'up' ? '↑' : product.trend === 'down' ? '↓' : '→'}
-                    </td>
+                  <tr key={product.id} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{product.name}</td>
+                    <td className="px-3 py-[11px] text-slate-600">{product.category}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-600">{product.revenue}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-600">{product.conversionRate}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-600">{product.inventory.toLocaleString()}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
         </Card>
-      </div>
 
-      <div className="col-span-12 lg:col-span-6 space-y-6">
-        <ChartCard
-          id="commerce-sales"
-          title="Sales trends"
-          description="Seasonally-adjusted GMV"
-          rows={salesRows}
-          columns={[
-            { key: 'month', label: 'Month' },
-            { key: 'revenue', label: 'GMV ($M)', align: 'right' },
-          ]}
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Sales trends"
         >
-          <ResponsiveContainer height={260}>
-            <BarChart data={data.salesTrend}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Bar dataKey="value" radius={[12, 12, 12, 12]} fill="var(--vertical-commerce)" />
-            </BarChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Operational health">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Operational health</h3>
-              <p className="text-xs text-slate-600">Fulfillment SLAs, payment resilience, and support load.</p>
+              <h3 className="text-title-sm text-slate-900">Sales trends</h3>
+              <p className="text-xs text-slate-600">Seasonally adjusted GMV (USD).</p>
             </div>
-            <Activity className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.operations.map((item) => (
-              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
+          <ResponsiveContainer height={150} className="mt-3">
+            <LineChart data={data.salesTrend} margin={{ top: 10, right: 16, left: -10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax: number) => dataMax * 1.18]} tickFormatter={(value) => `$${value}M`} />
+              <Tooltip formatter={(value: number) => [`$${value}M`, 'GMV']} contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+              <Line type="monotone" dataKey="value" stroke="var(--vertical-commerce)" strokeWidth={3} dot={{ r: 3 }} name="GMV" />
+            </LineChart>
+          </ResponsiveContainer>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">Headroom applied for clarity</div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[220px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Monthly breakdown"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Monthly breakdown</h3>
+              <p className="text-xs text-slate-600">Net contribution (USD millions).</p>
+            </div>
+          </div>
+          <ul className="mt-3 space-y-1 text-sm text-slate-700">
+            {data.monthlyBreakdown.map((entry) => (
+              <li key={entry.month} className="flex items-center justify-between rounded-[14px] border border-[var(--surface-border)] px-3 py-2">
+                <span>{entry.month}</span>
+                <span className="font-semibold text-slate-900">${entry.net.toFixed(2)}M</span>
+              </li>
+            ))}
+          </ul>
+          <div className="text-right text-[11px] text-slate-500">View all in finance workspace</div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Returns and low-stock alerts"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Returns & low-stock alerts</h3>
+              <p className="text-xs text-slate-600">Prioritized interventions.</p>
+            </div>
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {data.inventoryAlerts.map((alert) => (
+              <li key={alert.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-semibold text-slate-900">{item.title}</p>
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-slate-900">{alert.title}</p>
+                    <p className="text-xs text-slate-500">{alert.impact}</p>
+                  </div>
                   <StatusChip
-                    label={item.status}
-                    tone={item.status === 'healthy' ? 'success' : item.status === 'attention' ? 'warning' : 'info'}
+                    label={alert.status}
+                    tone={alert.status === 'urgent' ? 'danger' : alert.status === 'monitor' ? 'warning' : 'success'}
                   />
                 </div>
-                <p className="mt-2 text-xs text-slate-600">{item.description}</p>
               </li>
             ))}
           </ul>
         </Card>
       </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationList items={data.automation} />
-      </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationBuilder
-          verticalAccent={accent}
-          onCreate={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 800));
-          }}
-        />
-      </div>
-    </div>
+    </section>
   );
 }
 
@@ -677,96 +686,211 @@ function CorporateModule({
   data: PortfolioDashboardResponse['corporate'];
   accent: string;
 }) {
-  const funnelRows = data.funnel.map((stage) => ({
-    stage: stage.stage,
-    count: stage.count.toLocaleString(),
-    conversion: stage.conversion,
-    delta: `${stage.delta.toFixed(1)}%`,
+  const channelRows = data.channelPerformance.map((row) => ({
+    channel: row.channel,
+    spend: row.spend,
+    pipeline: row.pipeline,
+    roi: row.roi,
+  }));
+  const segmentRows = data.segmentImpact.map((row) => ({
+    segment: row.segment,
+    influence: row.influence,
+    winRate: row.winRate,
   }));
 
-  const sourceRows = data.leadSources.map((source) => ({ source: source.label, share: `${source.value}%` }));
-
   return (
-    <div className="grid grid-cols-12 gap-6" id="corporate-panel" role="tabpanel" aria-labelledby="corporate">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Growth marketing & pipeline analytics"
-          subtitle="Corporate analytics"
-          accent={accent}
-        />
-      </div>
+    <section id="corporate-panel" role="tabpanel" aria-labelledby="corporate" className="space-y-6">
+      <SectionHeader
+        title="Growth marketing & pipeline analytics"
+        subtitle="Corporate analytics"
+        accent={accent}
+      />
 
-      <div className="col-span-12 lg:col-span-7 space-y-6">
-        <ChartCard
-          id="corporate-funnel"
-          title="Conversion funnel"
-          description="Visitors → MQL → SQL → Opportunities → Closed"
-          rows={funnelRows}
-          columns={[
-            { key: 'stage', label: 'Stage' },
-            { key: 'count', label: 'Volume', align: 'right' },
-            { key: 'conversion', label: 'Conversion', align: 'right' },
-            { key: 'delta', label: 'Δ', align: 'right' },
-          ]}
-          tone="accent"
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Conversion campaigns"
         >
-          <ResponsiveContainer height={320}>
-            <BarChart data={data.funnel} layout="vertical" margin={{ left: 80 }}>
-              <CartesianGrid horizontal={false} stroke="rgba(148, 163, 184, 0.25)" />
-              <XAxis type="number" hide />
-              <YAxis dataKey="stage" type="category" tickLine={false} axisLine={false} width={200} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Bar dataKey="count" fill="var(--vertical-corporate)" radius={[12, 12, 12, 12]} />
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Conversion campaigns</h3>
+              <p className="text-xs text-slate-600">Spend vs pipeline creation (USD, headroom 15%).</p>
+            </div>
+            <ArrowUpRight className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+          </div>
+          <ResponsiveContainer height={140} className="mt-2">
+            <BarChart data={data.conversionCampaigns} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                domain={[0, (dataMax: number) => dataMax * 1.2]}
+                tickFormatter={(value) => `${value.toFixed(1)}M`}
+              />
+              <Tooltip
+                formatter={(value: number, name: string) => [`$${value.toFixed(1)}M`, name === 'value' ? 'Spend' : 'Pipeline']}
+                contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }}
+              />
+              <Bar dataKey="value" fill="var(--vertical-corporate)" radius={[10, 10, 0, 0]} name="Spend" />
+              <Line
+                type="monotone"
+                dataKey="secondary"
+                stroke="var(--primary-600)"
+                strokeWidth={3}
+                dot={{ r: 3 }}
+                name="Pipeline"
+              />
             </BarChart>
           </ResponsiveContainer>
-        </ChartCard>
+          <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+            <span className="inline-flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-[var(--vertical-corporate)]" aria-hidden />
+              Spend
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-[var(--primary-600)]" aria-hidden />
+              Pipeline
+            </span>
+          </div>
+        </Card>
 
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Executive insights">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Lead segments mix"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Lead segments mix</h3>
+              <p className="text-xs text-slate-600">Share of qualified pipeline by source.</p>
+            </div>
+            <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+          </div>
+          <div className="mt-3 flex flex-1 flex-col justify-between">
+            <ResponsiveContainer height={130}>
+              <PieChart>
+                <Pie data={data.leadSources} dataKey="value" innerRadius={54} outerRadius={92} paddingAngle={2}>
+                  {data.leadSources.map((source) => (
+                    <Cell key={source.id} fill={source.color} stroke="#1f2937" strokeWidth={1.2} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value: number) => [`${value}%`, 'Contribution']}
+                  contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }}
+                />
+                <Legend verticalAlign="bottom" height={36} iconType="circle" />
+              </PieChart>
+            </ResponsiveContainer>
+            <ol className="mt-3 space-y-1 text-xs text-slate-600">
+              {data.leadSources
+                .slice()
+                .sort((a, b) => b.value - a.value)
+                .map((source, index) => (
+                  <li key={source.id} className="flex items-center justify-between gap-3 rounded-full bg-white/70 px-3 py-1">
+                    <span className="flex items-center gap-2">
+                      <span className="text-[11px] font-semibold text-slate-500">#{index + 1}</span>
+                      <span className="font-semibold text-slate-900">{source.label}</span>
+                    </span>
+                    <span className="text-sm font-semibold text-slate-900">{source.value}%</span>
+                  </li>
+                ))}
+            </ol>
+          </div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Channel performance"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Channel performance</h3>
+              <p className="text-xs text-slate-600">Spend, influenced pipeline, ROI.</p>
+            </div>
+          </div>
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                <tr>
+                  <th className="px-3 py-2 text-left">Channel</th>
+                  <th className="px-3 py-2 text-right">Spend</th>
+                  <th className="px-3 py-2 text-right">Pipeline</th>
+                  <th className="px-3 py-2 text-right">ROI</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
+                {channelRows.map((row) => (
+                  <tr key={row.channel} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{row.channel}</td>
+                    <td className="px-3 py-[11px] text-right">{row.spend}</td>
+                    <td className="px-3 py-[11px] text-right">{row.pipeline}</td>
+                    <td className="px-3 py-[11px] text-right">{row.roi}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Segment impact"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Segment impact</h3>
+              <p className="text-xs text-slate-600">Influenced pipeline & win rate.</p>
+            </div>
+          </div>
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                <tr>
+                  <th className="px-3 py-2 text-left">Segment</th>
+                  <th className="px-3 py-2 text-right">Influence</th>
+                  <th className="px-3 py-2 text-right">Win rate</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
+                {segmentRows.map((row) => (
+                  <tr key={row.segment} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{row.segment}</td>
+                    <td className="px-3 py-[11px] text-right">{row.influence}</td>
+                    <td className="px-3 py-[11px] text-right">{row.winRate}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Executive insights"
+        >
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-title-sm text-slate-900">Executive insights</h3>
-              <p className="text-xs text-slate-600">Board-ready bullets with context tags.</p>
+              <p className="text-xs text-slate-600">Signals curated for board briefs.</p>
             </div>
             <Check className="h-5 w-5 text-[var(--success-600)]" aria-hidden />
           </div>
-          <ul className="mt-4 space-y-3">
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
             {data.insights.map((insight) => (
-              <li key={insight.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <p className="text-sm font-semibold text-slate-900">{insight.headline}</p>
+              <li key={insight.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
+                <p className="font-semibold text-slate-900">{insight.headline}</p>
                 <p className="mt-1 text-xs text-slate-600">{insight.detail}</p>
               </li>
             ))}
           </ul>
         </Card>
       </div>
-
-      <div className="col-span-12 lg:col-span-5 space-y-6">
-        <ChartCard
-          id="corporate-leads"
-          title="Lead source mix"
-          description="Colorblind-safe mix with accessible legend"
-          rows={sourceRows}
-          columns={[
-            { key: 'source', label: 'Source' },
-            { key: 'share', label: 'Share', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={260}>
-            <PieChart>
-              <Pie dataKey="value" data={data.leadSources} innerRadius={70} outerRadius={110} paddingAngle={2}>
-                {data.leadSources.map((source) => (
-                  <Cell key={source.id} fill={source.color} stroke="#1f2937" strokeWidth={1.4} />
-                ))}
-              </Pie>
-              <Legend verticalAlign="bottom" height={60} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-            </PieChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <AutomationList items={data.automation} />
-      </div>
-    </div>
+    </section>
   );
 }
 
@@ -777,107 +901,165 @@ function CustomAppModule({
   data: PortfolioDashboardResponse['customApp'];
   accent: string;
 }) {
-  return (
-    <div className="grid grid-cols-12 gap-6" id="customApp-panel" role="tabpanel" aria-labelledby="customApp">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Productivity suite & automation"
-          subtitle="Custom web app"
-          accent={accent}
-        />
-      </div>
+  const laneSummaries = data.kanban.map((lane) => ({
+    id: lane.id,
+    title: lane.title,
+    badge: lane.badge,
+    total: lane.tasks.length,
+  }));
 
-      <div className="col-span-12 xl:col-span-7">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Kanban delivery board">
+  return (
+    <section id="customApp-panel" role="tabpanel" aria-labelledby="customApp" className="space-y-6">
+      <SectionHeader
+        title="Productivity suite & automation"
+        subtitle="Custom web app"
+        accent={accent}
+      />
+
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Kanban summary board"
+        >
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Kanban delivery board</h3>
-              <p className="text-xs text-slate-600">
-                Keyboard accessible DnD — Space to lift, arrows to move, Enter to drop.
-              </p>
+              <h3 className="text-title-sm text-slate-900">Kanban summary board</h3>
+              <p className="text-xs text-slate-600">Velocity snapshot across active lanes.</p>
             </div>
+            <Workflow className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
           </div>
-          <div className="mt-4 grid gap-4 overflow-x-auto pb-2 sm:grid-cols-2 xl:grid-cols-4">
-            {data.kanban.map((lane) => (
-              <div key={lane.id} className="rounded-[18px] border border-[var(--surface-border)] bg-[var(--surface-s1)] p-4">
-                <div className="flex items-center justify-between">
-                  <h4 className="text-sm font-semibold text-slate-900">{lane.title}</h4>
-                  <StatusChip label={lane.badge} tone="info" />
+          <div className="mt-4 grid flex-1 grid-cols-4 gap-3">
+            {laneSummaries.map((lane) => (
+              <div
+                key={lane.id}
+                className="flex flex-col justify-between rounded-[16px] border border-[var(--surface-border)] bg-white/80 px-3 py-2"
+              >
+                <div className="flex items-center justify-between text-xs text-slate-500">
+                  <span className="font-semibold uppercase tracking-[0.12em] text-slate-600">{lane.title}</span>
+                  <span className="rounded-full bg-[var(--surface-s2)] px-2 py-0.5 text-[11px] font-semibold text-slate-700">
+                    {lane.badge}
+                  </span>
                 </div>
-                <ul className="mt-3 space-y-3">
-                  {lane.tasks.map((task) => (
-                    <li key={task.id} className="rounded-[16px] border border-[var(--surface-border)] bg-white/80 p-3 shadow-sm">
-                      <p className="text-sm font-semibold text-slate-900">{task.title}</p>
-                      <p className="mt-1 text-xs text-slate-500">Owner: {task.owner}</p>
-                      <p className="text-xs text-slate-500">Due {task.due}</p>
-                      {task.automation ? (
-                        <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--primary-600)]">
-                          {task.automation}
-                        </p>
-                      ) : null}
-                    </li>
-                  ))}
-                </ul>
+                <div className="mt-4 text-right">
+                  <p className="text-3xl font-semibold text-slate-900">{lane.total}</p>
+                  <p className="text-[11px] uppercase tracking-[0.12em] text-slate-500">cards</p>
+                </div>
               </div>
             ))}
           </div>
         </Card>
-      </div>
 
-      <div className="col-span-12 xl:col-span-5 space-y-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Idea backlog">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Usage tracking metrics"
+        >
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Idea backlog intake</h3>
-              <p className="text-xs text-slate-600">Routing rules auto-tag and assign backlog ideas.</p>
+              <h3 className="text-title-sm text-slate-900">Usage tracking metrics</h3>
+              <p className="text-xs text-slate-600">Active vs engaged seats.</p>
             </div>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.backlogIdeas.map((idea) => (
-              <li key={idea} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3 text-sm text-slate-700">
-                {idea}
+          <ResponsiveContainer height={140} className="mt-3">
+            <AreaChart data={data.usageTracking} margin={{ top: 12, right: 16, left: -10, bottom: 0 }}>
+              <defs>
+                <linearGradient id="usageGradient" x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="5%" stopColor="var(--vertical-custom)" stopOpacity={0.6} />
+                  <stop offset="95%" stopColor="var(--vertical-custom)" stopOpacity={0.05} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax: number) => dataMax * 1.1]} />
+              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+              <Area type="monotone" dataKey="value" stroke="var(--vertical-custom)" fill="url(#usageGradient)" name="Active" />
+              <Line type="monotone" dataKey="secondary" stroke="#0ea5e9" strokeWidth={3} dot={{ r: 3 }} name="Engaged" />
+            </AreaChart>
+          </ResponsiveContainer>
+          <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+            <span className="inline-flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-[var(--vertical-custom)]" aria-hidden />
+              Active seats
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-[#0ea5e9]" aria-hidden />
+              Engaged seats
+            </span>
+          </div>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Quickstart automations"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Quickstart automations</h3>
+              <p className="text-xs text-slate-600">Adoption and impact by playbook.</p>
+            </div>
+          </div>
+          <ResponsiveContainer height={120} className="mt-3">
+            <BarChart data={data.quickstartAutomations} margin={{ top: 8, right: 12, left: -12, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
+              <XAxis dataKey="name" tickLine={false} axisLine={false} tick={{ fontSize: 10 }} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, 100]} />
+              <Tooltip formatter={(value: number) => [`${value}% adoption`, 'Adoption']} contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+              <Bar dataKey="adoption" fill="var(--vertical-custom)" radius={[8, 8, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+          <ul className="mt-2 space-y-1 text-xs text-slate-600">
+            {data.quickstartAutomations.map((automation) => (
+              <li key={automation.id} className="flex items-center justify-between gap-3 rounded-full bg-white/70 px-3 py-1">
+                <span className="truncate font-semibold text-slate-900">{automation.name}</span>
+                <span className="text-[11px] uppercase tracking-[0.1em] text-slate-500">{automation.impact}</span>
               </li>
             ))}
           </ul>
         </Card>
 
-        <ChartCard
-          id="custom-workload"
-          title="Workload distribution"
-          description="Task load vs capacity"
-          rows={data.workloadDistribution.map((point) => ({ owner: point.label, tasks: point.value, capacity: point.secondary }))}
-          columns={[
-            { key: 'owner', label: 'Owner' },
-            { key: 'tasks', label: 'Tasks', align: 'right' },
-            { key: 'capacity', label: 'Capacity', align: 'right' },
-          ]}
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Ops backlog table"
         >
-          <ResponsiveContainer height={220}>
-            <BarChart data={data.workloadDistribution}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Bar dataKey="secondary" stackId="a" fill="rgba(148, 163, 184, 0.2)" radius={[12, 12, 12, 12]} />
-              <Bar dataKey="value" stackId="a" fill="var(--vertical-custom)" radius={[12, 12, 12, 12]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </ChartCard>
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Ops backlog</h3>
+              <p className="text-xs text-slate-600">Next five automation requests.</p>
+            </div>
+          </div>
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
+                <tr>
+                  <th className="px-3 py-2 text-left">Request</th>
+                  <th className="px-3 py-2 text-right">Owner</th>
+                  <th className="px-3 py-2 text-right">Status</th>
+                  <th className="px-3 py-2 text-right">ETA</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
+                {data.opsBacklog.map((item) => (
+                  <tr key={item.id} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{item.request}</td>
+                    <td className="px-3 py-[11px] text-right">{item.owner}</td>
+                    <td className="px-3 py-[11px] text-right">
+                      <StatusChip
+                        label={item.status.replace('-', ' ')}
+                        tone={item.status === 'blocked' ? 'danger' : item.status === 'in-progress' ? 'info' : 'warning'}
+                      />
+                    </td>
+                    <td className="px-3 py-[11px] text-right">{item.eta}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
       </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationBuilder
-          verticalAccent={accent}
-          onCreate={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 700));
-          }}
-        />
-      </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationList items={data.automation} />
-      </div>
-    </div>
+    </section>
   );
 }
 
@@ -888,99 +1070,68 @@ function ContentModule({
   data: PortfolioDashboardResponse['content'];
   accent: string;
 }) {
-  const engagementRows = data.engagementTrend.map((point) => ({ period: point.label, score: point.value }));
-
   return (
-    <div className="grid grid-cols-12 gap-6" id="content-panel" role="tabpanel" aria-labelledby="content">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Publishing workflow & engagement"
-          subtitle="Content & media"
-          accent={accent}
-        />
-      </div>
+    <section id="content-panel" role="tabpanel" aria-labelledby="content" className="space-y-6">
+      <SectionHeader
+        title="Publishing workflow & engagement"
+        subtitle="Content & media"
+        accent={accent}
+      />
 
-      <div className="col-span-12 lg:col-span-7 space-y-6">
-        <ChartCard
-          id="content-engagement"
-          title="Engagement trend"
-          description="Plays, reads, and watch time"
-          rows={engagementRows}
-          columns={[
-            { key: 'period', label: 'Period' },
-            { key: 'score', label: 'Engagement', align: 'right' },
-          ]}
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Engagement trend"
         >
-          <ResponsiveContainer height={280}>
-            <LineChart data={data.engagementTrend}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(251, 146, 60, 0.25)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Line type="monotone" dataKey="value" stroke="var(--vertical-content)" strokeWidth={3} dot={{ r: 5 }} />
-            </LineChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Publishing queue">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Publishing queue</h3>
-              <p className="text-xs text-slate-600">Ready, review, and blocked statuses with guardrails.</p>
+              <h3 className="text-title-sm text-slate-900">Engagement trend</h3>
+              <p className="text-xs text-slate-600">Eight-week blended engagement score.</p>
             </div>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.publishingQueue.map((item) => (
-              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-semibold text-slate-900">{item.topic}</p>
-                    <p className="text-xs text-slate-500">Slot {item.slot} • Editor {item.editor}</p>
-                  </div>
-                  <StatusChip
-                    label={item.status}
-                    tone={
-                      item.status === 'ready'
-                        ? 'success'
-                        : item.status === 'blocked'
-                        ? 'danger'
-                        : 'info'
-                    }
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
+          <ResponsiveContainer height={150} className="mt-3">
+            <LineChart data={data.engagementTrend} margin={{ top: 10, right: 16, left: -10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(251, 146, 60, 0.25)" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax: number) => dataMax * 1.15]} />
+              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+              <Line type="monotone" dataKey="value" stroke="var(--vertical-content)" strokeWidth={3} dot={{ r: 3 }} name="Engagement" />
+            </LineChart>
+          </ResponsiveContainer>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">Blended content engagement</div>
         </Card>
-      </div>
 
-      <div className="col-span-12 lg:col-span-5 space-y-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Top performing stories">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Top performing stories"
+        >
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-title-sm text-slate-900">Top performing stories</h3>
-              <p className="text-xs text-slate-600">Format, window, engagement, status.</p>
+              <p className="text-xs text-slate-600">5 most recent high-signal releases.</p>
             </div>
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Stories table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                 <tr>
-                  <th className="px-4 py-3 text-left">Title</th>
-                  <th className="px-4 py-3 text-left">Format</th>
-                  <th className="px-4 py-3 text-left">Window</th>
-                  <th className="px-4 py-3 text-right">Engagement</th>
-                  <th className="px-4 py-3 text-right">Status</th>
+                  <th className="px-3 py-2 text-left">Title</th>
+                  <th className="px-3 py-2 text-left">Format</th>
+                  <th className="px-3 py-2 text-left">Window</th>
+                  <th className="px-3 py-2 text-right">Engagement</th>
+                  <th className="px-3 py-2 text-right">Status</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm">
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
                 {data.topStories.map((story) => (
-                  <tr key={story.id}>
-                    <td className="px-4 py-[11px] font-semibold text-slate-900">{story.title}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{story.format}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{story.publishedAt}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{story.engagement}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{story.status}</td>
+                  <tr key={story.id} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{story.title}</td>
+                    <td className="px-3 py-[11px] text-slate-600">{story.format}</td>
+                    <td className="px-3 py-[11px] text-slate-600">{story.publishedAt}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-600">{story.engagement}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-600">{story.status}</td>
                   </tr>
                 ))}
               </tbody>
@@ -988,9 +1139,65 @@ function ContentModule({
           </div>
         </Card>
 
-        <AutomationList items={data.automation} />
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Publishing queue"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Publishing queue</h3>
+              <p className="text-xs text-slate-600">Next scheduled slots with health checks.</p>
+            </div>
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {data.publishingQueue.map((item) => (
+              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-slate-900">{item.topic}</p>
+                    <p className="text-xs text-slate-500">{item.slot} • {item.editor}</p>
+                  </div>
+                  <StatusChip
+                    label={item.status}
+                    tone={item.status === 'ready' ? 'success' : item.status === 'blocked' ? 'danger' : 'info'}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Highlights and approvals"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Highlights & approvals</h3>
+              <p className="text-xs text-slate-600">Stakeholder checkpoints this week.</p>
+            </div>
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {data.highlights.map((item) => (
+              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-slate-900">{item.title}</p>
+                    <p className="text-xs text-slate-500">{item.timestamp} • {item.owner}</p>
+                  </div>
+                  <StatusChip
+                    label={item.status.replace('-', ' ')}
+                    tone={item.status === 'approved' ? 'success' : item.status === 'needs-review' ? 'warning' : 'info'}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -1004,40 +1211,42 @@ function EdTechModule({
   const heatmapMax = Math.max(...data.activityHeatmap.values.map((entry) => entry.score));
 
   return (
-    <div className="grid grid-cols-12 gap-6" id="edtech-panel" role="tabpanel" aria-labelledby="edtech">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Learning analytics & student success"
-          subtitle="EdTech"
-          accent={accent}
-        />
-      </div>
+    <section id="edtech-panel" role="tabpanel" aria-labelledby="edtech" className="space-y-6">
+      <SectionHeader
+        title="Learning analytics & student success"
+        subtitle="EdTech"
+        accent={accent}
+      />
 
-      <div className="col-span-12 xl:col-span-6 space-y-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Program performance">
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Course performance"
+        >
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Program performance</h3>
+              <h3 className="text-title-sm text-slate-900">Course performance</h3>
               <p className="text-xs text-slate-600">Enrollment, completion, average scores.</p>
             </div>
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Program performance table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                 <tr>
-                  <th className="px-4 py-3 text-left">Course</th>
-                  <th className="px-4 py-3 text-right">Enrollment</th>
-                  <th className="px-4 py-3 text-right">Completion</th>
-                  <th className="px-4 py-3 text-right">Avg score</th>
+                  <th className="px-3 py-2 text-left">Course</th>
+                  <th className="px-3 py-2 text-right">Enrollment</th>
+                  <th className="px-3 py-2 text-right">Completion</th>
+                  <th className="px-3 py-2 text-right">Avg score</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm">
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
                 {data.courses.map((course) => (
-                  <tr key={course.id}>
-                    <td className="px-4 py-[11px] font-semibold text-slate-900">{course.title}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{course.enrollment.toLocaleString()}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{course.completion}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{course.avgScore}</td>
+                  <tr key={course.id} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] font-semibold text-slate-900">{course.title}</td>
+                    <td className="px-3 py-[11px] text-right">{course.enrollment.toLocaleString()}</td>
+                    <td className="px-3 py-[11px] text-right">{course.completion}</td>
+                    <td className="px-3 py-[11px] text-right">{course.avgScore}</td>
                   </tr>
                 ))}
               </tbody>
@@ -1045,47 +1254,44 @@ function EdTechModule({
           </div>
         </Card>
 
-        <AutomationList items={data.automation} />
-      </div>
-
-      <div className="col-span-12 xl:col-span-6 space-y-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Student activity heatmap">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Student activity heatmap"
+        >
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-title-sm text-slate-900">Student activity heatmap</h3>
-              <p className="text-xs text-slate-600">Keyboard navigation supported — use arrow keys to traverse.</p>
+              <p className="text-xs text-slate-600">Peak engagement by day and cohort week.</p>
             </div>
           </div>
-          <div className="mt-4 overflow-x-auto">
-            <table className="min-w-full text-center" aria-label="Student activity heatmap table">
-              <thead className="text-xs uppercase tracking-[0.08em] text-slate-500">
+          <div className="mt-3 overflow-x-auto">
+            <table className="min-w-full text-xs">
+              <thead>
                 <tr>
-                  <th className="px-2 py-2 text-left">Week</th>
+                  <th className="px-2 py-1 text-left text-slate-500">Week</th>
                   {data.activityHeatmap.days.map((day) => (
-                    <th key={day} className="px-2 py-2 text-center">
-                      {day}
-                    </th>
+                    <th key={day} className="px-2 py-1 text-left text-slate-500">{day}</th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="text-sm">
+              <tbody className="text-center text-slate-700">
                 {data.activityHeatmap.weeks.map((week) => (
                   <tr key={week}>
-                    <td className="px-2 py-2 text-left font-semibold text-slate-900">{week}</td>
+                    <th scope="row" className="px-2 py-2 text-left text-slate-500">{week}</th>
                     {data.activityHeatmap.days.map((day) => {
-                      const cell = data.activityHeatmap.values.find((value) => value.week === week && value.day === day);
-                      const score = cell?.score ?? 0;
-                      const intensity = score / heatmapMax;
+                      const value = data.activityHeatmap.values.find((entry) => entry.week === week && entry.day === day)?.score ?? 0;
+                      const intensity = value / heatmapMax;
                       return (
                         <td
                           key={`${week}-${day}`}
-                          className="px-2 py-2 text-xs font-semibold text-slate-700"
+                          className="px-2 py-2 font-semibold text-slate-700"
                           style={{
-                            background: `rgba(107, 70, 193, ${0.2 + intensity * 0.5})`,
+                            background: `rgba(244, 114, 182, ${0.18 + intensity * 0.55})`,
                             borderRadius: 12,
                           }}
                         >
-                          {score}
+                          {value}
                         </td>
                       );
                     })}
@@ -1096,27 +1302,58 @@ function EdTechModule({
           </div>
         </Card>
 
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Alerts">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Alerts"
+        >
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-title-sm text-slate-900">Alerts</h3>
-              <p className="text-xs text-slate-600">FERPA-ready alerts with remediation guidance.</p>
+              <p className="text-xs text-slate-600">Student success signals without scroll.</p>
             </div>
           </div>
-          <ul className="mt-4 space-y-3">
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
             {data.alerts.map((alert) => (
-              <li key={alert.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <StatusChip
-                  label={alert.severity}
-                  tone={alert.severity === 'critical' ? 'danger' : alert.severity === 'warning' ? 'warning' : 'info'}
-                />
-                <p className="mt-2 text-sm text-slate-700">{alert.message}</p>
+              <li key={alert.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="flex-1">{alert.message}</p>
+                  <StatusChip
+                    label={alert.severity}
+                    tone={alert.severity === 'critical' ? 'danger' : alert.severity === 'warning' ? 'warning' : 'info'}
+                  />
+                </div>
               </li>
             ))}
           </ul>
         </Card>
+
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Student success uplift"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Student success uplift</h3>
+              <p className="text-xs text-slate-600">Graduation impact by program interventions.</p>
+            </div>
+          </div>
+          <div className="mt-3 space-y-3">
+            <p className="text-3xl font-semibold text-slate-900">{data.successSummary.uplift}</p>
+            <p className="text-sm text-slate-600">{data.successSummary.narrative}</p>
+            <ul className="space-y-2 text-sm text-slate-700">
+              {data.successSummary.breakdown.map((item) => (
+                <li key={item.id} className="flex items-center justify-between rounded-[14px] border border-[var(--surface-border)] px-3 py-2">
+                  <span>{item.label}</span>
+                  <span className="font-semibold text-slate-900">{item.value}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -1127,158 +1364,128 @@ function SpecializedModule({
   data: PortfolioDashboardResponse['specialized'];
   accent: string;
 }) {
-  const momentumRows = data.realEstate.trend.map((point) => ({ month: point.label, momentum: point.value }));
-  const expenseRows = data.finance.expenses.map((point) => ({ week: point.label, actual: point.value, budget: point.secondary }));
-  const roiRows = data.finance.roiBreakdown.map((item) => ({ channel: item.label, share: `${item.value}%` }));
-
   return (
-    <div className="grid grid-cols-12 gap-6" id="specialized-panel" role="tabpanel" aria-labelledby="specialized">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Specialized niches"
-          subtitle="Real estate, finance, healthcare"
-          accent={accent}
-        />
-      </div>
+    <section id="specialized-panel" role="tabpanel" aria-labelledby="specialized" className="space-y-6">
+      <SectionHeader
+        title="Specialized niches"
+        subtitle="Real estate, finance, healthcare"
+        accent={accent}
+      />
 
-      <div className="col-span-12 xl:col-span-6 space-y-6">
-        <ChartCard
-          id="specialized-momentum"
-          title="Market momentum"
-          description="Real estate listings velocity"
-          rows={momentumRows}
-          columns={[
-            { key: 'month', label: 'Month' },
-            { key: 'momentum', label: 'Momentum', align: 'right' },
-          ]}
+      <div className="grid grid-cols-8 gap-x-10 gap-y-6">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Market movements"
         >
-          <ResponsiveContainer height={220}>
-            <AreaChart data={data.realEstate.trend}>
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Market movements</h3>
+              <p className="text-xs text-slate-600">Real estate listings velocity (index).</p>
+            </div>
+          </div>
+          <ResponsiveContainer height={150} className="mt-3">
+            <AreaChart data={data.realEstate.trend} margin={{ top: 10, right: 16, left: -10, bottom: 0 }}>
               <defs>
                 <linearGradient id="momentumGradient" x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="5%" stopColor="var(--vertical-specialized)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--vertical-specialized)" stopOpacity={0.05} />
+                  <stop offset="5%" stopColor="var(--vertical-specialized)" stopOpacity={0.7} />
+                  <stop offset="95%" stopColor="var(--vertical-specialized)" stopOpacity={0.08} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
               <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax: number) => dataMax * 1.15]} />
               <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Area type="monotone" dataKey="value" stroke="var(--vertical-specialized)" fill="url(#momentumGradient)" strokeWidth={3} />
+              <Area type="monotone" dataKey="value" stroke="var(--vertical-specialized)" strokeWidth={3} fill="url(#momentumGradient)" />
             </AreaChart>
           </ResponsiveContainer>
-        </ChartCard>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">Listings momentum</div>
+        </Card>
 
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Listings & inquiries">
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Spend vs budget"
+        >
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Listings & inquiries</h3>
-              <p className="text-xs text-slate-600">Key real estate pipeline with agent accountability.</p>
+              <h3 className="text-title-sm text-slate-900">Spend vs budget</h3>
+              <p className="text-xs text-slate-600">Finance automation keeps spend in range.</p>
             </div>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.realEstate.pipeline.map((item) => (
-              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <p className="text-sm font-semibold text-slate-900">{item.address}</p>
-                <p className="text-xs text-slate-500">Stage: {item.stage}</p>
-                <p className="text-xs text-slate-500">Inquiries: {item.inquiries}</p>
-                <p className="text-xs text-slate-500">Agent: {item.agent}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
-
-      <div className="col-span-12 xl:col-span-6 space-y-6">
-        <ChartCard
-          id="specialized-expenses"
-          title="Expense vs budget"
-          description="Finance automation keeps spend in check"
-          rows={expenseRows}
-          columns={[
-            { key: 'week', label: 'Week' },
-            { key: 'actual', label: 'Actual ($K)', align: 'right' },
-            { key: 'budget', label: 'Budget ($K)', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={220}>
-            <LineChart data={data.finance.expenses}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
+          <ResponsiveContainer height={150} className="mt-3">
+            <LineChart data={data.finance.expenses} margin={{ top: 10, right: 16, left: -10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.25)" />
               <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, (dataMax: number) => dataMax * 1.15]} />
               <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={false} name="Actual" />
-              <Line type="monotone" dataKey="secondary" stroke="#10b981" strokeWidth={3} dot={false} name="Budget" />
-              <Legend verticalAlign="bottom" height={36} />
+              <Line type="monotone" dataKey="value" stroke="var(--vertical-specialized)" strokeWidth={3} dot={{ r: 3 }} name="Actual" />
+              <Line type="monotone" dataKey="secondary" stroke="#10b981" strokeWidth={3} dot={{ r: 3 }} name="Budget" />
+              <Legend verticalAlign="bottom" height={32} />
             </LineChart>
           </ResponsiveContainer>
-        </ChartCard>
+        </Card>
 
-        <ChartCard
-          id="specialized-roi"
-          title="ROI breakdown"
-          description="Attribution-safe ROI mix"
-          rows={roiRows}
-          columns={[
-            { key: 'channel', label: 'Channel' },
-            { key: 'share', label: 'Share', align: 'right' },
-          ]}
+        <Card
+          className="col-span-8 flex h-[240px] flex-col border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Healthcare opportunities"
         >
-          <ResponsiveContainer height={220}>
-            <PieChart>
-              <Pie dataKey="value" data={data.finance.roiBreakdown} innerRadius={70} outerRadius={110} paddingAngle={2}>
-                {data.finance.roiBreakdown.map((segment) => (
-                  <Cell key={segment.id} fill={segment.color} stroke="#1f2937" strokeWidth={1.4} />
-                ))}
-              </Pie>
-              <Legend verticalAlign="bottom" height={50} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-            </PieChart>
-          </ResponsiveContainer>
-        </ChartCard>
-      </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Healthcare appointments">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-title-sm text-slate-900">Healthcare appointments</h3>
-              <p className="text-xs text-slate-600">Omni-channel reminders, smart rescheduling, PHI-safe.</p>
+              <h3 className="text-title-sm text-slate-900">Healthcare opportunities</h3>
+              <p className="text-xs text-slate-600">Multi-channel appointment readiness.</p>
             </div>
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Appointments table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
+          <div className="mt-3 flex-1 overflow-hidden rounded-[16px] border border-[var(--surface-border)]">
+            <table className="min-w-full text-sm text-slate-700">
+              <thead className="bg-white text-xs uppercase tracking-[0.08em] text-slate-500">
                 <tr>
-                  <th className="px-4 py-3 text-left">Patient</th>
-                  <th className="px-4 py-3 text-left">Clinician</th>
-                  <th className="px-4 py-3 text-left">Start</th>
-                  <th className="px-4 py-3 text-left">Channel</th>
-                  <th className="px-4 py-3 text-right">Status</th>
+                  <th className="px-3 py-2 text-left">Patient</th>
+                  <th className="px-3 py-2 text-left">Clinician</th>
+                  <th className="px-3 py-2 text-left">Start</th>
+                  <th className="px-3 py-2 text-left">Channel</th>
+                  <th className="px-3 py-2 text-right">Status</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm">
+              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)]">
                 {data.healthcare.appointments.map((appt) => (
-                  <tr key={appt.id}>
-                    <td className="px-4 py-[11px] text-slate-700">{appt.patient}</td>
-                    <td className="px-4 py-[11px] text-slate-700">{appt.clinician}</td>
-                    <td className="px-4 py-[11px] text-slate-700">{appt.start}</td>
-                    <td className="px-4 py-[11px] text-slate-700">{appt.channel}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-700">{appt.status}</td>
+                  <tr key={appt.id} className="hover:bg-[var(--primary-50)]/40">
+                    <td className="px-3 py-[11px] text-slate-700">{appt.patient}</td>
+                    <td className="px-3 py-[11px] text-slate-700">{appt.clinician}</td>
+                    <td className="px-3 py-[11px] text-slate-700">{appt.start}</td>
+                    <td className="px-3 py-[11px] text-slate-700">{appt.channel}</td>
+                    <td className="px-3 py-[11px] text-right text-slate-700">{appt.status}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
         </Card>
-      </div>
 
-      <div className="col-span-12 lg:col-span-6 space-y-6">
-        <AutomationList items={data.realEstate.automation} />
-        <AutomationList items={data.finance.automation} />
-        <AutomationList items={data.healthcare.automation} />
+        <Card
+          className="col-span-8 flex h-[240px] flex-col justify-between border border-[var(--surface-border)] bg-[var(--surface-s1)] shadow-none xl:col-span-4"
+          role="region"
+          aria-label="Industry signals"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-title-sm text-slate-900">Industry signals</h3>
+              <p className="text-xs text-slate-600">Cross-vertical strategic trends.</p>
+            </div>
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {data.industrySignals.map((signal) => (
+              <li key={signal.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-2.5">
+                <p className="font-semibold text-slate-900">{signal.title}</p>
+                <p className="text-xs text-slate-500">{signal.detail}</p>
+                <p className="text-[11px] uppercase tracking-[0.08em] text-slate-500">Confidence: {signal.confidence}</p>
+              </li>
+            ))}
+          </ul>
+        </Card>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -1461,7 +1668,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
   return (
     <div className="min-h-screen bg-[var(--surface-s0)] pb-16 text-slate-900">
       <header className="border-b border-[var(--surface-border)] bg-white/95 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-[1660px] flex-col gap-6 px-6 py-8">
+        <div className="mx-auto flex max-w-[1440px] flex-col gap-6 px-6 py-8">
           <div className="flex flex-wrap items-center justify-between gap-6">
             <div className="space-y-3">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Premium Multi-Category Dashboard</p>
@@ -1469,7 +1676,7 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
               <p className="max-w-3xl text-sm text-slate-600">{data.hero.description}</p>
               <button
                 type="button"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-full px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all duration-300 hover:-translate-y-0.5 focus-visible:focus-ring"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-full px-6 py-2 text-sm font-semibold text-white shadow-md shadow-slate-900/10 transition-all duration-300 hover:-translate-y-0.5 focus-visible:focus-ring"
                 style={{ backgroundImage: 'var(--brand-gradient)' }}
                 onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
               >
@@ -1547,8 +1754,8 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
         </div>
       </header>
 
-      <main className="mx-auto max-w-[1660px] space-y-6 px-6 py-10">
-        <div className="mb-4">
+      <main className="mx-auto max-w-[1660px] space-y-6 px-6 pb-10 pt-4">
+        <div>
           <KPIBand metrics={moduleMetrics} accentToken={accent} />
         </div>
         <div className="rounded-[24px] border border-dashed border-[var(--surface-border)] bg-[var(--surface-s1)] px-6 py-4 text-xs text-slate-500">

--- a/portfolio-dashboard/frontend/src/app/dashboard/data.ts
+++ b/portfolio-dashboard/frontend/src/app/dashboard/data.ts
@@ -94,6 +94,17 @@ export type CommerceSection = {
     description: string;
     status: 'healthy' | 'attention' | 'delayed';
   }>;
+  monthlyBreakdown: Array<{
+    month: string;
+    net: number;
+  }>;
+  inventoryAlerts: Array<{
+    id: string;
+    title: string;
+    type: 'returns' | 'low-stock';
+    impact: string;
+    status: 'urgent' | 'monitor' | 'healthy';
+  }>;
 };
 
 export type CorporateSection = {
@@ -106,6 +117,20 @@ export type CorporateSection = {
     delta: number;
   }>;
   leadSources: PieSegment[];
+  conversionCampaigns: ChartPoint[];
+  channelPerformance: Array<{
+    id: string;
+    channel: string;
+    spend: string;
+    pipeline: string;
+    roi: string;
+  }>;
+  segmentImpact: Array<{
+    id: string;
+    segment: string;
+    influence: string;
+    winRate: string;
+  }>;
   automation: AutomationWorkflow[];
   insights: Array<{
     id: string;
@@ -131,6 +156,21 @@ export type CustomAppSection = {
   workloadDistribution: ChartPoint[];
   automation: AutomationWorkflow[];
   backlogIdeas: string[];
+  usageTracking: ChartPoint[];
+  quickstartAutomations: Array<{
+    id: string;
+    name: string;
+    adoption: number;
+    impact: string;
+    category: string;
+  }>;
+  opsBacklog: Array<{
+    id: string;
+    request: string;
+    owner: string;
+    status: 'queued' | 'in-progress' | 'blocked';
+    eta: string;
+  }>;
 };
 
 export type ContentSection = {
@@ -151,6 +191,13 @@ export type ContentSection = {
     topic: string;
     editor: string;
     status: 'ready' | 'in-review' | 'blocked';
+  }>;
+  highlights: Array<{
+    id: string;
+    title: string;
+    owner: string;
+    status: 'approved' | 'needs-review' | 'in-progress';
+    timestamp: string;
   }>;
 };
 
@@ -178,6 +225,17 @@ export type EdTechSection = {
     message: string;
     severity: 'info' | 'warning' | 'critical';
   }>;
+  successSummary: {
+    uplift: string;
+    delta: number;
+    narrative: string;
+    breakdown: Array<{
+      id: string;
+      label: string;
+      value: string;
+      trend: MetricTrend;
+    }>;
+  };
 };
 
 export type SpecializedSection = {
@@ -211,6 +269,12 @@ export type SpecializedSection = {
     }>;
     automation: AutomationWorkflow[];
   };
+  industrySignals: Array<{
+    id: string;
+    title: string;
+    detail: string;
+    confidence: string;
+  }>;
 };
 
 export type PortfolioDashboardResponse = {
@@ -508,6 +572,15 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         inventory: 520,
         trend: 'up',
       },
+      {
+        id: 'prod-5',
+        name: 'Everyday Commuter Backpack',
+        category: 'Gear',
+        revenue: '$244K',
+        conversionRate: '6.9%',
+        inventory: 358,
+        trend: 'up',
+      },
     ],
     salesTrend: [
       { label: 'Mar', value: 210 },
@@ -573,6 +646,38 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         status: 'attention',
       },
     ],
+    monthlyBreakdown: [
+      { month: 'Jun', net: 1.92 },
+      { month: 'Jul', net: 2.04 },
+      { month: 'Aug', net: 2.21 },
+      { month: 'Sep', net: 2.38 },
+      { month: 'Oct', net: 2.57 },
+      { month: 'Nov', net: 2.88 },
+      { month: 'Dec', net: 3.14 },
+    ],
+    inventoryAlerts: [
+      {
+        id: 'alert-1',
+        title: 'Return spike – Smart Hydration Bottle',
+        type: 'returns',
+        impact: '2.8% ↑ vs goal',
+        status: 'monitor',
+      },
+      {
+        id: 'alert-2',
+        title: 'Low stock – Studio Performance Set',
+        type: 'low-stock',
+        impact: '14 days of cover left',
+        status: 'urgent',
+      },
+      {
+        id: 'alert-3',
+        title: 'Low stock – Minimalist Trainer',
+        type: 'low-stock',
+        impact: 'Next shipment ETA 4 days',
+        status: 'monitor',
+      },
+    ],
   },
   corporate: {
     metrics: [
@@ -622,6 +727,28 @@ const portfolioDashboard: PortfolioDashboardResponse = {
       { id: 'events', label: 'Events & webinars', value: 18, color: '#06b6d4' },
       { id: 'partners', label: 'Partner referrals', value: 14, color: '#f97316' },
       { id: 'direct', label: 'Direct & outbound', value: 9, color: '#10b981' },
+    ],
+    conversionCampaigns: [
+      { label: 'Jul', value: 2.1, secondary: 1.4 },
+      { label: 'Aug', value: 2.4, secondary: 1.6 },
+      { label: 'Sep', value: 2.8, secondary: 1.9 },
+      { label: 'Oct', value: 3.1, secondary: 2.2 },
+      { label: 'Nov', value: 3.4, secondary: 2.5 },
+      { label: 'Dec', value: 3.9, secondary: 2.9 },
+    ],
+    channelPerformance: [
+      { id: 'channel-1', channel: 'Paid search', spend: '$184K', pipeline: '$2.6M', roi: '6.2x' },
+      { id: 'channel-2', channel: 'Paid social', spend: '$136K', pipeline: '$1.9M', roi: '5.1x' },
+      { id: 'channel-3', channel: 'Field events', spend: '$92K', pipeline: '$1.4M', roi: '4.7x' },
+      { id: 'channel-4', channel: 'Partner co-marketing', spend: '$54K', pipeline: '$1.1M', roi: '7.8x' },
+      { id: 'channel-5', channel: 'Outbound SDR', spend: '$76K', pipeline: '$980K', roi: '4.2x' },
+    ],
+    segmentImpact: [
+      { id: 'seg-1', segment: 'Enterprise', influence: '$5.8M', winRate: '32%' },
+      { id: 'seg-2', segment: 'Upper mid-market', influence: '$3.2M', winRate: '28%' },
+      { id: 'seg-3', segment: 'Mid-market', influence: '$2.1M', winRate: '24%' },
+      { id: 'seg-4', segment: 'SMB', influence: '$1.1M', winRate: '19%' },
+      { id: 'seg-5', segment: 'Public sector', influence: '$780K', winRate: '22%' },
     ],
     automation: [
       {
@@ -803,6 +930,27 @@ const portfolioDashboard: PortfolioDashboardResponse = {
       'Revenue workspace with finance system sync',
       'Customer health scoring scenario planner',
     ],
+    usageTracking: [
+      { label: 'Jul', value: 54, secondary: 42 },
+      { label: 'Aug', value: 62, secondary: 48 },
+      { label: 'Sep', value: 68, secondary: 51 },
+      { label: 'Oct', value: 74, secondary: 57 },
+      { label: 'Nov', value: 81, secondary: 63 },
+      { label: 'Dec', value: 88, secondary: 69 },
+    ],
+    quickstartAutomations: [
+      { id: 'qa-1', name: 'Schedule stand-up summary', adoption: 86, impact: '+12% throughput', category: 'Engineering' },
+      { id: 'qa-2', name: 'Auto-provision workspaces', adoption: 74, impact: '-18% setup time', category: 'IT Ops' },
+      { id: 'qa-3', name: 'Feedback triage labels', adoption: 69, impact: '+9 pt CSAT', category: 'Product' },
+      { id: 'qa-4', name: 'Exec digest compiler', adoption: 63, impact: '4 hrs saved/wk', category: 'Leadership' },
+    ],
+    opsBacklog: [
+      { id: 'ops-1', request: 'Contract renewal workflow', owner: 'RevOps', status: 'queued', eta: 'Jan 12' },
+      { id: 'ops-2', request: 'Usage-to-billing sync', owner: 'Finance', status: 'in-progress', eta: 'Dec 22' },
+      { id: 'ops-3', request: 'CS escalation routing', owner: 'Support Ops', status: 'queued', eta: 'Jan 5' },
+      { id: 'ops-4', request: 'Data residency selector', owner: 'Security', status: 'blocked', eta: 'TBD' },
+      { id: 'ops-5', request: 'Role audit trail', owner: 'Compliance', status: 'in-progress', eta: 'Jan 18' },
+    ],
   },
   content: {
     metrics: [
@@ -945,6 +1093,36 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         status: 'blocked',
       },
     ],
+    highlights: [
+      {
+        id: 'highlight-1',
+        title: 'Executive newsletter approved for syndication',
+        owner: 'Editorial board',
+        status: 'approved',
+        timestamp: 'Updated 14m ago',
+      },
+      {
+        id: 'highlight-2',
+        title: 'Legal review pending on brand partnership script',
+        owner: 'Legal ops',
+        status: 'needs-review',
+        timestamp: 'Due in 2h',
+      },
+      {
+        id: 'highlight-3',
+        title: 'Community Q&A highlight reel stitching',
+        owner: 'Video lab',
+        status: 'in-progress',
+        timestamp: 'ETA today 5:30 PM',
+      },
+      {
+        id: 'highlight-4',
+        title: 'Spotlight series guest confirmed (Week 49)',
+        owner: 'Guest booking',
+        status: 'approved',
+        timestamp: 'Logged 32m ago',
+      },
+    ],
   },
   edtech: {
     metrics: [
@@ -1009,6 +1187,13 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         enrollment: 4873,
         completion: '71%',
         avgScore: '79%',
+      },
+      {
+        id: 'course-5',
+        title: 'Revenue Operations Foundations',
+        enrollment: 3628,
+        completion: '74%',
+        avgScore: '83%',
       },
     ],
     activityHeatmap: {
@@ -1101,6 +1286,16 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         severity: 'info',
       },
     ],
+    successSummary: {
+      uplift: '+6.4 pt graduation uplift',
+      delta: 6.4,
+      narrative: 'Personalized pacing plans and mentor rotations increased graduation odds across priority cohorts.',
+      breakdown: [
+        { id: 'ss-1', label: 'At-risk cohort uplift', value: '+9.1 pts', trend: 'up' },
+        { id: 'ss-2', label: 'Mentor satisfaction', value: '94%', trend: 'up' },
+        { id: 'ss-3', label: 'Scholarship retention', value: '87%', trend: 'steady' },
+      ],
+    },
   },
   specialized: {
     realEstate: {
@@ -1301,6 +1496,22 @@ const portfolioDashboard: PortfolioDashboardResponse = {
           channel: 'Virtual',
           status: 'Confirmed',
         },
+        {
+          id: 'appt-4',
+          patient: 'Noah Bennett',
+          clinician: 'Dr. Camille Hart',
+          start: 'Dec 10 • 16:20',
+          channel: 'In-person',
+          status: 'Confirmed',
+        },
+        {
+          id: 'appt-5',
+          patient: 'Emi Nakamura',
+          clinician: 'Dr. Luis Romero',
+          start: 'Dec 11 • 10:05',
+          channel: 'Virtual',
+          status: 'Awaiting Intake',
+        },
       ],
       automation: [
         {
@@ -1325,6 +1536,32 @@ const portfolioDashboard: PortfolioDashboardResponse = {
         },
       ],
     },
+    industrySignals: [
+      {
+        id: 'signal-1',
+        title: 'Fintech compliance automation demand spiking',
+        detail: 'Inbound RFPs up 18% month-over-month across regulated fintech segments.',
+        confidence: 'High',
+      },
+      {
+        id: 'signal-2',
+        title: 'Hybrid care clinics expanding asynchronous consults',
+        detail: 'Clinics piloting AI triage tools report 2.6x faster routing.',
+        confidence: 'Medium',
+      },
+      {
+        id: 'signal-3',
+        title: 'Proptech marketplaces consolidating data feeds',
+        detail: 'MLS API consolidation driving demand for workflow standardization.',
+        confidence: 'Medium',
+      },
+      {
+        id: 'signal-4',
+        title: 'Sustainability reporting mandates accelerating',
+        detail: 'EU CSRD readiness programs triggering automation backlogs for suppliers.',
+        confidence: 'High',
+      },
+    ],
   },
 };
 

--- a/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/StickyFilterBar.tsx
@@ -117,9 +117,9 @@ export function StickyFilterBar() {
   }, [filters]);
 
   return (
-    <div className="sticky top-0 z-10 -mx-6 border-b border-[var(--surface-border)] bg-[var(--surface-s2)]/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-[var(--surface-s2)]">
-      <div className="flex items-center justify-between gap-4 overflow-hidden">
-        <div className="flex flex-1 items-center gap-4 overflow-x-auto pb-1 pt-1 [scrollbar-width:none] sm:[scrollbar-width:auto]">
+    <div className="sticky top-0 z-10 border-b border-[var(--surface-border)] bg-[var(--surface-s2)]/95 backdrop-blur supports-[backdrop-filter]:bg-[var(--surface-s2)]">
+      <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4 px-6 py-3">
+        <div className="flex flex-1 items-center gap-4 overflow-x-auto [scrollbar-width:none] sm:[scrollbar-width:auto]">
           {/* Date range (global) */}
           <Group label="Date Range">
             <Select


### PR DESCRIPTION
## Summary
- rebuild the commerce, corporate, custom app, content, edtech, and specialized dashboards to follow the new 8-column grid with 240px cards, refreshed charts, and tidy tables
- extend mocked data to cover new conversion campaigns, channel performance, backlog, highlights, and alert datasets powering the refreshed layouts
- tighten the header and sticky filter bar to the 1440px container and cleaned spacing to meet the updated brief

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d60d6ad070832ea86282c152c26319