### PR TITLE
Raise gate thresholds and require real perf measurements

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@
   ```
 
 ### Full Suite & Coverage
-- `make test` runs the frontend and backend suites with coverage, enforces the 70% line
+- `make test` runs the frontend and backend suites with coverage, enforces the 80% line
   threshold defined in `gates_config.yaml`, and aggregates results into
   `coverage/coverage-summary.json` for the quality gate pipeline.
 - Individual reports are left in `frontend/coverage/coverage-summary.json` and

--- a/docs/LOCAL_DEV_WORKFLOW.md
+++ b/docs/LOCAL_DEV_WORKFLOW.md
@@ -164,12 +164,18 @@ Keeps the tasks DAG aligned with generated assets.
 
 ```bash
 PROJECT_ROOT="$PROJECT_DIR" python scripts/collect_coverage.py || true
-PROJECT_ROOT="$PROJECT_DIR" python scripts/collect_perf.py || true
+PROJECT_ROOT="$PROJECT_DIR" python scripts/collect_perf.py
 PROJECT_ROOT="$PROJECT_DIR" python scripts/scan_deps.py || true
 PROJECT_ROOT="$PROJECT_DIR" python scripts/enforce_gates.py
 ```
 
-Gate thresholds are defined in [`gates_config.yaml`](../gates_config.yaml).
+Gate thresholds are defined in [`gates_config.yaml`](../gates_config.yaml) and
+now require **≥80 % line coverage** plus **zero critical/high dependency
+vulnerabilities**. `collect_perf.py` exits non-zero when it cannot read a real
+P95 latency value from `PERF_P95_MS` or `metrics/input_perf.txt`, preventing the
+gate from running without documented performance evidence. The generated
+`metrics/perf.json` must therefore contain a positive finite value before the
+pipeline proceeds.
 
 ### 11. Build the submission pack
 

--- a/docs/UTILITY_SCRIPTS.md
+++ b/docs/UTILITY_SCRIPTS.md
@@ -310,36 +310,27 @@ python scripts/collect_coverage.py --format xml --output-file coverage.xml
 
 ### collect_perf.py
 
-Collects performance metrics.
+Collects performance metrics and refuses to emit placeholder data.
 
 #### Purpose
-- Runs performance tests
-- Collects performance metrics
-- Generates performance reports
+- Fails the run unless a real performance measurement is supplied.
+- Normalizes the input and writes `metrics/perf.json` for the gates pipeline.
+- Provides a consistent hand-off for CI/CD evidence bundles.
 
 #### Usage
 ```bash
-python scripts/collect_perf.py [options]
-```
+# Provide the latency explicitly
+PERF_P95_MS=420 python scripts/collect_perf.py
 
-#### Options
-- `--test-file` - Performance test file (default: `tests/performance.py`)
-- `--output-file` - Performance report output file
-- `--format` - Report format: json, csv, html (default: json)
-- `--iterations` - Number of test iterations (default: 10)
-- `--warmup` - Warmup iterations (default: 3)
-
-#### Example
-```bash
-# Collect performance metrics
+# Or drop a measurement in metrics/input_perf.txt first
+echo 420 > metrics/input_perf.txt
 python scripts/collect_perf.py
