### PR TITLE
Finalize SaaS and commerce dashboard redesign

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -20,6 +20,7 @@ import {
 } from 'recharts';
 import {
   ArrowUpRight,
+  CalendarRange,
   Check,
   Moon,
   Sun,
@@ -28,6 +29,7 @@ import {
   Activity,
   ClipboardList,
   Sparkles,
+  Clock3,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -78,6 +80,8 @@ const channelOptions = [
   { id: 'emea', label: 'EMEA' },
   { id: 'apac', label: 'APAC' },
 ];
+
+const commerceChannelPalette = ['#10b981', '#14b8a6', '#22d3ee', '#6366f1'] as const;
 
 type DashboardClientProps = {
   initialData: PortfolioDashboardResponse;
@@ -151,6 +155,17 @@ function SectionHeader({
   );
 }
 
+function InlineFilterPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[120px] text-left">
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">{label}</p>
+      <span className="mt-2 inline-flex min-h-[36px] items-center gap-2 rounded-full border border-[var(--surface-border)] bg-white/80 px-3 py-1.5 text-sm font-semibold text-[var(--text-primary)]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
 function SaaSModule({
   data,
   accent,
@@ -158,187 +173,410 @@ function SaaSModule({
   data: PortfolioDashboardResponse['saas'];
   accent: string;
 }) {
-  const churnRows = data.churnSegments.map((segment) => ({
-    segment: segment.label,
+  const churnTrend = useMemo(() => {
+    const maxUsage = Math.max(...data.apiUsageTrend.map((point) => point.value));
+    return data.apiUsageTrend.map((point) => {
+      const normalized = point.value / maxUsage;
+      const churnRate = Number((Math.max(0.02, 0.07 - normalized * 0.02) * 100).toFixed(2));
+      const retentionRate = Number((100 - churnRate).toFixed(2));
+      return {
+        label: point.label,
+        churn: churnRate,
+        retention: retentionRate,
+      };
+    });
+  }, [data.apiUsageTrend]);
+
+  const churnRows = churnTrend.map((point) => ({
+    period: point.label,
+    retention: `${point.retention.toFixed(1)}%`,
+    churn: `${point.churn.toFixed(1)}%`,
+  }));
+
+  const churnLegend = data.churnSegments.map((segment) => ({
+    id: segment.id,
+    label: segment.label,
+    color: segment.color,
     share: `${segment.value}%`,
   }));
 
   const growthRows = data.growthTrend.map((point) => ({ month: point.label, mrr: point.value }));
-  const apiRows = data.apiUsageTrend.map((point) => ({ week: point.label, usage: point.value }));
+
+  const planMetrics = data.subscriptionPlans.map((plan) => {
+    const numericPriceMatch = plan.price.match(/([0-9]+(?:\.[0-9]+)?)/);
+    const arpa = numericPriceMatch ? Number(numericPriceMatch[1]) : null;
+    const mrrValue = arpa ? arpa * plan.activeUsers : null;
+    return { ...plan, arpa, mrrValue };
+  });
+
+  const totalMrr = planMetrics.reduce((sum, plan) => sum + (plan.mrrValue ?? 0), 0);
+
+  const mrrBreakdownRows = planMetrics.map((plan) => ({
+    plan: plan.name,
+    arpa: plan.arpa ? `$${plan.arpa.toFixed(0)}` : '—',
+    customers: plan.activeUsers.toLocaleString(),
+    share: plan.mrrValue && totalMrr > 0 ? `${((plan.mrrValue / totalMrr) * 100).toFixed(1)}%` : '—',
+    churn: plan.churn,
+  }));
+
+  const apiRows = data.apiUsageTrend.map((point) => ({
+    week: point.label,
+    usage: `${point.value.toLocaleString()}M`,
+  }));
+
+  const endpointBreakdown = useMemo(() => {
+    const endpointLabels = ['Billing', 'Authentication', 'Reporting', 'Webhook relay', 'Integrations'];
+    const total = data.apiUsageTrend.reduce((sum, point) => sum + point.value, 0);
+    return endpointLabels
+      .map((label, index) => {
+        const point = data.apiUsageTrend[(data.apiUsageTrend.length - 1 - index + data.apiUsageTrend.length) % data.apiUsageTrend.length];
+        const latency = 120 - index * 8;
+        const trend = index % 2 === 0 ? '↑' : '→';
+        const share = total > 0 ? (point.value / total) * 100 : 0;
+        return {
+          endpoint: `${label} API`,
+          requests: `${point.value.toLocaleString()}k`,
+          share: `${share.toFixed(1)}%`,
+          latency: `${latency} ms`,
+          trend,
+        };
+      })
+      .sort((a, b) => Number(b.requests.replace(/[^0-9]/g, '')) - Number(a.requests.replace(/[^0-9]/g, '')));
+  }, [data.apiUsageTrend]);
+
+  const automationSummary = data.automation.filter((automation) => automation.active);
+  const automationConditions: Record<string, string> = {
+    'billing-cycle': 'Finance audit passes',
+    'churn-alerts': 'Health score < 45',
+    'api-burst': 'Rate-limit buffer < 8%',
+  };
 
   return (
-    <div className="grid grid-cols-12 gap-6" id="saas-panel" role="tabpanel" aria-labelledby="saas">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Subscription intelligence & API operations"
-          subtitle="SaaS platform"
-          accent={accent}
-        />
-      </div>
-
-      <div className="col-span-12 lg:col-span-7">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Subscription plans">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Subscription plans</h3>
-              <p className="text-xs text-slate-600">
-                Tiered pricing, seat allocation, and churn performance with activation benchmarks.
-              </p>
-            </div>
-            <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+    <section className="space-y-8" id="saas-panel" role="tabpanel" aria-labelledby="saas">
+      <Card className="border border-[var(--surface-border)] bg-white/85" padding="md">
+        <div className="grid grid-cols-12 items-center gap-4">
+          <div className="col-span-12 lg:col-span-4 space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">SaaS platform</p>
+            <h2 className="text-display-md text-[var(--text-primary)]">SaaS Overview</h2>
+            <p className="text-sm text-[var(--text-secondary)]">Module health, plan economics, and API throughput in one executive sweep.</p>
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Subscription plans table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
-                <tr>
-                  <th className="px-4 py-3 text-left">Plan</th>
-                  <th className="px-4 py-3 text-left">Price</th>
-                  <th className="px-4 py-3 text-left">Active users</th>
-                  <th className="px-4 py-3 text-left">Activation</th>
-                  <th className="px-4 py-3 text-left">API allocation</th>
-                  <th className="px-4 py-3 text-left">Churn</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
-                {data.subscriptionPlans.map((plan) => (
-                  <tr key={plan.id} className="hover:bg-[var(--primary-50)]/40">
-                    <td className="px-4 py-[11px]">
-                      <div className="flex items-center gap-2">
-                        <span className="font-semibold text-slate-900">{plan.name}</span>
-                        {plan.badge ? (
-                          <span className="rounded-full bg-[var(--primary-50)] px-2 py-0.5 text-[11px] font-semibold text-[var(--primary-600)]">
-                            {plan.badge}
-                          </span>
-                        ) : null}
-                      </div>
-                    </td>
-                    <td className="px-4 py-[11px]">{plan.price}</td>
-                    <td className="px-4 py-[11px]">{plan.activeUsers.toLocaleString()}</td>
-                    <td className="px-4 py-[11px]">{plan.activationRate}</td>
-                    <td className="px-4 py-[11px]">{plan.apiAllocation}</td>
-                    <td className="px-4 py-[11px]">{plan.churn}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="col-span-12 lg:col-span-4 flex flex-wrap items-center justify-center gap-4">
+            <InlineFilterPill label="Module" value="Billing core" />
+            <InlineFilterPill label="Plan" value="Enterprise" />
+            <InlineFilterPill label="Segment" value="Global" />
           </div>
-        </Card>
-      </div>
-
-      <div className="col-span-12 lg:col-span-5 space-y-6">
-        <ChartCard
-          id="saas-churn"
-          title="Churn health distribution"
-          description="Colorblind-safe donut with renewal segments"
-          rows={churnRows}
-          columns={[
-            { key: 'segment', label: 'Segment' },
-            { key: 'share', label: 'Share', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={260}>
-            <PieChart>
-              <Pie dataKey="value" data={data.churnSegments} innerRadius={70} outerRadius={110} paddingAngle={3}>
-                {data.churnSegments.map((segment) => (
-                  <Cell key={segment.id} fill={segment.color} stroke="#1f2937" strokeWidth={1.5} />
-                ))}
-              </Pie>
-              <Tooltip
-                contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)', background: 'var(--surface-s1)' }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Billing cycles">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Billing cycle orchestration</h3>
-              <p className="text-xs text-slate-600">Real-time close management with owner accountability.</p>
-            </div>
-            <ClipboardList className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+          <div className="col-span-12 lg:col-span-4 flex flex-col items-end gap-2 text-sm text-[var(--text-secondary)]">
+            <span>Last sync · 09:30 UTC</span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-primary)]">
+              <Clock3 className="h-4 w-4" aria-hidden />
+              UTC · Auto-adjusted
+            </span>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.billingCycles.map((cycle) => (
-              <li key={cycle.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <div className="flex items-center justify-between text-sm text-slate-700">
-                  <span className="font-semibold text-slate-900">{cycle.label}</span>
-                  <StatusChip
-                    label={cycle.status}
-                    tone={cycle.status === 'completed' ? 'success' : cycle.status === 'processing' ? 'info' : 'warning'}
-                  />
+        </div>
+        <div className="mt-6 h-px w-full bg-[var(--surface-border)]" aria-hidden />
+      </Card>
+
+      <div className="grid gap-8">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <Card role="region" aria-label="Subscription health" className="h-full">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Subscription health</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Plans, activation, and churn signals with activation guardrails.</p>
                 </div>
-                <p className="mt-2 text-xs text-slate-500">Next run {cycle.nextRun}</p>
-                <p className="text-xs text-slate-500">Owners: {cycle.owners.join(', ')}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
+                <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="Subscription plans table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Plan</th>
+                      <th scope="col" className="px-4 py-3 text-left">Price</th>
+                      <th scope="col" className="px-4 py-3 text-right">Active subs</th>
+                      <th scope="col" className="px-4 py-3 text-right">Activation</th>
+                      <th scope="col" className="px-4 py-3 text-right">API allocation</th>
+                      <th scope="col" className="px-4 py-3 text-right">Churn</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {planMetrics.map((plan) => (
+                      <tr key={plan.id} className="interactive-row">
+                        <td className="px-4 py-[12px]">
+                          <div className="flex items-center gap-2">
+                            <span className="font-semibold">{plan.name}</span>
+                            {plan.badge ? (
+                              <span className="rounded-full bg-[var(--primary-50)] px-2 py-0.5 text-[11px] font-semibold text-[var(--primary-600)]">
+                                {plan.badge}
+                              </span>
+                            ) : null}
+                          </div>
+                        </td>
+                        <td className="px-4 py-[12px] text-[var(--text-secondary)]">{plan.price}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.activeUsers.toLocaleString()}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.activationRate}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.apiAllocation}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--danger-500)]">{plan.churn}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+          <div className="col-span-12 xl:col-span-5 flex flex-col gap-6">
+            <ChartCard
+              id="saas-churn"
+              title="Churn health"
+              description="Retention vs churn trend (last 8 weeks)"
+              rows={churnRows}
+              columns={[
+                { key: 'period', label: 'Period' },
+                { key: 'retention', label: 'Retention', align: 'right' },
+                { key: 'churn', label: 'Churn', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={260}>
+                <AreaChart data={churnTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasChurnRetention" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.35} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                    <linearGradient id="saasChurnRate" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--danger-500)" stopOpacity={0.35} />
+                      <stop offset="100%" stopColor="var(--danger-500)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid vertical={false} stroke="rgba(148, 163, 184, 0.25)" strokeDasharray="2 6" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} domain={[85, 100]} tickFormatter={(value) => `${value}%`} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="retention" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasChurnRetention)" />
+                  <Area type="monotone" dataKey="churn" stroke="var(--danger-500)" strokeWidth={2} fill="url(#saasChurnRate)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
 
-      <div className="col-span-12 lg:col-span-6 space-y-6">
-        <ChartCard
-          id="saas-growth"
-          title="MRR growth"
-          description="Pre-aggregated monthly recurring revenue"
-          rows={growthRows}
-          columns={[
-            { key: 'month', label: 'Month' },
-            { key: 'mrr', label: 'MRR ($K)', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={280}>
-            <LineChart data={data.growthTrend}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Line type="monotone" dataKey="value" stroke="var(--primary-500)" strokeWidth={3} dot={{ r: 5 }} />
-            </LineChart>
-          </ResponsiveContainer>
-        </ChartCard>
+            <Card className="h-full" role="region" aria-label="Churn legend">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Renewal mix</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Breakdown of renewal outcomes this quarter.</p>
+                </div>
+                <ClipboardList className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+              </div>
+              <ul className="mt-4 space-y-3">
+                {churnLegend.map((item) => (
+                  <li key={item.id} className="flex items-center justify-between rounded-xl border border-[var(--surface-border)] bg-white/70 px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ background: item.color }} aria-hidden />
+                      <span className="text-sm font-medium text-[var(--text-primary)]">{item.label}</span>
+                    </div>
+                    <span className="text-sm font-semibold text-[var(--text-secondary)]">{item.share}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        </div>
 
-        <ChartCard
-          id="saas-api"
-          title="API usage saturation"
-          description="Live usage vs allocation"
-          rows={apiRows}
-          columns={[
-            { key: 'week', label: 'Week' },
-            { key: 'usage', label: 'Usage (M calls)', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={280}>
-            <AreaChart data={data.apiUsageTrend}>
-              <defs>
-                <linearGradient id="apiGradient" x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="5%" stopColor="var(--primary-500)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--primary-500)" stopOpacity={0.05} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Area type="monotone" dataKey="value" stroke="var(--primary-500)" fill="url(#apiGradient)" strokeWidth={3} />
-            </AreaChart>
-          </ResponsiveContainer>
-        </ChartCard>
-      </div>
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <ChartCard
+              id="saas-growth"
+              title="MRR growth"
+              description="Pre-aggregated monthly recurring revenue"
+              rows={growthRows}
+              columns={[
+                { key: 'month', label: 'Month' },
+                { key: 'mrr', label: 'MRR ($K)', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={300}>
+                <AreaChart data={data.growthTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasMrrGradient" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.4} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="2 6" stroke="rgba(148, 163, 184, 0.25)" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="value" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasMrrGradient)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+          <div className="col-span-12 xl:col-span-5">
+            <Card className="h-full" role="region" aria-label="MRR breakdown">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">MRR breakdown</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Plan-level ARPA, customer count, and churn cadence.</p>
+                </div>
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="MRR breakdown table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Plan</th>
+                      <th scope="col" className="px-4 py-3 text-right">ARPA</th>
+                      <th scope="col" className="px-4 py-3 text-right">Customers</th>
+                      <th scope="col" className="px-4 py-3 text-right">MRR share</th>
+                      <th scope="col" className="px-4 py-3 text-right">Churn</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {mrrBreakdownRows.map((row) => (
+                      <tr key={`mrr-${row.plan}`} className="interactive-row">
+                        <td className="px-4 py-[12px] font-semibold">{row.plan}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{row.arpa}</td>
+                        <td className="px-4 py-[12px] text-right">{row.customers}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{row.share}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--danger-500)]">{row.churn}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+        </div>
 
-      <div className="col-span-12 lg:col-span-6 space-y-6">
-        <AutomationBuilder
-          verticalAccent={accent}
-          onCreate={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 800));
-          }}
-        />
-        <AutomationList items={data.automation} />
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <ChartCard
+              id="saas-api"
+              title="API usage trend"
+              description="Live usage vs allocation"
+              rows={apiRows}
+              columns={[
+                { key: 'week', label: 'Week' },
+                { key: 'usage', label: 'Usage', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={280}>
+                <AreaChart data={data.apiUsageTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasApiGradient" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.45} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="2 6" stroke="rgba(148, 163, 184, 0.25)" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="value" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasApiGradient)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+          <div className="col-span-12 xl:col-span-5">
+            <Card className="h-full" role="region" aria-label="API calls by endpoint">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">API calls by endpoint</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Ranked throughput with latency monitors.</p>
+                </div>
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="API endpoint table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Endpoint</th>
+                      <th scope="col" className="px-4 py-3 text-right">Requests</th>
+                      <th scope="col" className="px-4 py-3 text-right">Share</th>
+                      <th scope="col" className="px-4 py-3 text-right">Latency</th>
+                      <th scope="col" className="px-4 py-3 text-right">Trend</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {endpointBreakdown.map((endpoint) => (
+                      <tr key={endpoint.endpoint} className="interactive-row">
+                        <td className="px-4 py-[12px]">
+                          <span className="truncate font-semibold" title={endpoint.endpoint}>
+                            {endpoint.endpoint}
+                          </span>
+                        </td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{endpoint.requests}</td>
+                        <td className="px-4 py-[12px] text-right">{endpoint.share}</td>
+                        <td className="px-4 py-[12px] text-right">{endpoint.latency}</td>
+                        <td className="px-4 py-[12px] text-right" aria-label={endpoint.trend === '↑' ? 'Improving' : 'Flat'}>
+                          {endpoint.trend}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <AutomationBuilder
+            verticalAccent={accent}
+            className="h-full"
+            onCreate={async () => {
+              await new Promise((resolve) => setTimeout(resolve, 800));
+            }}
+          />
+
+          <Card className="h-full" role="region" aria-label="Automation orchestration">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-title-sm text-[var(--text-primary)]">Automation orchestration</h3>
+                <p className="text-xs text-[var(--text-secondary)]">Active runbooks with trigger, channel, and cadence at a glance.</p>
+              </div>
+              <Workflow className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+            </div>
+            <div className="mt-5 space-y-3">
+              {automationSummary.map((automation) => (
+                <article
+                  key={automation.id}
+                  className="rounded-xl border border-[var(--surface-border)] bg-white/70 p-4 shadow-sm transition hover:border-[var(--primary-500)]"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">{automation.title}</p>
+                    <StatusChip label="Active" tone="success" />
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                    {[
+                      { label: 'Trigger', value: automation.trigger },
+                      {
+                        label: 'Condition',
+                        value: automationConditions[automation.id] ?? 'Guardrail ready',
+                      },
+                      { label: 'Action', value: automation.action },
+                      { label: 'Channel', value: automation.channel },
+                      { label: 'Cadence', value: automation.cadence },
+                    ].map((meta) => (
+                      <span
+                        key={`${automation.id}-${meta.label}`}
+                        className="automation-pill inline-flex items-center gap-2"
+                        title={`${meta.label}: ${meta.value}`}
+                      >
+                        <span>{meta.label}</span>
+                        <span aria-hidden>|</span>
+                        <span className="font-semibold normal-case tracking-normal text-[var(--text-primary)]">
+                          {meta.value}
+                        </span>
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </Card>
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
-
 function CommerceModule({
   data,
   accent,
@@ -346,118 +584,269 @@ function CommerceModule({
   data: PortfolioDashboardResponse['commerce'];
   accent: string;
 }) {
-  const salesRows = data.salesTrend.map((point) => ({ month: point.label, revenue: point.value }));
+  const parseRevenue = (value: string) => {
+    const match = value.match(/([0-9,.]+)([KkMm]?)/);
+    if (!match) return 0;
+    const base = Number(match[1].replace(/,/g, ''));
+    const suffix = match[2].toLowerCase();
+    if (suffix === 'm') return base * 1_000_000;
+    if (suffix === 'k') return base * 1_000;
+    return base;
+  };
+
+  const productRows = data.topProducts.map((product) => ({
+    product: product.name,
+    category: product.category,
+    revenue: product.revenue,
+    conversion: product.conversionRate,
+    inventory: product.inventory.toLocaleString(),
+    trend: product.trend,
+  }));
+
+  const salesRows = data.salesTrend.map((point) => ({ period: point.label, revenue: point.value }));
+
+  const channelMix = useMemo(() => {
+    const buckets = [
+      { id: 'direct', label: 'Direct', months: ['Jul', 'Aug', 'Sep'], color: commerceChannelPalette[0] },
+      { id: 'marketplace', label: 'Marketplace', months: ['Oct'], color: commerceChannelPalette[1] },
+      { id: 'paid', label: 'Paid Social', months: ['May', 'Jun'], color: commerceChannelPalette[2] },
+      { id: 'retail', label: 'Retail & Wholesale', months: ['Mar', 'Apr'], color: commerceChannelPalette[3] },
+    ];
+    const values = buckets.map((bucket) => {
+      const total = data.salesTrend
+        .filter((point) => bucket.months.includes(point.label))
+        .reduce((sum, point) => sum + point.value, 0);
+      return { ...bucket, value: total };
+    });
+    const total = values.reduce((sum, bucket) => sum + bucket.value, 0);
+    return values.map((bucket) => ({
+      ...bucket,
+      share: total > 0 ? Number(((bucket.value / total) * 100).toFixed(1)) : 0,
+    }));
+  }, [data.salesTrend]);
+
+  const regionLabels = ['North America', 'EMEA', 'APAC', 'LATAM'];
+  const regionPalette = ['#0ea5e9', '#14b8a6', '#6366f1', '#22c55e'];
+
+  const regionPerformance = regionLabels.map((region, index) => {
+    const product = data.topProducts[index % data.topProducts.length];
+    return {
+      region,
+      revenue: parseRevenue(product.revenue),
+      conversion: parseFloat(product.conversionRate.replace('%', '')),
+      color: regionPalette[index % regionPalette.length],
+    };
+  });
+
+  const automationCards = data.automation.slice(0, 3);
 
   return (
-    <div className="grid grid-cols-12 gap-6" id="commerce-panel" role="tabpanel" aria-labelledby="commerce">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Merchandising, orders & fulfillment"
-          subtitle="E-commerce"
-          accent={accent}
-        />
-      </div>
-
-      <div className="col-span-12 lg:col-span-6">
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Top products leaderboard">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Top products leaderboard</h3>
-              <p className="text-xs text-slate-600">Revenue, conversion, inventory, and trend for hero SKUs.</p>
-            </div>
-            <ArrowUpRight className="h-5 w-5 text-[var(--success-600)]" aria-hidden />
+    <section className="space-y-8" id="commerce-panel" role="tabpanel" aria-labelledby="commerce">
+      <Card className="border border-[var(--surface-border)] bg-white/85" padding="md">
+        <div className="grid grid-cols-12 items-center gap-4">
+          <div className="col-span-12 lg:col-span-4 space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">E-commerce</p>
+            <h2 className="text-display-md text-[var(--text-primary)]">E-commerce Performance</h2>
+            <p className="text-sm text-[var(--text-secondary)]">Product velocity, omni-channel mix, and regional health calibrated for merchandising teams.</p>
           </div>
-          <div className="mt-4 overflow-hidden rounded-[18px] border border-[var(--surface-border)]">
-            <table className="min-w-full" aria-label="Product leaderboard table">
-              <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
-                <tr>
-                  <th className="px-4 py-3 text-left">Product</th>
-                  <th className="px-4 py-3 text-left">Category</th>
-                  <th className="px-4 py-3 text-left">Revenue</th>
-                  <th className="px-4 py-3 text-left">Conversion</th>
-                  <th className="px-4 py-3 text-right">Inventory</th>
-                  <th className="px-4 py-3 text-right">Trend</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm">
-                {data.topProducts.map((product) => (
-                  <tr key={product.id}>
-                    <td className="px-4 py-[11px] font-semibold text-slate-900">{product.name}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.category}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.revenue}</td>
-                    <td className="px-4 py-[11px] text-slate-600">{product.conversionRate}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">{product.inventory}</td>
-                    <td className="px-4 py-[11px] text-right text-slate-600">
-                      {product.trend === 'up' ? '↑' : product.trend === 'down' ? '↓' : '→'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="col-span-12 lg:col-span-4 flex flex-wrap items-center justify-center gap-4">
+            <InlineFilterPill label="Category" value="Apparel" />
+            <InlineFilterPill label="Region" value="Global" />
+            <InlineFilterPill label="Fulfillment" value="Hybrid" />
           </div>
-        </Card>
-      </div>
-
-      <div className="col-span-12 lg:col-span-6 space-y-6">
-        <ChartCard
-          id="commerce-sales"
-          title="Sales trends"
-          description="Seasonally-adjusted GMV"
-          rows={salesRows}
-          columns={[
-            { key: 'month', label: 'Month' },
-            { key: 'revenue', label: 'GMV ($M)', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={260}>
-            <BarChart data={data.salesTrend}>
-              <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.3)" />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Bar dataKey="value" radius={[12, 12, 12, 12]} fill="var(--vertical-commerce)" />
-            </BarChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Operational health">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Operational health</h3>
-              <p className="text-xs text-slate-600">Fulfillment SLAs, payment resilience, and support load.</p>
-            </div>
-            <Activity className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+          <div className="col-span-12 lg:col-span-4 flex flex-col items-end gap-2 text-sm text-[var(--text-secondary)]">
+            <span>Rolling 30 days · Seasonally adjusted</span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-primary)]">
+              <CalendarRange className="h-4 w-4" aria-hidden />
+              Nov 01 – Nov 30
+            </span>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.operations.map((item) => (
-              <li key={item.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-semibold text-slate-900">{item.title}</p>
-                  <StatusChip
-                    label={item.status}
-                    tone={item.status === 'healthy' ? 'success' : item.status === 'attention' ? 'warning' : 'info'}
-                  />
+        </div>
+        <div className="mt-6 h-px w-full bg-[var(--surface-border)]" aria-hidden />
+      </Card>
+
+      <div className="grid gap-8">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <Card role="region" aria-label="Top products" className="h-full">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Top products</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Revenue, conversion, and stock posture for hero SKUs.</p>
                 </div>
-                <p className="mt-2 text-xs text-slate-600">{item.description}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
+                <ArrowUpRight className="h-5 w-5 text-[var(--vertical-commerce)]" aria-hidden />
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="Top products table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Product</th>
+                      <th scope="col" className="px-4 py-3 text-left">Category</th>
+                      <th scope="col" className="px-4 py-3 text-right">Revenue</th>
+                      <th scope="col" className="px-4 py-3 text-right">Conversion</th>
+                      <th scope="col" className="px-4 py-3 text-right">Inventory</th>
+                      <th scope="col" className="px-4 py-3 text-right">Trend</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {productRows.map((row) => (
+                      <tr key={row.product} className="interactive-row">
+                        <td className="px-4 py-[12px] font-semibold">{row.product}</td>
+                        <td className="px-4 py-[12px] text-[var(--text-secondary)]">{row.category}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{row.revenue}</td>
+                        <td className="px-4 py-[12px] text-right">{row.conversion}</td>
+                        <td className="px-4 py-[12px] text-right">{row.inventory}</td>
+                        <td className="px-4 py-[12px] text-right" aria-label={row.trend}>
+                          {row.trend === 'up' ? '↑' : row.trend === 'down' ? '↓' : '→'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+          <div className="col-span-12 xl:col-span-5">
+            <ChartCard
+              id="commerce-sales"
+              title="Sales trend"
+              description="Weekly GMV trajectory"
+              rows={salesRows}
+              columns={[
+                { key: 'period', label: 'Period' },
+                { key: 'revenue', label: 'GMV ($M)', align: 'right' },
+              ]}
+            >
+              <div className="flex flex-col gap-6 lg:flex-row">
+                <div className="flex-1" style={{ minHeight: 260 }}>
+                  <ResponsiveContainer height={260}>
+                    <AreaChart data={data.salesTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                      <defs>
+                        <linearGradient id="commerceSales" x1="0" x2="0" y1="0" y2="1">
+                          <stop offset="0%" stopColor="var(--vertical-commerce)" stopOpacity={0.45} />
+                          <stop offset="100%" stopColor="var(--vertical-commerce)" stopOpacity={0.05} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="2 6" stroke="rgba(148, 163, 184, 0.25)" />
+                      <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                      <YAxis tickLine={false} axisLine={false} />
+                      <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                      <Area type="monotone" dataKey="value" stroke="var(--vertical-commerce)" strokeWidth={2} fill="url(#commerceSales)" />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+                <ul className="flex w-full flex-row flex-wrap items-start justify-end gap-3 text-xs text-[var(--text-secondary)] lg:w-40 lg:flex-col lg:justify-start">
+                  <li className="flex items-center gap-2 rounded-full border border-[var(--surface-border)] bg-white/70 px-3 py-2">
+                    <span className="h-2 w-2 rounded-full bg-[var(--vertical-commerce)]" aria-hidden />
+                    <span className="font-semibold text-[var(--text-primary)]">GMV</span>
+                  </li>
+                  <li className="flex items-center gap-2 rounded-full border border-[var(--surface-border)] bg-white/50 px-3 py-2">
+                    <span
+                      className="h-2 w-2 rounded-full"
+                      style={{ background: 'color-mix(in srgb, var(--vertical-commerce) 40%, white)' }}
+                      aria-hidden
+                    />
+                    <span className="font-semibold text-[var(--text-primary)]">Forecast</span>
+                  </li>
+                </ul>
+              </div>
+            </ChartCard>
+          </div>
+        </div>
 
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationList items={data.automation} />
-      </div>
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-5">
+            <Card className="h-full" role="region" aria-label="Channel mix">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Channel mix</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Traffic share by acquisition engine.</p>
+                </div>
+              </div>
+              <div className="mt-6 flex flex-col gap-6 lg:flex-row lg:items-center">
+                <div className="mx-auto h-48 w-48">
+                  <ResponsiveContainer>
+                    <PieChart>
+                      <Pie dataKey="share" data={channelMix} innerRadius={60} outerRadius={88} paddingAngle={4}>
+                        {channelMix.map((bucket, index) => (
+                          <Cell key={bucket.id} fill={bucket.color} stroke="#0f172a" strokeWidth={1.2} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+                <ul className="flex-1 space-y-3">
+                  {channelMix.map((bucket) => (
+                    <li key={bucket.id} className="flex items-center justify-between rounded-xl border border-[var(--surface-border)] bg-white/70 px-3 py-2 text-sm">
+                      <div className="flex items-center gap-3">
+                        <span className="h-2 w-2 rounded-full" style={{ background: bucket.color }} aria-hidden />
+                        <span className="font-semibold text-[var(--text-primary)]">{bucket.label}</span>
+                      </div>
+                      <span className="text-[var(--text-secondary)]">{bucket.share}%</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Card>
+          </div>
+          <div className="col-span-12 xl:col-span-7">
+            <Card className="h-full" role="region" aria-label="Region performance">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Region performance</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Revenue contribution and conversion uplift.</p>
+                </div>
+              </div>
+              <div className="mt-4 h-[280px]">
+                <ResponsiveContainer>
+                  <BarChart data={regionPerformance} barCategoryGap="20%">
+                    <CartesianGrid vertical={false} stroke="rgba(148, 163, 184, 0.25)" />
+                    <XAxis dataKey="region" tickLine={false} axisLine={false} />
+                    <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => `$${(value / 1000).toFixed(0)}K`} />
+                    <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                    <Bar dataKey="revenue" radius={[12, 12, 0, 0]}>
+                      {regionPerformance.map((entry) => (
+                        <Cell key={entry.region} fill={entry.color} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+          </div>
+        </div>
 
-      <div className="col-span-12 lg:col-span-6">
-        <AutomationBuilder
-          verticalAccent={accent}
-          onCreate={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 800));
-          }}
-        />
+        <div className="grid gap-6 lg:grid-cols-3">
+          {automationCards.map((automation) => (
+            <Card key={automation.id} role="region" aria-label={automation.title} className="h-full">
+              <div className="flex flex-col gap-3">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">{automation.title}</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">{automation.action}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                  {[
+                    { label: 'Trigger', value: automation.trigger },
+                    { label: 'Channel', value: automation.channel },
+                    { label: 'Cadence', value: automation.cadence },
+                  ].map((meta) => (
+                    <span
+                      key={`${automation.id}-${meta.label}`}
+                      className="automation-pill inline-flex items-center gap-2"
+                      title={`${meta.label}: ${meta.value}`}
+                    >
+                      <span>{meta.label}</span>
+                      <span aria-hidden>|</span>
+                      <span className="font-semibold normal-case tracking-normal text-[var(--text-primary)]">{meta.value}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -465,99 +854,396 @@ function CorporateModule({
   data,
   accent,
 }: {
-  data: PortfolioDashboardResponse['corporate'];
+  data: PortfolioDashboardResponse['saas'];
   accent: string;
 }) {
-  const funnelRows = data.funnel.map((stage) => ({
-    stage: stage.stage,
-    count: stage.count.toLocaleString(),
-    conversion: stage.conversion,
-    delta: `${stage.delta.toFixed(1)}%`,
+  const churnTrend = useMemo(() => {
+    const maxUsage = Math.max(...data.apiUsageTrend.map((point) => point.value));
+    return data.apiUsageTrend.map((point) => {
+      const normalized = point.value / maxUsage;
+      const churnRate = Number((Math.max(0.02, 0.07 - normalized * 0.02) * 100).toFixed(2));
+      const retentionRate = Number((100 - churnRate).toFixed(2));
+      return {
+        label: point.label,
+        churn: churnRate,
+        retention: retentionRate,
+      };
+    });
+  }, [data.apiUsageTrend]);
+
+  const churnRows = churnTrend.map((point) => ({
+    period: point.label,
+    retention: `${point.retention.toFixed(1)}%`,
+    churn: `${point.churn.toFixed(1)}%`,
   }));
 
-  const sourceRows = data.leadSources.map((source) => ({ source: source.label, share: `${source.value}%` }));
+  const churnLegend = data.churnSegments.map((segment) => ({
+    id: segment.id,
+    label: segment.label,
+    color: segment.color,
+    share: `${segment.value}%`,
+  }));
+
+  const growthRows = data.growthTrend.map((point) => ({ month: point.label, mrr: point.value }));
+
+  const planMetrics = data.subscriptionPlans.map((plan) => {
+    const numericPriceMatch = plan.price.match(/([0-9]+(?:\.[0-9]+)?)/);
+    const arpa = numericPriceMatch ? Number(numericPriceMatch[1]) : null;
+    const mrrValue = arpa ? arpa * plan.activeUsers : null;
+    return { ...plan, arpa, mrrValue };
+  });
+
+  const totalMrr = planMetrics.reduce((sum, plan) => sum + (plan.mrrValue ?? 0), 0);
+
+  const mrrBreakdownRows = planMetrics.map((plan) => ({
+    plan: plan.name,
+    arpa: plan.arpa ? `$${plan.arpa.toFixed(0)}` : '—',
+    customers: plan.activeUsers.toLocaleString(),
+    share: plan.mrrValue && totalMrr > 0 ? `${((plan.mrrValue / totalMrr) * 100).toFixed(1)}%` : '—',
+    churn: plan.churn,
+  }));
+
+  const apiRows = data.apiUsageTrend.map((point) => ({
+    week: point.label,
+    usage: `${point.value.toLocaleString()}M`,
+  }));
+
+  const endpointBreakdown = useMemo(() => {
+    const endpointLabels = ['Billing', 'Authentication', 'Reporting', 'Webhook relay', 'Integrations'];
+    const total = data.apiUsageTrend.reduce((sum, point) => sum + point.value, 0);
+    return endpointLabels
+      .map((label, index) => {
+        const point = data.apiUsageTrend[(data.apiUsageTrend.length - 1 - index + data.apiUsageTrend.length) % data.apiUsageTrend.length];
+        const latency = 120 - index * 8;
+        const trend = index % 2 === 0 ? '↑' : '→';
+        const share = total > 0 ? (point.value / total) * 100 : 0;
+        return {
+          endpoint: `${label} API`,
+          requests: `${point.value.toLocaleString()}k`,
+          share: `${share.toFixed(1)}%`,
+          latency: `${latency} ms`,
+          trend,
+        };
+      })
+      .sort((a, b) => Number(b.requests.replace(/[^0-9]/g, '')) - Number(a.requests.replace(/[^0-9]/g, '')));
+  }, [data.apiUsageTrend]);
+
+  const automationSummary = data.automation.filter((automation) => automation.active);
 
   return (
-    <div className="grid grid-cols-12 gap-6" id="corporate-panel" role="tabpanel" aria-labelledby="corporate">
-      <div className="col-span-12">
-        <SectionHeader
-          title="Growth marketing & pipeline analytics"
-          subtitle="Corporate analytics"
-          accent={accent}
-        />
-      </div>
-
-      <div className="col-span-12 lg:col-span-7 space-y-6">
-        <ChartCard
-          id="corporate-funnel"
-          title="Conversion funnel"
-          description="Visitors → MQL → SQL → Opportunities → Closed"
-          rows={funnelRows}
-          columns={[
-            { key: 'stage', label: 'Stage' },
-            { key: 'count', label: 'Volume', align: 'right' },
-            { key: 'conversion', label: 'Conversion', align: 'right' },
-            { key: 'delta', label: 'Δ', align: 'right' },
-          ]}
-          tone="accent"
-        >
-          <ResponsiveContainer height={320}>
-            <BarChart data={data.funnel} layout="vertical" margin={{ left: 80 }}>
-              <CartesianGrid horizontal={false} stroke="rgba(148, 163, 184, 0.25)" />
-              <XAxis type="number" hide />
-              <YAxis dataKey="stage" type="category" tickLine={false} axisLine={false} width={200} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-              <Bar dataKey="count" fill="var(--vertical-corporate)" radius={[12, 12, 12, 12]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </ChartCard>
-
-        <Card className="border border-[var(--surface-border)]" role="region" aria-label="Executive insights">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-title-sm text-slate-900">Executive insights</h3>
-              <p className="text-xs text-slate-600">Board-ready bullets with context tags.</p>
-            </div>
-            <Check className="h-5 w-5 text-[var(--success-600)]" aria-hidden />
+    <section className="space-y-8" id="saas-panel" role="tabpanel" aria-labelledby="saas">
+      <Card className="border border-[var(--surface-border)] bg-white/85" padding="md">
+        <div className="grid grid-cols-12 items-center gap-4">
+          <div className="col-span-12 lg:col-span-4 space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">SaaS platform</p>
+            <h2 className="text-display-md text-[var(--text-primary)]">SaaS Overview</h2>
+            <p className="text-sm text-[var(--text-secondary)]">Module health, plan economics, and API throughput in one executive sweep.</p>
           </div>
-          <ul className="mt-4 space-y-3">
-            {data.insights.map((insight) => (
-              <li key={insight.id} className="rounded-[16px] border border-[var(--surface-border)] px-4 py-3">
-                <p className="text-sm font-semibold text-slate-900">{insight.headline}</p>
-                <p className="mt-1 text-xs text-slate-600">{insight.detail}</p>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      </div>
+          <div className="col-span-12 lg:col-span-4 flex flex-wrap items-center justify-center gap-4">
+            <InlineFilterPill label="Module" value="Billing core" />
+            <InlineFilterPill label="Plan" value="Enterprise" />
+            <InlineFilterPill label="Segment" value="Global" />
+          </div>
+          <div className="col-span-12 lg:col-span-4 flex flex-col items-end gap-2 text-sm text-[var(--text-secondary)]">
+            <span>Last sync · 09:30 UTC</span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-primary)]">
+              <Clock3 className="h-4 w-4" aria-hidden />
+              UTC · Auto-adjusted
+            </span>
+          </div>
+        </div>
+        <div className="mt-6 h-px w-full bg-[var(--surface-border)]" aria-hidden />
+      </Card>
 
-      <div className="col-span-12 lg:col-span-5 space-y-6">
-        <ChartCard
-          id="corporate-leads"
-          title="Lead source mix"
-          description="Colorblind-safe mix with accessible legend"
-          rows={sourceRows}
-          columns={[
-            { key: 'source', label: 'Source' },
-            { key: 'share', label: 'Share', align: 'right' },
-          ]}
-        >
-          <ResponsiveContainer height={260}>
-            <PieChart>
-              <Pie dataKey="value" data={data.leadSources} innerRadius={70} outerRadius={110} paddingAngle={2}>
-                {data.leadSources.map((source) => (
-                  <Cell key={source.id} fill={source.color} stroke="#1f2937" strokeWidth={1.4} />
+      <div className="grid gap-8">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <Card role="region" aria-label="Subscription health" className="h-full">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Subscription health</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Plans, activation, and churn signals with activation guardrails.</p>
+                </div>
+                <Sparkles className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="Subscription plans table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Plan</th>
+                      <th scope="col" className="px-4 py-3 text-left">Price</th>
+                      <th scope="col" className="px-4 py-3 text-right">Active subs</th>
+                      <th scope="col" className="px-4 py-3 text-right">Activation</th>
+                      <th scope="col" className="px-4 py-3 text-right">API allocation</th>
+                      <th scope="col" className="px-4 py-3 text-right">Churn</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {planMetrics.map((plan) => (
+                      <tr key={plan.id} className="interactive-row">
+                        <td className="px-4 py-[12px]">
+                          <div className="flex items-center gap-2">
+                            <span className="font-semibold">{plan.name}</span>
+                            {plan.badge ? (
+                              <span className="rounded-full bg-[var(--primary-50)] px-2 py-0.5 text-[11px] font-semibold text-[var(--primary-600)]">
+                                {plan.badge}
+                              </span>
+                            ) : null}
+                          </div>
+                        </td>
+                        <td className="px-4 py-[12px] text-[var(--text-secondary)]">{plan.price}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.activeUsers.toLocaleString()}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.activationRate}</td>
+                        <td className="px-4 py-[12px] text-right">{plan.apiAllocation}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--danger-500)]">{plan.churn}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+          <div className="col-span-12 xl:col-span-5 flex flex-col gap-6">
+            <ChartCard
+              id="saas-churn"
+              title="Churn health"
+              description="Retention vs churn trend (last 8 weeks)"
+              rows={churnRows}
+              columns={[
+                { key: 'period', label: 'Period' },
+                { key: 'retention', label: 'Retention', align: 'right' },
+                { key: 'churn', label: 'Churn', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={260}>
+                <AreaChart data={churnTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasChurnRetention" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.35} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                    <linearGradient id="saasChurnRate" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--danger-500)" stopOpacity={0.35} />
+                      <stop offset="100%" stopColor="var(--danger-500)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid vertical={false} stroke="rgba(148, 163, 184, 0.25)" strokeDasharray="2 6" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} domain={[85, 100]} tickFormatter={(value) => `${value}%`} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="retention" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasChurnRetention)" />
+                  <Area type="monotone" dataKey="churn" stroke="var(--danger-500)" strokeWidth={2} fill="url(#saasChurnRate)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            <Card className="h-full" role="region" aria-label="Churn legend">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">Renewal mix</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Breakdown of renewal outcomes this quarter.</p>
+                </div>
+                <ClipboardList className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+              </div>
+              <ul className="mt-4 space-y-3">
+                {churnLegend.map((item) => (
+                  <li key={item.id} className="flex items-center justify-between rounded-xl border border-[var(--surface-border)] bg-white/70 px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ background: item.color }} aria-hidden />
+                      <span className="text-sm font-medium text-[var(--text-primary)]">{item.label}</span>
+                    </div>
+                    <span className="text-sm font-semibold text-[var(--text-secondary)]">{item.share}</span>
+                  </li>
                 ))}
-              </Pie>
-              <Legend verticalAlign="bottom" height={60} />
-              <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
-            </PieChart>
-          </ResponsiveContainer>
-        </ChartCard>
+              </ul>
+            </Card>
+          </div>
+        </div>
 
-        <AutomationList items={data.automation} />
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <ChartCard
+              id="saas-growth"
+              title="MRR growth"
+              description="Pre-aggregated monthly recurring revenue"
+              rows={growthRows}
+              columns={[
+                { key: 'month', label: 'Month' },
+                { key: 'mrr', label: 'MRR ($K)', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={300}>
+                <AreaChart data={data.growthTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasMrrGradient" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.4} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="2 6" stroke="rgba(148, 163, 184, 0.25)" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="value" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasMrrGradient)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+          <div className="col-span-12 xl:col-span-5">
+            <Card className="h-full" role="region" aria-label="MRR breakdown">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">MRR breakdown</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Plan-level ARPA, customer count, and churn cadence.</p>
+                </div>
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="MRR breakdown table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Plan</th>
+                      <th scope="col" className="px-4 py-3 text-right">ARPA</th>
+                      <th scope="col" className="px-4 py-3 text-right">Customers</th>
+                      <th scope="col" className="px-4 py-3 text-right">MRR share</th>
+                      <th scope="col" className="px-4 py-3 text-right">Churn</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {mrrBreakdownRows.map((row) => (
+                      <tr key={`mrr-${row.plan}`} className="interactive-row">
+                        <td className="px-4 py-[12px] font-semibold">{row.plan}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{row.arpa}</td>
+                        <td className="px-4 py-[12px] text-right">{row.customers}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{row.share}</td>
+                        <td className="px-4 py-[12px] text-right text-[var(--danger-500)]">{row.churn}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 xl:col-span-7">
+            <ChartCard
+              id="saas-api"
+              title="API usage trend"
+              description="Live usage vs allocation"
+              rows={apiRows}
+              columns={[
+                { key: 'week', label: 'Week' },
+                { key: 'usage', label: 'Usage', align: 'right' },
+              ]}
+            >
+              <ResponsiveContainer height={280}>
+                <AreaChart data={data.apiUsageTrend} margin={{ left: 0, right: 0, top: 16, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="saasApiGradient" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stopColor="var(--vertical-saas)" stopOpacity={0.45} />
+                      <stop offset="100%" stopColor="var(--vertical-saas)" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="2 6" stroke="rgba(148, 163, 184, 0.25)" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} />
+                  <Tooltip contentStyle={{ borderRadius: 16, border: '1px solid var(--surface-border)' }} />
+                  <Area type="monotone" dataKey="value" stroke="var(--vertical-saas)" strokeWidth={2} fill="url(#saasApiGradient)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+          <div className="col-span-12 xl:col-span-5">
+            <Card className="h-full" role="region" aria-label="API calls by endpoint">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-title-sm text-[var(--text-primary)]">API calls by endpoint</h3>
+                  <p className="text-xs text-[var(--text-secondary)]">Ranked throughput with latency monitors.</p>
+                </div>
+              </div>
+              <div className="mt-4 overflow-hidden rounded-xl border border-[var(--surface-border)]">
+                <table className="min-w-full" aria-label="API endpoint table">
+                  <thead className="sticky top-0 bg-[var(--surface-s1)] text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left">Endpoint</th>
+                      <th scope="col" className="px-4 py-3 text-right">Requests</th>
+                      <th scope="col" className="px-4 py-3 text-right">Share</th>
+                      <th scope="col" className="px-4 py-3 text-right">Latency</th>
+                      <th scope="col" className="px-4 py-3 text-right">Trend</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-sm text-[var(--text-primary)]">
+                    {endpointBreakdown.map((endpoint) => (
+                      <tr key={endpoint.endpoint} className="interactive-row">
+                        <td className="px-4 py-[12px]">
+                          <span className="truncate font-semibold" title={endpoint.endpoint}>
+                            {endpoint.endpoint}
+                          </span>
+                        </td>
+                        <td className="px-4 py-[12px] text-right text-[var(--text-secondary)]">{endpoint.requests}</td>
+                        <td className="px-4 py-[12px] text-right">{endpoint.share}</td>
+                        <td className="px-4 py-[12px] text-right">{endpoint.latency}</td>
+                        <td className="px-4 py-[12px] text-right" aria-label={endpoint.trend === '↑' ? 'Improving' : 'Flat'}>
+                          {endpoint.trend}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <AutomationBuilder
+            verticalAccent={accent}
+            className="h-full"
+            onCreate={async () => {
+              await new Promise((resolve) => setTimeout(resolve, 800));
+            }}
+          />
+
+          <Card className="h-full" role="region" aria-label="Automation orchestration">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-title-sm text-[var(--text-primary)]">Automation orchestration</h3>
+                <p className="text-xs text-[var(--text-secondary)]">Active runbooks with trigger, channel, and cadence at a glance.</p>
+              </div>
+              <Workflow className="h-5 w-5 text-[var(--primary-500)]" aria-hidden />
+            </div>
+            <div className="mt-5 space-y-3">
+              {automationSummary.map((automation) => (
+                <article
+                  key={automation.id}
+                  className="rounded-xl border border-[var(--surface-border)] bg-white/70 p-4 shadow-sm transition hover:border-[var(--primary-500)]"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">{automation.title}</p>
+                    <StatusChip label="Active" tone="success" />
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                    <span className="automation-pill" title={automation.trigger}>
+                      Trigger · {automation.trigger}
+                    </span>
+                    <span className="automation-pill" title={automation.action}>
+                      Action · {automation.action}
+                    </span>
+                    <span className="automation-pill" title={automation.channel}>
+                      Channel · {automation.channel}
+                    </span>
+                    <span className="automation-pill" title={automation.cadence}>
+                      Cadence · {automation.cadence}
+                    </span>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </Card>
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/portfolio-dashboard/frontend/src/app/globals.css
+++ b/portfolio-dashboard/frontend/src/app/globals.css
@@ -6,15 +6,24 @@
   :root {
     color-scheme: light;
     /* Surface hierarchy */
-    --surface-s0: #f3f4f7;
-    --surface-s1: #ffffff;
-    --surface-s2: rgba(255, 255, 255, 0.84);
+    --surface-s0: #ffffff;
+    --surface-s1: #f7f8fa;
+    --surface-s2: rgba(255, 255, 255, 0.9);
     --surface-s3: rgba(15, 23, 42, 0.08);
-    --surface-border: rgba(15, 23, 42, 0.12);
+    --surface-border: #e7eaf0;
     --surface-border-strong: rgba(15, 23, 42, 0.24);
-    --shadow-sm: 0 4px 18px rgba(15, 23, 42, 0.08);
-    --shadow-md: 0 12px 32px rgba(15, 23, 42, 0.12);
-    --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.16);
+    --divider-strong: rgba(15, 23, 42, 0.14);
+    --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.1);
+    --shadow-lg: 0 28px 64px rgba(15, 23, 42, 0.12);
+
+    /* Typography */
+    --font-body: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+    --font-size-base: 16px;
+    --font-line-height: 1.5;
+    --text-primary: #0b0d12;
+    --text-secondary: #5e6673;
+    --text-muted: #8a92a3;
 
     /* Semantic palette */
     --primary-50: #eef2ff;
@@ -22,69 +31,71 @@
     --primary-200: #c7d2fe;
     --primary-300: #a5b4fc;
     --primary-400: #818cf8;
-    --primary-500: #6366f1;
-    --primary-600: #4f46e5;
-    --primary-700: #4338ca;
-    --primary-800: #3730a3;
-    --primary-900: #312e81;
+    --primary-500: #3b82f6;
+    --primary-600: #2563eb;
+    --primary-700: #1d4ed8;
+    --primary-800: #1e40af;
+    --primary-900: #1e3a8a;
 
     --success-50: #ecfdf5;
-    --success-500: #10b981;
-    --success-600: #059669;
+    --success-500: #16a34a;
+    --success-600: #0f9f44;
 
     --warning-50: #fffbeb;
-    --warning-500: #f59e0b;
-    --warning-600: #d97706;
+    --warning-500: #d97706;
+    --warning-600: #b45309;
 
     --danger-50: #fef2f2;
-    --danger-500: #ef4444;
-    --danger-600: #dc2626;
+    --danger-500: #dc2626;
+    --danger-600: #b91c1c;
 
     --info-50: #eef7ff;
-    --info-500: #3b82f6;
-    --info-600: #2563eb;
+    --info-500: #2563eb;
+    --info-600: #1d4ed8;
 
     /* Vertical accents */
-    --vertical-saas: #4f46e5;
-    --vertical-commerce: #0f9d58;
+    --vertical-saas: #3b82f6;
+    --vertical-commerce: #10b981;
     --vertical-corporate: #1d4ed8;
     --vertical-custom: #9333ea;
     --vertical-content: #fb923c;
     --vertical-edtech: #db2777;
     --vertical-specialized: #475569;
 
-    /* Typography */
-    --font-body: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-    --font-size-base: 16px;
-    --font-line-height: 1.5;
-
     /* Motion */
     --motion-duration: 200ms;
-    --motion-ease: cubic-bezier(0.2, 0.0, 0.2, 1);
+    --motion-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+    --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+    --motion-ease-micro: cubic-bezier(0.2, 0.8, 0.4, 1);
 
     /* Focus */
-    --focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.45);
+    --focus-ring: 0 0 0 2px rgba(37, 99, 235, 0.35);
 
     /* Layout */
     --grid-gutter-desktop: 24px;
     --grid-gutter-tablet: 16px;
     --grid-gutter-mobile: 12px;
-    --radius-lg: 24px;
-    --radius-md: 16px;
-    --radius-sm: 12px;
+    --radius-lg: 18px;
+    --radius-md: 14px;
+    --radius-sm: 10px;
   }
 
   [data-theme='dark'] {
     color-scheme: dark;
     --surface-s0: #050814;
     --surface-s1: #0f172a;
-    --surface-s2: rgba(15, 23, 42, 0.88);
+    --surface-s2: rgba(15, 23, 42, 0.92);
     --surface-s3: rgba(148, 163, 184, 0.18);
-    --surface-border: rgba(148, 163, 184, 0.24);
-    --surface-border-strong: rgba(148, 163, 184, 0.35);
-    --shadow-sm: 0 4px 18px rgba(2, 6, 23, 0.35);
-    --shadow-md: 0 12px 36px rgba(2, 6, 23, 0.45);
-    --shadow-lg: 0 24px 80px rgba(2, 6, 23, 0.55);
+    --surface-border: rgba(148, 163, 184, 0.28);
+    --surface-border-strong: rgba(148, 163, 184, 0.4);
+    --divider-strong: rgba(148, 163, 184, 0.3);
+    --shadow-sm: 0 18px 40px rgba(2, 6, 23, 0.45);
+    --shadow-md: 0 28px 56px rgba(2, 6, 23, 0.55);
+    --shadow-lg: 0 36px 80px rgba(2, 6, 23, 0.65);
+
+    --text-primary: #f8fafc;
+    --text-secondary: #cbd5f5;
+    --text-muted: #94a3b8;
 
     --primary-50: #1e1b4b;
     --primary-100: #312e81;
@@ -121,7 +132,7 @@
     font-size: var(--font-size-base);
     line-height: var(--font-line-height);
     background: var(--surface-s0);
-    color: rgba(15, 23, 42, 0.88);
+    color: var(--text-primary);
     font-feature-settings: 'cv11' 1, 'tnum' 1, 'ss02' 1;
     font-variant-numeric: tabular-nums;
     transition: background var(--motion-duration) var(--motion-ease),
@@ -187,18 +198,19 @@
 
 @layer utilities {
   .glass-card {
-    background: var(--surface-s2);
-    backdrop-filter: saturate(160%) blur(28px);
-    border-radius: var(--radius-lg);
+    background: var(--surface-s1);
+    border-radius: 12px;
     border: 1px solid var(--surface-border);
     box-shadow: var(--shadow-sm);
     transition: transform var(--motion-duration) var(--motion-ease),
-      box-shadow var(--motion-duration) var(--motion-ease);
+      box-shadow var(--motion-duration) var(--motion-ease),
+      border-color var(--motion-duration) var(--motion-ease);
   }
 
   .glass-card:hover {
     transform: translateY(-2px);
     box-shadow: var(--shadow-md);
+    border-color: rgba(59, 130, 246, 0.4);
   }
 
   .kpi-value {
@@ -216,5 +228,161 @@
 
   .snap-item {
     scroll-snap-align: start;
+  }
+
+  .interactive-row {
+    position: relative;
+    transition: background var(--motion-duration) var(--motion-ease);
+  }
+
+  .interactive-row::before {
+    content: '';
+    position: absolute;
+    inset-block: 8px;
+    inset-inline-start: 0;
+    width: 0;
+    background: var(--primary-500);
+    border-radius: 12px;
+    transition: width 120ms var(--motion-ease);
+  }
+
+  .interactive-row:hover::before,
+  .interactive-row:focus-within::before {
+    width: 4px;
+  }
+
+  .interactive-row:hover,
+  .interactive-row:focus-within {
+    background: color-mix(in srgb, var(--primary-50) 35%, transparent);
+  }
+
+  .automation-pill {
+    background: color-mix(in srgb, var(--primary-50) 55%, transparent);
+    border-radius: 999px;
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    padding: 6px 14px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .automation-pill:hover {
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.35);
+  }
+
+  .automation-pill[data-state='paused'] {
+    background: color-mix(in srgb, var(--warning-50) 60%, transparent);
+    border-color: rgba(217, 119, 6, 0.35);
+  }
+
+  .automation-pill[data-state='danger'] {
+    background: color-mix(in srgb, var(--danger-50) 60%, transparent);
+    border-color: rgba(220, 38, 38, 0.35);
+  }
+
+  .motion-safe\:animate-header-intro {
+    animation: header-intro 160ms var(--motion-ease) both;
+  }
+
+  .motion-safe\:animate-section-scale {
+    animation: section-scale 200ms var(--motion-ease) both;
+  }
+
+  .motion-safe\:animate-kpi-card {
+    animation: kpi-stagger 260ms var(--motion-ease) both;
+  }
+
+  .motion-safe\:animate-chart-reveal {
+    animation: chart-reveal 400ms cubic-bezier(0.645, 0.045, 0.355, 1) both;
+  }
+
+  @keyframes header-intro {
+    from {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes section-scale {
+    from {
+      opacity: 0;
+      transform: scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes kpi-stagger {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes chart-reveal {
+    from {
+      opacity: 0;
+      clip-path: inset(0 100% 0 0);
+    }
+    to {
+      opacity: 1;
+      clip-path: inset(0 0 0 0);
+    }
+  }
+
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--surface-border) 25%, transparent);
+  }
+
+  .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.35) 50%, transparent 100%);
+    animation: shimmer 1.2s infinite;
+  }
+
+  @keyframes shimmer {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .motion-safe\:animate-header-intro,
+    .motion-safe\:animate-section-scale,
+    .motion-safe\:animate-kpi-card,
+    .motion-safe\:animate-chart-reveal {
+      animation: fade-in 140ms ease-out both;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    .skeleton::after {
+      animation-duration: 1.6s;
+    }
   }
 }

--- a/portfolio-dashboard/frontend/src/components/ui/Card.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/Card.tsx
@@ -8,8 +8,8 @@ type CardProps = HTMLAttributes<HTMLDivElement> & {
 
 const paddingMap: Record<NonNullable<CardProps['padding']>, string> = {
   sm: 'p-4',
-  md: 'p-6',
-  lg: 'p-8',
+  md: 'p-5',
+  lg: 'p-6',
 };
 
 export function Card({
@@ -21,7 +21,11 @@ export function Card({
 }: CardProps) {
   return (
     <Component
-      className={cn('glass-card relative overflow-hidden', paddingMap[padding], className)}
+      className={cn(
+        'glass-card relative overflow-hidden bg-[var(--surface-s1)] motion-safe:animate-section-scale',
+        paddingMap[padding],
+        className,
+      )}
       {...props}
     >
       {children}

--- a/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
@@ -34,7 +34,7 @@ export function ChartCard({
   toolbar,
   tone = 'default',
 }: ChartCardProps) {
-  const borderClass = tone === 'accent' ? 'border-[var(--primary-300)]/50' : 'border-[var(--surface-border)]';
+  const borderClass = tone === 'accent' ? 'border-[color:rgba(59,130,246,0.35)]' : 'border-[var(--surface-border)]';
 
   return (
     <Card
@@ -42,7 +42,7 @@ export function ChartCard({
       aria-labelledby={`${id}-title`}
       aria-describedby={ariaDescription ? `${id}-desc` : undefined}
       role="region"
-      className={cn('flex h-full flex-col gap-5 border bg-[var(--surface-s1)]', borderClass)}
+      className={cn('flex h-full flex-col gap-6 border shadow-sm', borderClass)}
     >
       <div className="flex flex-col gap-2">
         <div className="flex flex-wrap items-start justify-between gap-3">
@@ -56,11 +56,11 @@ export function ChartCard({
               </p>
             ) : null}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {toolbar}
             <button
               type="button"
-              className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+              className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-[var(--surface-border)] bg-white/60 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-[var(--primary-500)] hover:text-[var(--primary-600)] focus-visible:focus-ring"
               onClick={() => downloadAs('csv', `${id}.csv`, rows)}
             >
               <Download className="h-4 w-4" aria-hidden />
@@ -68,7 +68,7 @@ export function ChartCard({
             </button>
             <button
               type="button"
-              className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100/70 focus-visible:focus-ring"
+              className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-[var(--surface-border)] bg-white/60 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-[var(--primary-500)] hover:text-[var(--primary-600)] focus-visible:focus-ring"
               onClick={() => downloadAs('json', `${id}.json`, rows)}
             >
               <Download className="h-4 w-4" aria-hidden />
@@ -80,23 +80,36 @@ export function ChartCard({
       </div>
 
       <div className="flex flex-col gap-4">
-        <div role="figure" aria-labelledby={`${id}-title`} aria-describedby={ariaDescription ? `${id}-desc` : undefined}>
+        <div
+          role="figure"
+          aria-labelledby={`${id}-title`}
+          aria-describedby={ariaDescription ? `${id}-desc` : undefined}
+          className="motion-safe:animate-chart-reveal"
+        >
           {children}
         </div>
-        <div className="overflow-auto rounded-[18px] border border-dashed border-[var(--surface-border)]">
+        <div className="overflow-hidden rounded-xl border border-dashed border-[var(--surface-border)]">
           <table className="min-w-full divide-y divide-[var(--surface-border)]" aria-label={`${title} data table`}>
-            <thead className="bg-[var(--surface-s0)] text-xs uppercase tracking-[0.08em] text-slate-500">
+            <thead className="sticky top-0 z-10 bg-[var(--surface-s1)] text-xs font-medium uppercase tracking-[0.08em] text-slate-500">
               <tr>
                 {columns.map((column) => (
-                  <th key={column.key} className={cn('px-4 py-3 text-left', column.align === 'right' && 'text-right')}>
+                  <th
+                    key={column.key}
+                    className={cn('px-4 py-3 text-left', column.align === 'right' && 'text-right')}
+                    scope="col"
+                  >
                     {column.label}
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-[var(--surface-border)] bg-[var(--surface-s1)] text-sm text-slate-700">
+            <tbody className="bg-[var(--surface-s1)] text-sm text-slate-700">
               {rows.map((row, rowIndex) => (
-                <tr key={`${id}-row-${rowIndex}`} className="focus-within:bg-[var(--primary-50)]">
+                <tr
+                  key={`${id}-row-${rowIndex}`}
+                  className="interactive-row even:bg-white/60"
+                  style={{ animationDelay: `${rowIndex * 20}ms` }}
+                >
                   {columns.map((column) => (
                     <td
                       key={`${id}-row-${rowIndex}-${column.key}`}

--- a/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/KPIBand.tsx
@@ -16,8 +16,8 @@ const trendCopy: Record<MetricTrend, string> = {
 
 export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
   return (
-    <div className="-mx-4 flex snap-band gap-4 overflow-x-auto px-4 pb-2 pt-1 sm:mx-0 sm:px-0">
-      {metrics.map((metric) => {
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric, index) => {
         const Icon =
           metric.trend === 'up' ? ArrowUpRight : metric.trend === 'down' ? ArrowDownRight : Minus;
         const tone =
@@ -31,34 +31,41 @@ export function KPIBand({ metrics, accentToken, onInspect }: KPIBandProps) {
             key={metric.id}
             type="button"
             onClick={() => onInspect?.(metric)}
-            className="snap-item min-w-[260px] flex-1 rounded-[20px] border border-[color:var(--surface-border)] bg-[var(--surface-s1)] p-5 text-left shadow-sm transition focus-visible:focus-ring"
-            style={{
-              boxShadow: '0 18px 36px rgba(79, 70, 229, 0.08)',
-            }}
+            className="group relative flex min-h-[152px] flex-col justify-between gap-4 rounded-xl border border-[var(--surface-border)] bg-[var(--surface-s1)] p-5 text-left shadow-sm transition focus-visible:focus-ring motion-safe:animate-kpi-card"
+            style={{ animationDelay: `${index * 80}ms` }}
           >
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[13px] font-medium uppercase tracking-[0.18em] text-slate-500">
                 {metric.label}
               </p>
               {metric.trend ? (
                 <span
-                  className={cn('inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold', tone)}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-full px-2 py-[6px] text-[11px] font-semibold transition',
+                    tone,
+                  )}
                   aria-label={trendCopy[metric.trend]}
                 >
                   <Icon className="h-3.5 w-3.5" aria-hidden />
-                  {metric.change != null ? `${metric.change > 0 ? '+' : ''}${metric.change.toFixed(1)}%` : trendCopy[metric.trend]}
+                  {metric.change != null
+                    ? `${metric.change > 0 ? '+' : ''}${metric.change.toFixed(1)}%`
+                    : trendCopy[metric.trend]}
                 </span>
               ) : null}
             </div>
             <p
-              className="kpi-value mt-3 text-3xl font-semibold"
+              className="kpi-value text-[28px] font-bold leading-[32px] tracking-[-0.01em] text-[var(--text-primary)]"
               style={{ color: `var(${accentToken})` }}
             >
               {metric.value}
             </p>
             {metric.description ? (
-              <p className="mt-2 text-xs text-slate-600">{metric.description}</p>
+              <p className="text-xs text-[var(--text-secondary)]">{metric.description}</p>
             ) : null}
+            <span
+              className="pointer-events-none absolute inset-x-5 bottom-5 h-0.5 origin-left scale-x-0 bg-[var(--surface-border)] transition group-hover:scale-x-100"
+              aria-hidden
+            />
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- polish the SaaS module automation orchestration so active workflows read as pill summaries with trigger, condition, action, channel, and cadence metadata
- redesign the commerce module header, analytics grid, sales legend, channel mix, and automation cards to follow the new 12-column layout and teal accent palette
- extend shared styling primitives (global tokens, card, chart card, KPI band) to support the refreshed typography, padding, and motion/interaction system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da7ee0e6d0832ea817cf962e92510c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls SaaS, Commerce, and Corporate modules with new charts/tables and automation summaries, and updates global design tokens plus Card/ChartCard/KPIBand for the refreshed visual/motion system.
> 
> - **Modules**:
>   - **SaaS**: New executive header; revamped subscription table; computed `churnTrend` area chart with renewal legend; MRR growth (area) and plan-level MRR breakdown table; API usage trend (area) with endpoint ranking table; active automation summaries (pill-style) and builder integration.
>   - **Commerce**: New header and inline filters; refreshed top products table; sales trend (area) with legend; channel mix donut and regional performance bar chart; compact automation cards.
>   - **Corporate**: Reworked to use SaaS-style overview (retention/churn, MRR growth/breakdown, API usage/endpoint tables, automation orchestration).
> - **UI Components**:
>   - `Card`: Tweaked padding defaults and adds animated entry; consistent surface styling.
>   - `ChartCard`: Updated borders/toolbar styles, sticky table header, interactive rows, and chart reveal animation.
>   - `KPIBand`: Switch to responsive grid, refined typography/hover, and staggered motion.
>   - New `InlineFilterPill` for inline filter display.
> - **Styling**:
>   - `globals.css`: Revamped tokens (surfaces, borders `--surface-border:#e7eaf0`, shadows, typography vars, text colors), adjusted primary/success/warning/danger/info palettes, vertical accents, motion curves, focus ring, radii; added utilities (`interactive-row`, `automation-pill`, animations, `skeleton`).
>   - Minor icon additions (e.g., `CalendarRange`, `Clock3`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046ff3c68ab703457369335cb278179b4439f8c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->