### PR TITLE
Add template-derived layer summaries to stack selection

### DIFF
--- a/docs/COMPLIANCE_EVIDENCE.md
+++ b/docs/COMPLIANCE_EVIDENCE.md
@@ -7,6 +7,7 @@ Compliance requirements are enforced throughout the lifecycle so every generated
 | Component | Purpose | Location |
 | --- | --- | --- |
 | Stack selection evidence | Captures the chosen variants, engine versions, and compliance modes before generation. | `${PROJECT_ROOT}/selection.json`, `${PROJECT_ROOT}/evidence/stack-selection.md` |
+| Layer summaries | Documents the selected UI, API, and database templates with synthesized descriptions for review. | `${PROJECT_ROOT}/evidence/ui-summary.md`, `${PROJECT_ROOT}/evidence/api-summary.md`, `${PROJECT_ROOT}/evidence/database-summary.md` |
 | Gate thresholds | Defines minimum coverage, performance, and vulnerability tolerances. | [`gates_config.yaml`](../gates_config.yaml) |
 | Gate enforcement | Aggregates metrics and fails the run when thresholds are missed. | [`scripts/enforce_gates.py`](../scripts/enforce_gates.py) |
 | Compliance validator | Confirms required controls, policies, and documentation are emitted. | [`scripts/validate_compliance_assets.py`](../scripts/validate_compliance_assets.py) |
@@ -15,7 +16,7 @@ Compliance requirements are enforced throughout the lifecycle so every generated
 
 ## Evidence Flow
 
-1. **Preflight (`scripts/select_stacks.py`)** – When `--compliance` is set, the stack selection records which regimes (HIPAA, GDPR, PCI, etc.) were requested. The command writes machine-readable (`selection.json`) and human-readable (`evidence/stack-selection.md`) outputs.
+1. **Preflight (`scripts/select_stacks.py`)** – When `--compliance` is set, the stack selection records which regimes (HIPAA, GDPR, PCI, etc.) were requested. The command writes machine-readable (`selection.json`), human-readable (`evidence/stack-selection.md`), and template-driven layer summaries (`evidence/ui-summary.md`, `evidence/api-summary.md`, `evidence/database-summary.md`). Reviewers should confirm the summaries match the selected variants and that any downgrade notes appear both in the stack-selection table and the detailed files.
 2. **Generation** – Template packs emit code, policies, and docs that match the selected compliance modes.
 3. **Testing & Metrics** – `scripts/install_and_test.sh` plus the metric collectors gather coverage, dependency, and performance data under `${PROJECT_ROOT}`.
 4. **Gate Enforcement** – `scripts/enforce_gates.py` reads `gates_config.yaml` and fails if thresholds are not met. Adjust the config when regimes demand stricter requirements, but coordinate changes with CI to keep parity.

--- a/docs/LOCAL_DEV_WORKFLOW.md
+++ b/docs/LOCAL_DEV_WORKFLOW.md
@@ -118,6 +118,14 @@ python scripts/select_stacks.py \
 
 Add `--compliance "$COMPLIANCE"` or `--nestjs-orm "$NESTJS_ORM"` when required. Exit code `3` indicates unmet engine version requirements.
 
