### PR TITLE
Add live generated timestamp system to dashboard header

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -60,6 +60,7 @@ import { Card } from '@/components/ui/Card';
 import { ChartCard } from '@/components/ui/ChartCard';
 import { AutomationBuilder } from '@/components/ui/AutomationBuilder';
 import { StatusChip } from '@/components/ui/StatusChip';
+import { GeneratedAtStamp, type GeneratedStatus } from '@/components/ui/GeneratedAtStamp';
 import { useToast } from '@/components/ui/ToastProvider';
 import { cn } from '@/lib/utils';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
@@ -3103,13 +3104,154 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
   const router = useRouter();
   const [isReady, setIsReady] = useState(false);
 
-  const { data } = useQuery({
+  const { data, refetch, isFetching, isError } = useQuery({
     queryKey: ['portfolio-dashboard'],
     queryFn: fetchPortfolioDashboard,
     initialData,
+    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 
+  const timezone = useMemo(() => {
+    if (typeof Intl === 'undefined') return 'UTC';
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (error) {
+      return 'UTC';
+    }
+  }, []);
+
+  const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
+  const [generatedStatus, setGeneratedStatus] = useState<GeneratedStatus>('ready');
+  const [displayTimestamp, setDisplayTimestamp] = useState<string | null>(initialData.generatedAt ?? null);
+  const [lastGoodTimestamp, setLastGoodTimestamp] = useState<string | null>(initialData.generatedAt ?? null);
+  const lastGoodTimestampRef = useRef<string | null>(initialData.generatedAt ?? null);
+  const filterChangeRef = useRef(false);
+
   useLiveMetrics();
+
+  const handleRefresh = useCallback(async () => {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      setGeneratedStatus('offline');
+      return;
+    }
+
+    setGeneratedStatus('loading');
+
+    try {
+      const result = await refetch({ throwOnError: true });
+      const nextTimestamp =
+        result.data?.generatedAt ?? lastGoodTimestampRef.current ?? new Date().toISOString();
+      lastGoodTimestampRef.current = nextTimestamp;
+      setLastGoodTimestamp(nextTimestamp);
+      setDisplayTimestamp(nextTimestamp);
+      setGeneratedStatus('ready');
+    } catch (error) {
+      setGeneratedStatus('stale');
+      setDisplayTimestamp(lastGoodTimestampRef.current);
+    }
+  }, [refetch]);
+
+  useEffect(() => {
+    if (!data?.generatedAt) return;
+    lastGoodTimestampRef.current = data.generatedAt;
+    setLastGoodTimestamp(data.generatedAt);
+    setDisplayTimestamp(data.generatedAt);
+    setGeneratedStatus((previous) => {
+      if (previous === 'offline') {
+        return previous;
+      }
+      return 'ready';
+    });
+  }, [data?.generatedAt]);
+
+  useEffect(() => {
+    if (isError) {
+      setGeneratedStatus('stale');
+    }
+  }, [isError]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleOffline = () => setGeneratedStatus('offline');
+    const handleOnline = () =>
+      setGeneratedStatus((previous) => (previous === 'stale' ? 'stale' : 'ready'));
+
+    if (!window.navigator.onLine) {
+      setGeneratedStatus('offline');
+    }
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
+  const filterSignature = useMemo(
+    () =>
+      `${selectedModule}|${filters.dateRange}|${filters.segment ?? 'all'}|${filters.channel ?? 'global'}`,
+    [filters.channel, filters.dateRange, filters.segment, selectedModule]
+  );
+
+  useEffect(() => {
+    if (!filterChangeRef.current) {
+      filterChangeRef.current = true;
+      return;
+    }
+    void handleRefresh();
+  }, [filterSignature, handleRefresh]);
+
+  useEffect(() => {
+    if (!autoRefreshEnabled) return;
+    const interval = window.setInterval(() => {
+      void handleRefresh();
+    }, 5 * 60 * 1000);
+    return () => window.clearInterval(interval);
+  }, [autoRefreshEnabled, handleRefresh]);
+
+  const handleToggleAutoRefresh = useCallback(() => {
+    setAutoRefreshEnabled((previous) => !previous);
+  }, []);
+
+  const handleManualRefresh = useCallback(() => {
+    if (generatedStatus === 'loading' || isFetching) return;
+    void handleRefresh();
+  }, [generatedStatus, handleRefresh, isFetching]);
+
+  const moduleLabel = useMemo(
+    () => data?.tabs.find((tab) => tab.id === selectedModule)?.label ?? 'SaaS Platform',
+    [data?.tabs, selectedModule]
+  );
+
+  const dateRangeLabel = useMemo(() => {
+    const option = dateRangeOptions.find((item) => item.id === filters.dateRange);
+    return option?.label ?? 'Last 30 days';
+  }, [filters.dateRange]);
+
+  const segmentLabel = useMemo(() => {
+    const option = segmentOptions.find((item) => item.id === (filters.segment ?? 'all'));
+    return option?.label ?? 'All segments';
+  }, [filters.segment]);
+
+  const channelLabel = useMemo(() => {
+    const option = channelOptions.find((item) => item.id === (filters.channel ?? 'global'));
+    return option?.label ?? 'Global';
+  }, [filters.channel]);
+
+  const contextSummary = useMemo(
+    () => `Module: ${moduleLabel} • ${dateRangeLabel} • ${segmentLabel} • ${channelLabel}`,
+    [channelLabel, dateRangeLabel, moduleLabel, segmentLabel]
+  );
+
+  const statusForStamp: GeneratedStatus = useMemo(() => {
+    if (generatedStatus === 'offline') return 'offline';
+    if (generatedStatus === 'stale') return 'stale';
+    if (generatedStatus === 'loading' || isFetching) return 'loading';
+    return 'ready';
+  }, [generatedStatus, isFetching]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => setIsReady(true));
@@ -3202,6 +3344,17 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
               </div>
             </div>
             <div className="col-span-12 lg:col-span-4 flex flex-col items-start gap-4 lg:items-end">
+              <GeneratedAtStamp
+                timestamp={displayTimestamp}
+                lastGoodTimestamp={lastGoodTimestamp}
+                status={statusForStamp}
+                timezone={timezone}
+                contextSummary={contextSummary}
+                autoRefreshEnabled={autoRefreshEnabled}
+                onToggleAutoRefresh={handleToggleAutoRefresh}
+                onRefresh={handleManualRefresh}
+                isRefreshing={statusForStamp === 'loading'}
+              />
               <div className="flex flex-wrap items-center justify-end gap-2">
                 <button
                   type="button"
@@ -3228,9 +3381,6 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                 <Sparkles className="h-4 w-4" aria-hidden />
                 {data.hero.cta}
               </button>
-              <div className="rounded-xl border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-[12px] text-[var(--neutral-600,#5e6673)]">
-                Generated at {new Date(data.generatedAt).toLocaleString()}
-              </div>
             </div>
           </div>
           <div className="mt-8 flex flex-wrap items-center gap-3">

--- a/portfolio-dashboard/frontend/src/components/ui/GeneratedAtStamp.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/GeneratedAtStamp.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Clock3, RefreshCcw, WifiOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+type GeneratedStatus = 'loading' | 'ready' | 'stale' | 'offline';
+
+type GeneratedAtStampProps = {
+  timestamp: string | null;
+  lastGoodTimestamp: string | null;
+  status: GeneratedStatus;
+  timezone: string;
+  contextSummary: string;
+  autoRefreshEnabled: boolean;
+  onToggleAutoRefresh: () => void;
+  onRefresh: () => void;
+  isRefreshing: boolean;
+};
+
+function formatDisplay(timestamp: string | null, timezone: string) {
+  if (!timestamp) return '—';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '—';
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: true,
+      timeZone: timezone,
+    }).format(date);
+  } catch (error) {
+    return date.toLocaleString();
+  }
+}
+
+function getRelativeLabel(timestamp: string | null) {
+  if (!timestamp) return 'Unknown';
+  const now = Date.now();
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  const diff = Math.max(0, now - date.getTime());
+  const minutes = Math.floor(diff / 60000);
+  const seconds = Math.floor((diff % 60000) / 1000);
+  if (minutes <= 0) {
+    if (seconds <= 5) return 'Updated just now';
+    return `Updated ${seconds}s ago`;
+  }
+  if (minutes < 60) {
+    return `Updated ${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Updated ${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Updated ${days}d ago`;
+}
+
+function getFreshnessTone(timestamp: string | null) {
+  if (!timestamp) return 'warning';
+  const diff = Date.now() - new Date(timestamp).getTime();
+  if (Number.isNaN(diff)) return 'warning';
+  if (diff <= 5 * 60 * 1000) return 'positive';
+  if (diff <= 10 * 60 * 1000) return 'neutral';
+  return 'warning';
+}
+
+export function GeneratedAtStamp({
+  timestamp,
+  lastGoodTimestamp,
+  status,
+  timezone,
+  contextSummary,
+  autoRefreshEnabled,
+  onToggleAutoRefresh,
+  onRefresh,
+  isRefreshing,
+}: GeneratedAtStampProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [relativeLabel, setRelativeLabel] = useState(() => getRelativeLabel(timestamp));
+
+  useEffect(() => {
+    setRelativeLabel(getRelativeLabel(timestamp));
+    if (prefersReducedMotion) return;
+    const interval = window.setInterval(() => {
+      setRelativeLabel(getRelativeLabel(timestamp));
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [prefersReducedMotion, timestamp]);
+
+  const tone = getFreshnessTone(lastGoodTimestamp ?? timestamp);
+
+  const tooltip = useMemo(() => {
+    const iso = lastGoodTimestamp ? new Date(lastGoodTimestamp).toISOString() : 'n/a';
+    return `${iso}\n${timezone}\n${contextSummary}`;
+  }, [contextSummary, lastGoodTimestamp, timezone]);
+
+  const displayTimestamp = formatDisplay(timestamp ?? lastGoodTimestamp, timezone);
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case 'loading':
+        return 'Generating…';
+      case 'offline':
+        return 'Offline cache';
+      case 'stale':
+        return 'Showing last good data';
+      default:
+        return 'Generated at';
+    }
+  }, [status]);
+
+  const freshnessClasses = cn(
+    'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.08em]',
+    tone === 'positive' && 'border-[rgba(22,163,74,0.35)] bg-[rgba(22,163,74,0.08)] text-[#166534]',
+    tone === 'neutral' && 'border-[rgba(59,130,246,0.28)] bg-[rgba(59,130,246,0.08)] text-[#1d4ed8]',
+    tone === 'warning' && 'border-[rgba(217,119,6,0.35)] bg-[rgba(217,119,6,0.12)] text-[#b45309]'
+  );
+
+  return (
+    <div className="flex flex-col items-end gap-3 text-right">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <span className={freshnessClasses}>
+          <Clock3 className="h-3.5 w-3.5" aria-hidden />
+          {relativeLabel}
+        </span>
+        <button
+          type="button"
+          onClick={onToggleAutoRefresh}
+          aria-pressed={autoRefreshEnabled}
+          className={cn(
+            'inline-flex min-h-[32px] items-center gap-2 rounded-full border px-3 py-1 text-[12px] font-medium transition focus-visible:focus-ring',
+            autoRefreshEnabled
+              ? 'border-[rgba(59,130,246,0.45)] bg-[rgba(59,130,246,0.12)] text-[var(--primary-600)]'
+              : 'border-[var(--surface-border)] bg-[var(--surface-s1)] text-[var(--neutral-600,#5e6673)] hover:border-[var(--primary-300)]'
+          )}
+        >
+          <RefreshCcw className="h-3.5 w-3.5" aria-hidden />
+          {autoRefreshEnabled ? 'Auto-refresh on' : 'Auto-refresh off'}
+        </button>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          aria-busy={isRefreshing}
+          className={cn(
+            'inline-flex min-h-[32px] items-center gap-2 rounded-full border border-[var(--surface-border)] bg-[var(--surface-s1)] px-3 py-1 text-[12px] font-medium text-[var(--neutral-700,#384150)] transition hover:border-[var(--primary-300)] hover:text-[var(--primary-600)] focus-visible:focus-ring',
+            isRefreshing && 'cursor-not-allowed opacity-60'
+          )}
+        >
+          <span className="inline-flex items-center gap-1">
+            <RefreshCcw className="h-3.5 w-3.5" aria-hidden />
+            Refresh now
+          </span>
+        </button>
+      </div>
+      <div
+        className={cn(
+          'generated-at-token inline-flex items-center gap-3 rounded-[12px] border px-4 py-3 text-[12px] transition',
+          status === 'loading' && 'border-[rgba(59,130,246,0.4)] bg-[rgba(59,130,246,0.08)] text-[var(--primary-600)]',
+          status === 'stale' && 'border-[rgba(217,119,6,0.4)] bg-[rgba(217,119,6,0.08)] text-[#b45309]',
+          status === 'offline' && 'border-[rgba(71,85,105,0.5)] bg-[rgba(71,85,105,0.08)] text-[#334155]',
+          status === 'ready' && 'border-[var(--surface-border)] bg-[var(--surface-s1)] text-[var(--neutral-600,#5e6673)]'
+        )}
+        title={tooltip}
+        role="status"
+        aria-live={status === 'loading' ? 'polite' : 'off'}
+      >
+        {status === 'loading' ? (
+          <span className="flex items-center gap-2">
+            <span className="relative flex h-3 w-3 items-center justify-center">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--primary-500)] opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--primary-600)]" />
+            </span>
+            {statusLabel}
+          </span>
+        ) : null}
+        {status === 'stale' ? (
+          <span className="inline-flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" aria-hidden />
+            {statusLabel}
+          </span>
+        ) : null}
+        {status === 'offline' ? (
+          <span className="inline-flex items-center gap-2">
+            <WifiOff className="h-4 w-4" aria-hidden />
+            {statusLabel}
+          </span>
+        ) : null}
+        {status === 'ready' ? (
+          <span className="inline-flex items-center gap-2">
+            <Clock3 className="h-4 w-4" aria-hidden />
+            {statusLabel}
+          </span>
+        ) : null}
+        <span className="font-semibold text-[var(--neutral-900,#0b0d12)] dark:text-[rgba(233,236,242,0.94)]">
+          {displayTimestamp}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export type { GeneratedStatus };
+


