### PR TITLE
Add automated PRD gate generation and validation

### DIFF
--- a/docs/LOCAL_DEV_WORKFLOW.md
+++ b/docs/LOCAL_DEV_WORKFLOW.md
@@ -84,7 +84,26 @@ python scripts/validate_tasks.py --input "${PROJECT_DIR}/PLAN.tasks.json"
 
 Ensures unique IDs, valid dependency edges, and enum integrity before generation.
 
-### 4. Preflight stack selection
+### 4. Generate PRD & architecture summary
+
+```bash
+python scripts/generate_prd_assets.py \
+  --name "$NAME" \
+  --plan "${PROJECT_DIR}/PLAN.md" \
+  --tasks "${PROJECT_DIR}/PLAN.tasks.json" \
+  --output-dir "$PROJECT_DIR" \
+  --frontend "$FE" --backend "$BE" --database "$DB" \
+  --auth "${AUTH:-}" --deploy "${DEPLOY:-}" \
+  --industry "$INDUSTRY" --project-type "$PROJECT_TYPE"
+
+python scripts/validate_prd_gate.py \
+  --prd "${PROJECT_DIR}/PRD.md" \
+  --architecture "${PROJECT_DIR}/ARCHITECTURE.md"
+```
+
+This step applies the `dev-workflow/1-create-prd.md` protocol automatically, producing `PRD.md` and `ARCHITECTURE.md` under the project directory. The validator halts the lifecycle if either file is missing, if required sections are absent, or if the front matter omits the sign-off metadata shown in [Workflow Overview](WORKFLOW_OVERVIEW.md#prd--architecture-gate-automation).
+
+### 5. Preflight stack selection
 
 ```bash
 python scripts/select_stacks.py \
@@ -99,7 +118,7 @@ python scripts/select_stacks.py \
 
 Add `--compliance "$COMPLIANCE"` or `--nestjs-orm "$NESTJS_ORM"` when required. Exit code `3` indicates unmet engine version requirements.
 
-### 5. Dry-run generation (no writes)
+### 6. Dry-run generation (no writes)
 
 ```bash
 ./scripts/generate_client_project.py \
@@ -111,7 +130,7 @@ Add `--compliance "$COMPLIANCE"` or `--nestjs-orm "$NESTJS_ORM"` when required. 
 
 Review the printed tree to confirm the scaffold layout.
 
-### 6. Generate the project
+### 7. Generate the project
 
 ```bash
 ./scripts/generate_client_project.py \
@@ -123,7 +142,7 @@ Review the printed tree to confirm the scaffold layout.
 
 All files are written beneath `${OUTPUT_ROOT}/${NAME}`.
 
-### 7. Install dependencies & run tests
+### 8. Install dependencies & run tests
 
 ```bash
 PROJECT_ROOT="$PROJECT_DIR" ./scripts/install_and_test.sh
@@ -131,7 +150,7 @@ PROJECT_ROOT="$PROJECT_DIR" ./scripts/install_and_test.sh
 
 The helper script detects which stacks were generated and executes language-appropriate installs and tests, writing logs and artifacts inside `${PROJECT_ROOT}`.
 
-### 8. Sync tasks and revalidate
+### 9. Sync tasks and revalidate
 
 ```bash
 python scripts/sync_from_scaffold.py --input "${PROJECT_DIR}/PLAN.tasks.json" --root "$PROJECT_DIR"
@@ -141,7 +160,7 @@ python scripts/validate_tasks.py --input "${PROJECT_DIR}/tasks.json"
 
 Keeps the tasks DAG aligned with generated assets.
 
-### 9. Collect metrics and enforce gates
+### 10. Collect metrics and enforce gates
 
 ```bash
 PROJECT_ROOT="$PROJECT_DIR" python scripts/collect_coverage.py || true
@@ -152,7 +171,7 @@ PROJECT_ROOT="$PROJECT_DIR" python scripts/enforce_gates.py
 
 Gate thresholds are defined in [`gates_config.yaml`](../gates_config.yaml).
 
-### 10. Build the submission pack
+### 11. Build the submission pack
 
 ```bash
 PROJECT_ROOT="$PROJECT_DIR" NAME="$NAME" ./scripts/build_submission_pack.sh
@@ -160,7 +179,7 @@ PROJECT_ROOT="$PROJECT_DIR" NAME="$NAME" ./scripts/build_submission_pack.sh
 
 Bundles evidence, metrics, and manifests under `${PROJECT_ROOT}/dist/` for hand-off.
 
-### 11. Validate compliance assets
+### 12. Validate compliance assets
 
 ```bash
 python scripts/validate_compliance_assets.py | tee "${PROJECT_DIR}/evidence/validate_compliance_assets.log"

--- a/docs/WORKFLOW_OVERVIEW.md
+++ b/docs/WORKFLOW_OVERVIEW.md
@@ -10,6 +10,22 @@ Understanding → Planning        Draft PRD & architecture (dev-workflow)    PRD
                                 Define DB/API/UI, estimates                Wireframes/mockups
                                                                             Sign-off: PRD + Architecture OK
 
+### PRD + Architecture Gate Automation
+
+- **Generator:** `scripts/generate_prd_assets.py` consumes `PLAN.md` / `PLAN.tasks.json` and writes `PRD.md` and `ARCHITECTURE.md` inside the active project directory.
+- **Validator:** `scripts/validate_prd_gate.py` halts the lifecycle when either file is missing, required sections are absent, or the sign-off metadata is incomplete.
+- **Required front matter:**
+
+  ```yaml
+  ---
+  signoff_stage: PRD + Architecture OK
+  signoff_approver: <approver name or automation id>
+  signoff_timestamp: 2024-01-01T00:00:00Z
+  ---
+  ```
+
+  The approver must be populated (no `TBD`/`pending` placeholders) and the timestamp must be ISO-8601.
+
 Planning → Generation           Dry-run scaffold                           Structure preview
                                 Generate repo(s)                           Generated project(s)
                                 CI/CD, docs, rules emitted                 Sign-off: Scaffold OK

--- a/scripts/e2e_from_brief.sh
+++ b/scripts/e2e_from_brief.sh
@@ -141,6 +141,25 @@ echo "[E2E] Plan from brief"
 echo "[E2E] Validate tasks graph"
 "$PY_BIN" scripts/validate_tasks.py --input "$PLAN_TASKS_PATH"
 
+echo "[E2E] Generate PRD & architecture"
+"$PY_BIN" scripts/generate_prd_assets.py \
+  --name "$NAME" \
+  --plan "$PLAN_PATH" \
+  --tasks "$PLAN_TASKS_PATH" \
+  --output-dir "$PROJECT_DIR" \
+  --frontend "$FE" \
+  --backend "$BE" \
+  --database "$DB" \
+  --auth "${AUTH:-}" \
+  --deploy "${DEPLOY:-}" \
+  --industry "${INDUSTRY:-}" \
+  --project-type "${PROJECT_TYPE:-}"
+
+echo "[E2E] Validate PRD gate"
+"$PY_BIN" scripts/validate_prd_gate.py \
+  --prd "$PROJECT_DIR/PRD.md" \
+  --architecture "$PROJECT_DIR/ARCHITECTURE.md"
+
 echo "[E2E] Preflight selection gate"
 selection_cmd=(
   "$PY_BIN" scripts/select_stacks.py

--- a/scripts/generate_prd_assets.py
+++ b/scripts/generate_prd_assets.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Generate PRD and architecture summaries from planning artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from textwrap import dedent
+
+PROTOCOL_PATH = Path("dev-workflow/1-create-prd.md")
+
+def iso_utc_now() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=False).isoformat().replace("+00:00", "Z")
+
+
+def read_plan_summary(path: Path) -> str:
+    if not path.exists():
+        return "Plan summary unavailable; see planning logs."
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return stripped
+    return "Plan summary unavailable; see planning logs."
+
+
+def load_tasks(path: Path) -> dict[str, list[dict]]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return {k: v for k, v in data.items() if isinstance(v, list)}
+    return {}
+
+
+def extract_template_sections(protocol_path: Path) -> dict[str, str]:
+    text = protocol_path.read_text(encoding="utf-8", errors="ignore") if protocol_path.exists() else ""
+    marker = "```markdown"
+    start = text.find(marker)
+    end = text.find("```", start + len(marker)) if start != -1 else -1
+    if start == -1 or end == -1:
+        return {}
+    block = text[start + len(marker):end]
+    return {"template": dedent(block).strip()}
+
+
+def build_task_section(tasks: dict[str, list[dict]]) -> str:
+    if not tasks:
+        return "- Derived from PLAN.tasks.json (no structured task data available)."
+    lines: list[str] = []
+    for area, items in sorted(tasks.items()):
+        lines.append(f"- **{area.title()} Focus:**")
+        if not items:
+            lines.append("  - No tasks captured for this area yet.")
+            continue
+        for item in items[:5]:
+            title = item.get("title") or item.get("summary") or "Unnamed task"
+            ident = item.get("id") or "?"
+            estimate = item.get("estimate")
+            suffix = f" (estimate: {estimate})" if estimate else ""
+            lines.append(f"  - [{ident}] {title}{suffix}")
+        if len(items) > 5:
+            lines.append(f"  - … {len(items) - 5} additional tasks omitted for brevity.")
+    return "\n".join(lines)
+
+
+def render_prd(args: argparse.Namespace, plan_summary: str, task_section: str) -> str:
+    template_section = extract_template_sections(PROTOCOL_PATH).get("template")
+    if not template_section:
+        template_section = dedent(
+            """
+            # PRD: [Feature Name]
+
+            ## 1. Overview
+            - **Business Goal:** [Description of the need and problem solved]
+            - **Detected Architecture:**
+              - **Primary Component:** `[Frontend App | Backend Service | ...]`
+
+            ## 2. Functional Specifications
+            - **User Stories:** [For UI] or **API Contract:** [For Services]
+
+            ## 3. Technical Specifications
+            - **Inter-Service Communication:** [Details of API calls]
+            - **Security & Authentication:** [Security model]
+
+            ## 4. Out of Scope
+            - [What this feature will NOT do]
+            """
+        ).strip()
+
+    frontend = args.frontend or "TBD"
+    backend = args.backend or "TBD"
+    database = args.database or "TBD"
+    auth = args.auth or "Role-based access as defined in compliance matrix"
+
+    replacements = {
+        "[Feature Name]": args.name,
+        "[Description of the need and problem solved]": plan_summary,
+        "`[Frontend App | Backend Service | ...]`": f"Frontend ({frontend}) + Backend ({backend}) + Database ({database})",
+        "[For UI] or **API Contract:** [For Services]": "User stories derived from the validated task graph:",
+        "[Details of API calls]": f"{backend} services expose REST endpoints consumed by the {frontend} frontend.",
+        "[Security model]": auth,
+        "[What this feature will NOT do]": "See PLAN.md for items explicitly deferred beyond the initial scaffold.",
+    }
+
+    body = template_section
+    for needle, replacement in replacements.items():
+        body = body.replace(needle, replacement)
+
+    nested_tasks = "\n".join(f"  {line}" for line in task_section.splitlines())
+    body = body.replace(
+        "User stories derived from the validated task graph:",
+        f"User stories derived from the validated task graph:\n{nested_tasks}",
+    )
+
+    signoff_block = dedent(
+        f"""
+        ---
+        signoff_stage: PRD + Architecture OK
+        signoff_approver: lifecycle-automation
+        signoff_timestamp: {iso_utc_now()}
+        ---
+        """
+    ).strip()
+
+    industry_line = f"- **Industry Alignment:** {args.industry}" if args.industry else "- **Industry Alignment:** Unspecified"
+    project_type_line = f"- **Project Type:** {args.project_type}" if args.project_type else "- **Project Type:** Unspecified"
+
+    overview_block = f"- **Business Goal:** {plan_summary}\n{industry_line}\n{project_type_line}"
+    body = body.replace(f"- **Business Goal:** {plan_summary}", overview_block)
+
+    return f"{signoff_block}\n\n{body.strip()}\n"
+
+
+def render_architecture(args: argparse.Namespace, task_section: str) -> str:
+    frontend = args.frontend or "TBD"
+    backend = args.backend or "TBD"
+    database = args.database or "TBD"
+    auth = args.auth or "TBD"
+    deploy = args.deploy or "TBD"
+
+    mermaid = dedent(
+        f"""
+        ```mermaid
+        flowchart LR
+          UI[{frontend}] --> API[{backend}]
+          API --> DB[({database})]
+        ```
+        """
+    ).strip()
+
+    lines = dedent(
+        f"""
+        # Architecture Summary: {args.name}
+
+        ## Primary Components
+        - Frontend: {frontend}
+        - Backend: {backend}
+        - Database: {database}
+        - Authentication: {auth}
+        - Deployment Target: {deploy}
+
+        ## Integration Flows
+        - {frontend} consumes RESTful APIs exposed by {backend}.
+        - {backend} persists canonical data to {database}.
+        - Authentication is handled via {auth} to enforce least-privilege access.
+
+        ## Supporting Tasks
+        {task_section}
+
+        ## System Diagram
+        {mermaid}
+        """
+    ).strip()
+    if args.industry:
+        lines += f"\n\n## Compliance & Domain Notes\n- Architecture tuned for {args.industry} requirements."
+    return lines + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate PRD and architecture assets from planning artifacts.")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--tasks", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--frontend")
+    parser.add_argument("--backend")
+    parser.add_argument("--database")
+    parser.add_argument("--auth")
+    parser.add_argument("--deploy")
+    parser.add_argument("--industry")
+    parser.add_argument("--project-type")
+    args = parser.parse_args()
+
+    plan_summary = read_plan_summary(Path(args.plan))
+    tasks = load_tasks(Path(args.tasks))
+    task_section = build_task_section(tasks)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prd_content = render_prd(args, plan_summary, task_section)
+    (output_dir / "PRD.md").write_text(prd_content, encoding="utf-8")
+
+    architecture_content = render_architecture(args, task_section)
+    (output_dir / "ARCHITECTURE.md").write_text(architecture_content, encoding="utf-8")
+
+    evidence_dir = output_dir / "evidence"
+    evidence_dir.mkdir(exist_ok=True)
+    (evidence_dir / "prd_generation.json").write_text(
+        json.dumps(
+            {
+                "protocol": str(PROTOCOL_PATH),
+                "plan": args.plan,
+                "tasks": args.tasks,
+                "generated_at": iso_utc_now(),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_prd_gate.py
+++ b/scripts/validate_prd_gate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate PRD gate artifacts before proceeding with generation."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+import sys
+
+REQUIRED_SECTIONS = [
+    "## 1. Overview",
+    "## 2. Functional Specifications",
+    "## 3. Technical Specifications",
+    "## 4. Out of Scope",
+]
+
+
+class ValidationError(Exception):
+    pass
+
+
+def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---"):
+        raise ValidationError("PRD is missing required YAML front matter for sign-off metadata.")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise ValidationError("Front matter terminator not found (expected closing ---).")
+    block = text[3:end].strip().splitlines()
+    metadata: dict[str, str] = {}
+    for raw in block:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    body = text[end + len("\n---"):]
+    return metadata, body
+
+
+def validate_timestamp(value: str) -> None:
+    candidate = value.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ValidationError(f"Invalid ISO-8601 timestamp for sign-off: {value}") from exc
+
+
+def validate_metadata(metadata: dict[str, str], stage: str) -> None:
+    if metadata.get("signoff_stage") != stage:
+        raise ValidationError(f"Expected signoff_stage '{stage}', found '{metadata.get('signoff_stage')}'.")
+    approver = metadata.get("signoff_approver", "")
+    if not approver or approver.strip().lower() in {"", "tbd", "todo", "pending"}:
+        raise ValidationError("signoff_approver must be populated with the approving agent or user.")
+    timestamp = metadata.get("signoff_timestamp")
+    if not timestamp:
+        raise ValidationError("signoff_timestamp is required in the PRD front matter.")
+    validate_timestamp(timestamp)
+
+
+def validate_sections(body: str) -> None:
+    for section in REQUIRED_SECTIONS:
+        if section not in body:
+            raise ValidationError(f"PRD is missing required section: {section}")
+
+
+def validate_architecture(path: Path) -> None:
+    if not path.exists():
+        raise ValidationError(f"Architecture summary missing: {path}")
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    required_snippets = ["# Architecture Summary", "## Primary Components", "## Integration Flows"]
+    for snippet in required_snippets:
+        if snippet not in text:
+            raise ValidationError(f"Architecture summary missing required content: {snippet}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate PRD sign-off metadata and supporting architecture notes.")
+    parser.add_argument("--prd", required=True)
+    parser.add_argument("--architecture")
+    parser.add_argument("--required-stage", default="PRD + Architecture OK")
+    args = parser.parse_args()
+
+    prd_path = Path(args.prd)
+    if not prd_path.exists():
+        raise SystemExit("PRD.md not found; run PRD generation before continuing.")
+    text = prd_path.read_text(encoding="utf-8", errors="ignore")
+
+    metadata, body = parse_front_matter(text)
+    validate_metadata(metadata, args.required_stage)
+    validate_sections(body)
+
+    if args.architecture:
+        validate_architecture(Path(args.architecture))
+
+    print("PRD gate validation passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ValidationError as exc:
+        print(f"[PRD Gate] {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- generate PRD.md and ARCHITECTURE.md from planning artifacts during the lifecycle run and enforce their presence before stack selection
- add a validator that halts the pipeline when the PRD sign-off metadata or required sections are missing
- document the new PRD gate sequencing and metadata requirements across the workflow guides

## Testing
- python -m compileall scripts/generate_prd_assets.py scripts/validate_prd_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68d7bca0d6f4832e8464c923fb4609ae

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generate `PRD.md` and `ARCHITECTURE.md` from planning artifacts and enforce a PRD sign-off gate before stack selection; update docs and E2E to integrate the new step.
> 
> - **Automation**:
>   - Add `scripts/generate_prd_assets.py` to produce `PRD.md` and `ARCHITECTURE.md` from `PLAN.md`/`PLAN.tasks.json`, including sign-off front matter and evidence JSON.
>   - Add `scripts/validate_prd_gate.py` to enforce PRD sign-off metadata, required sections, and presence/structure of architecture notes.
> - **Workflow Integration**:
>   - Update `docs/LOCAL_DEV_WORKFLOW.md` to insert a new step for PRD/architecture generation and renumber subsequent steps.
>   - Update `docs/WORKFLOW_OVERVIEW.md` with a "PRD + Architecture Gate Automation" section detailing generator, validator, and required front matter.
> - **Pipeline**:
>   - Modify `scripts/e2e_from_brief.sh` to run PRD/architecture generation and gate validation after task validation and before stack selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4984a521492640e93ebf89e47267bffd845540e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->