-
-# Collect with custom iterations
-python scripts/collect_perf.py --iterations 20 --warmup 5
-
-# Generate CSV report
-python scripts/collect_perf.py --format csv --output-file perf-report.csv
 ```
+
+The script validates that the captured latency is a positive, finite number and
+exits with status `1` when the input is missing or malformed. Downstream gates
+will also fail if `metrics/perf.json` contains a non-positive value, so ensure
+your load/perf tooling populates one of the inputs before enforcing thresholds.
 
 ## Usage Examples
 

--- a/gates_config.yaml
+++ b/gates_config.yaml
@@ -9,8 +9,8 @@ quality_gates:
     threshold: 0
   security_scan:
     critical_threshold: 0
-    high_threshold: 5
+    high_threshold: 0
     required: true
   test_coverage:
     required: true
-    threshold: 70
+    threshold: 80

--- a/scripts/collect_perf.py
+++ b/scripts/collect_perf.py
@@ -1,36 +1,80 @@
 #!/usr/bin/env python3
 """
 Write metrics/perf.json with an http_p95_ms value.
-- For simplicity, reads from env PERF_P95_MS or from metrics/input_perf.txt (ms)
-- In real setups, integrate k6/Locust and write this file from their outputs.
 
-Usage:
+Usage examples:
   PERF_P95_MS=420 python scripts/collect_perf.py
+  # or
+  echo 420 > metrics/input_perf.txt && python scripts/collect_perf.py
+
+The script now fails fast when no valid measurement is supplied so CI cannot
+advance without real performance evidence.
 """
+
 from __future__ import annotations
 
+import math
 import os
+import sys
 from pathlib import Path
+
 
 ROOT = Path(os.getenv("PROJECT_ROOT") or Path(__file__).resolve().parents[1])
 METRICS = ROOT / "metrics"
 
 
+def _read_perf_source() -> tuple[str, str] | tuple[None, None]:
+    """Return the raw value and its source identifier."""
+
+    val = os.getenv("PERF_P95_MS")
+    if val:
+        return val.strip(), "PERF_P95_MS"
+
+    p = METRICS / "input_perf.txt"
+    if p.exists():
+        try:
+            text = p.read_text(encoding="utf-8").strip()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"[PERF] Failed to read {p}: {exc}", file=sys.stderr)
+            return None, None
+        if text:
+            return text, str(p)
+    return None, None
+
+
+def _validate_perf(raw: str, source: str) -> float:
+    try:
+        value = float(raw)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        raise ValueError(f"non-numeric value from {source}: {raw!r} ({exc})") from exc
+
+    if not math.isfinite(value):
+        raise ValueError(f"non-finite value from {source}: {value!r}")
+    if value <= 0:
+        raise ValueError(f"expected positive latency from {source}, got {value}")
+    return value
+
+
 def main() -> int:
     METRICS.mkdir(parents=True, exist_ok=True)
-    val = os.getenv("PERF_P95_MS")
-    if not val:
-        p = METRICS / "input_perf.txt"
-        if p.exists():
-            try:
-                val = p.read_text(encoding="utf-8").strip()
-            except Exception:
-                val = None
+
+    raw, source = _read_perf_source()
+    if not raw or not source:
+        print(
+            "[PERF] Missing performance input. Provide PERF_P95_MS or metrics/input_perf.txt.",
+            file=sys.stderr,
+        )
+        return 1
+
     try:
-        p95 = float(val) if val else 9999.0
-    except Exception:
-        p95 = 9999.0
-    (METRICS / "perf.json").write_text(f"{{\n  \"http_p95_ms\": {p95} \n}}\n", encoding="utf-8")
+        p95 = _validate_perf(raw, source)
+    except ValueError as exc:
+        print(f"[PERF] {exc}", file=sys.stderr)
+        return 1
+
+    (METRICS / "perf.json").write_text(
+        f"{{\n  \"http_p95_ms\": {p95} \n}}\n", encoding="utf-8"
+    )
     print(f"{{\"http_p95_ms\": {p95} }}")
     return 0
 

--- a/scripts/enforce_gates.py
+++ b/scripts/enforce_gates.py
@@ -15,6 +15,7 @@ Metrics files expected:
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sys
@@ -84,7 +85,12 @@ def read_perf_p95_ms() -> float:
     if not p.exists():
         raise SystemExit("[GATES] metrics/perf.json missing")
     d = _read_json(p)
-    return float(d.get("http_p95_ms") or d.get("p95_ms") or d.get("p95"))
+    val = float(d.get("http_p95_ms") or d.get("p95_ms") or d.get("p95"))
+    if not math.isfinite(val) or val <= 0:
+        raise SystemExit(
+            f"[GATES] Invalid perf measurement in {p}: expected positive finite number, got {val!r}"
+        )
+    return val
 
 
 def thresholds_from_quality_gates(gates: dict) -> dict:


### PR DESCRIPTION
## Summary
- raise the line coverage and vulnerability targets in gates_config.yaml to match SLO expectations
- enforce that collect_perf.py and enforce_gates.py require positive, real performance measurements before continuing
- document the new thresholds and performance evidence requirements across lifecycle and utility guides

## Testing
- python -m compileall scripts/collect_perf.py scripts/enforce_gates.py

------
https://chatgpt.com/codex/tasks/task_e_68d8becc6530832e926d46acab5ae6b6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9c1b5ab1259e42cdbf942d25734029ca3d277f20. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->