### PR DESCRIPTION
## Summary
- add a GeneratedAtStamp UI component with freshness chip, tooltip context, and refresh controls
- integrate the stamp into the dashboard header with auto-refresh, manual refresh, and offline/stale handling based on global filters
- propagate filter, module, and timezone context for the tooltip while preserving the existing data model

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daa4281bc4832e952359cb76644845

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a context-aware generated-at status component and integrates it into the dashboard with auto/manual refresh, filter-driven refetching, and offline/stale states.
> 
> - **UI**:
>   - `components/ui/GeneratedAtStamp.tsx`: New component showing generated time with freshness chip, tooltip (timezone + context), and controls for auto-refresh and manual refresh; supports `loading`, `ready`, `stale`, and `offline` states.
> - **Dashboard**:
>   - `app/dashboard/DashboardClient.tsx`:
>     - Integrates `GeneratedAtStamp` in the header; removes static "Generated at ..." block.
>     - Enhances React Query usage with `refetch`, `isFetching`, `isError`, `refetchOnWindowFocus: false`, `staleTime: 0`.
>     - Adds auto-refresh interval (5m), manual refresh handler, and filter-change-triggered refetch.
>     - Tracks `generatedStatus`, last good/display timestamps; listens to online/offline events.
>     - Computes timezone and context summary (module/date/segment/channel) for tooltip display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0a9e675eeeef059cda8d310cfc909849e408c1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->