+Outputs include:
+
+- `selection.json` – machine-readable summary of layers, variants, engine checks, and template-derived layer summaries.
+- `evidence/stack-selection.md` – human-readable overview including links to each layer summary.
+- `evidence/ui-summary.md`, `evidence/api-summary.md`, `evidence/database-summary.md` – Markdown syntheses extracted from the selected template READMEs.
+
+Reviewers should open the three layer summary files and confirm the descriptions match the chosen template variant (including any downgrade notes) and that the highlighted features align with the template README. If discrepancies surface, regenerate with the correct stack or update the template documentation before continuing.
+
 ### 6. Dry-run generation (no writes)
 
 ```bash

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -16,7 +16,7 @@ This repository is the factory that turns an approved client brief into a fully 
 
 1. **Brief ingestion and planning** – `scripts/plan_from_brief.py` parses the client brief and produces `PLAN.md` and `PLAN.tasks.json` inside an isolated project directory.
 2. **Task validation** – `scripts/validate_tasks.py` confirms dependency IDs, enums, and graph topology for the generated plan.
-3. **Stack preflight** – `scripts/select_stacks.py` records the stack selection, verifies engine requirements, and writes evidence in the project directory.
+3. **Stack preflight** – `scripts/select_stacks.py` records the stack selection, verifies engine requirements, and writes evidence plus layer summaries in the project directory for downstream gates.
 4. **Generation** – `scripts/generate_client_project.py` performs a dry-run preview and the final scaffold using the template packs.
 5. **Post-generation lifecycle** – install/tests, task sync, metric collection, gate enforcement, submission pack, and compliance validation all run against the isolated project root.
 6. **CI/CD** – the supported workflows run secrets preflight, stage deployments, production promotion, and nightly health validation using the same scripts.

--- a/scripts/select_stacks.py
+++ b/scripts/select_stacks.py
@@ -3,13 +3,128 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+
+# -----------------------------
+# Utility: markdown summarization
+# -----------------------------
+
+SUMMARY_REPLACEMENTS = {
+    "PROJECT_NAME": "Project",
+}
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _replace_tokens(text: str, replacements: Dict[str, str]) -> str:
+    for token, value in replacements.items():
+        text = text.replace(f"{{{{{token}}}}}", value)
+    return text
+
+
+def _find_readme(base: Path) -> Optional[Path]:
+    candidates = [
+        base / "README.summary.md",
+        base / "README.md",
+        base.parent / "README.summary.md",
+        base.parent / "README.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _extract_paragraph(text: str) -> str:
+    lines = text.splitlines()
+    paragraph: List[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        if stripped.startswith("#"):
+            # Skip headings at the top of the file
+            if not paragraph:
+                continue
+            break
+        if stripped.startswith("-") and not paragraph:
+            # Avoid leading bullet lists being treated as summary
+            continue
+        if stripped.startswith("##"):
+            break
+        paragraph.append(stripped)
+    return " ".join(paragraph).strip()
+
+
+def _extract_features(text: str, limit: int = 3) -> List[str]:
+    lines = text.splitlines()
+    features: List[str] = []
+    collecting = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("##"):
+            collecting = stripped.lower().startswith("## features")
+            continue
+        if collecting:
+            if not stripped or stripped.startswith("#"):
+                if features:
+                    break
+                continue
+            if stripped.startswith("-"):
+                features.append(stripped)
+                if len(features) >= limit:
+                    break
+            else:
+                if features:
+                    break
+    return features
+
+
+def _summarize_template(base: Path, replacements: Dict[str, str]) -> str:
+    readme = _find_readme(base)
+    if not readme:
+        return f"No README found for template at {base}."
+    raw = _read_text(readme)
+    if not raw:
+        return f"Unable to read README for template at {base}."
+    text = _replace_tokens(raw, replacements)
+    paragraph = _extract_paragraph(text)
+    features = _extract_features(text)
+    summary_parts: List[str] = []
+    if paragraph:
+        summary_parts.append(paragraph)
+    if features:
+        summary_parts.append("Key features:\n" + "\n".join(features))
+    return "\n\n".join(summary_parts).strip() or f"README for {base} did not contain descriptive text."
+
+
+def _write_summary_file(path: Path, title: str, content: str) -> None:
+    normalized = content.strip() if content else ""
+    if not normalized:
+        normalized = "Summary unavailable."
+    path.write_text(f"# {title}\n\n{normalized}\n", encoding="utf-8")
+
+
+def _excerpt(text: str, limit: int = 220) -> str:
+    if not text:
+        return ""
+    first_block = text.split("\n\n", 1)[0]
+    cleaned = " ".join(first_block.strip().split())
+    if len(cleaned) > limit:
+        return cleaned[: limit - 1].rstrip() + "…"
+    return cleaned
 
 
 # -----------------------------
@@ -262,6 +377,19 @@ def main() -> int:
 
     compliance = [s for s in (args.compliance.split(",") if args.compliance else []) if s]
 
+    replacements = dict(SUMMARY_REPLACEMENTS)
+    replacements.update(
+        {
+            "INDUSTRY": args.industry,
+            "PROJECT_TYPE": args.project_type,
+        }
+    )
+    replacements.setdefault("COMPLIANCE", ", ".join(compliance) if compliance else "standard")
+
+    ui_summary = _summarize_template(fe_dir / fe_variant, replacements)
+    api_summary = _summarize_template(be_dir / be_variant, replacements)
+    db_summary = _summarize_template(db_dir / "base", replacements)
+
     out = {
         "frontend": Selection(
             requested=args.frontend,
@@ -282,6 +410,20 @@ def main() -> int:
         "engine_checks": engine_checks,
         "warnings": warnings,
         "status": "ok" if not unmet else "engine_unmet",
+        "summaries": {
+            "ui": {
+                "path": str(Path(args.summary).parent / "ui-summary.md"),
+                "summary": ui_summary,
+            },
+            "api": {
+                "path": str(Path(args.summary).parent / "api-summary.md"),
+                "summary": api_summary,
+            },
+            "database": {
+                "path": str(Path(args.summary).parent / "database-summary.md"),
+                "summary": db_summary,
+            },
+        },
     }
 
     # Write outputs
@@ -290,7 +432,17 @@ def main() -> int:
     sel_path.write_text(json.dumps(out, indent=2), encoding="utf-8")
 
     md_path = Path(args.summary)
-    md_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_dir = md_path.parent
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    ui_summary_path = evidence_dir / "ui-summary.md"
+    api_summary_path = evidence_dir / "api-summary.md"
+    db_summary_path = evidence_dir / "database-summary.md"
+
+    _write_summary_file(ui_summary_path, "UI Summary", ui_summary)
+    _write_summary_file(api_summary_path, "API Summary", api_summary)
+    _write_summary_file(db_summary_path, "Database Summary", db_summary)
+
     lines: List[str] = []
     lines.append("# Stack Selection (Preflight)\n")
     lines.append("| Layer | Requested | Variant Req. | Chosen | Variant | Note |\n")
@@ -309,6 +461,10 @@ def main() -> int:
         lines.append("\n## Warnings\n")
         for w in warnings:
             lines.append(f"- {w}\n")
+    lines.append("\n## Layer Summaries\n")
+    lines.append(f"- **UI**: {_excerpt(ui_summary)} ([details]({ui_summary_path.name}))\n")
+    lines.append(f"- **API**: {_excerpt(api_summary)} ([details]({api_summary_path.name}))\n")
+    lines.append(f"- **Database**: {_excerpt(db_summary)} ([details]({db_summary_path.name}))\n")
     md_path.write_text("".join(lines), encoding="utf-8")
 
     if unmet:


### PR DESCRIPTION
## Summary
- synthesize UI, API, and database summaries from selected template READMEs during stack selection
- write the layer summaries to the evidence directory and expose them in both JSON and Markdown outputs for downstream gates
- update workflow and compliance documentation to describe the new artifacts and reviewer validation steps

## Testing
- python -m compileall scripts/select_stacks.py
- python scripts/select_stacks.py --industry healthcare --project-type platform --frontend angular --backend nestjs --database postgres --output tmp/selection.json --summary tmp/evidence/stack-selection.md --node v20.20.0 --python 3.12.1 --go 1.21.0 --docker 24.0.0


------
https://chatgpt.com/codex/tasks/task_e_68d8c0110804832ebd618f64215fa5ed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Synthesizes UI/API/DB summaries from template READMEs in `scripts/select_stacks.py`, writes them to `evidence/` and surfaces excerpts/paths in JSON and Markdown; updates docs to reflect new artifacts and review steps.
> 
> - **Scripts (`scripts/select_stacks.py`)**:
>   - Add README parsing and summarization utilities to extract a paragraph and key features.
>   - Generate layer summaries for `UI`, `API`, and `Database`; write to `evidence/ui-summary.md`, `evidence/api-summary.md`, `evidence/database-summary.md`.
>   - Include `summaries` with paths and content in `selection.json` and add summary excerpts/links in `evidence/stack-selection.md`.
> - **Docs**:
>   - `docs/COMPLIANCE_EVIDENCE.md`: Document new layer summary artifacts and their role in preflight evidence.
>   - `docs/LOCAL_DEV_WORKFLOW.md`: List new outputs and reviewer validation steps for layer summaries.
>   - `docs/SYSTEM_OVERVIEW.md`: Note that preflight now writes evidence plus layer summaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b7142e50347c46841afc84b4cab7cd23973c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->