### PR TITLE
Improve RTL ergonomics for dashboard header and controls

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -1185,6 +1185,7 @@ function GeneratedAtIndicator({
           <button
             type="button"
             className="generated-at-button"
+            dir="ltr"
             onMouseEnter={() => setTooltipOpen(true)}
             onMouseLeave={() => setTooltipOpen(false)}
             onFocus={() => setTooltipOpen(true)}
@@ -3580,6 +3581,7 @@ function getModuleMetrics(
 
 export default function DashboardClient({ initialData }: DashboardClientProps) {
   const { theme, toggleTheme, direction, setDirection } = useThemeContext();
+  const isRtl = direction === 'rtl';
   const { selectedModule, setModule, filters, setFilters } = useDashboardStore();
   const { push } = useToast();
   const router = useRouter();
@@ -3673,48 +3675,62 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
       <header className="border-b border-[var(--surface-border)] bg-[var(--surface-s0)]/95 backdrop-blur">
         <div className="mx-auto max-w-7xl px-6 py-8">
           <div className={cn('grid grid-cols-12 gap-6', isReady && 'animate-dashboard-header')}>
-            <div className="col-span-12 lg:col-span-8 space-y-4">
-              <div>
-                <p className="text-[12px] font-medium uppercase tracking-[0.18em] text-[var(--neutral-500,#5e6673)]">
-                  Portfolio-grade product operations
-                </p>
-                <h1 className="text-[32px] font-semibold text-[var(--neutral-900,#0b0d12)]">
-                  {data.hero.title}
-                </h1>
-                <p className="mt-2 max-w-3xl text-[14px] text-[var(--neutral-600,#5e6673)]">{data.hero.description}</p>
-              </div>
-              <div className="flex flex-wrap gap-3">
-                <SegmentedTabs tabs={data.tabs} activeId={selectedModule} onChange={setModule} />
-                <div className="h-px flex-1 self-center border-t border-dashed border-[var(--surface-border)]" aria-hidden />
-              </div>
+          <div className={cn('col-span-12 lg:col-span-8 space-y-4', isRtl && 'text-right')}>
+            <div>
+              <p className="text-[12px] font-medium uppercase tracking-[0.18em] text-[var(--neutral-500,#5e6673)]">
+                Portfolio-grade product operations
+              </p>
+              <h1 className="text-[32px] font-semibold text-[var(--neutral-900,#0b0d12)]">
+                {data.hero.title}
+              </h1>
+              <p className="mt-2 max-w-3xl text-[14px] text-[var(--neutral-600,#5e6673)]">{data.hero.description}</p>
             </div>
-            <div className="col-span-12 lg:col-span-4 flex flex-col items-start gap-4 lg:items-end">
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <button
-                  type="button"
-                  className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-4 py-2 text-sm font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
-                  onClick={toggleTheme}
-                >
+            <div className={cn('flex flex-wrap gap-3', isRtl && 'flex-row-reverse justify-end')}>
+              <SegmentedTabs tabs={data.tabs} activeId={selectedModule} onChange={setModule} />
+              <div className="h-px flex-1 self-center border-t border-dashed border-[var(--surface-border)]" aria-hidden />
+            </div>
+          </div>
+          <div
+            className={cn(
+              'col-span-12 lg:col-span-4 flex flex-col gap-4',
+              isRtl ? 'items-end lg:items-start text-right' : 'items-start lg:items-end'
+            )}
+          >
+            <div
+              className={cn(
+                'flex flex-wrap items-center gap-2',
+                isRtl ? 'flex-row-reverse justify-start' : 'justify-end'
+              )}
+            >
+              <button
+                type="button"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-4 py-2 text-sm font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
+                onClick={toggleTheme}
+              >
                   {theme === 'dark' ? <Sun className="h-4 w-4" aria-hidden /> : <Moon className="h-4 w-4" aria-hidden />}
                   {theme === 'dark' ? 'Light mode' : 'Dark mode'}
                 </button>
-                <button
-                  type="button"
-                  className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-4 py-2 text-sm font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
-                  onClick={() => setDirection(direction === 'ltr' ? 'rtl' : 'ltr')}
-                >
-                  <Earth className="h-4 w-4" aria-hidden />
-                  {direction === 'ltr' ? 'Switch to RTL' : 'Switch to LTR'}
-                </button>
-              </div>
               <button
                 type="button"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-[var(--primary-600)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-500)] focus-visible:focus-ring"
-                onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-4 py-2 text-sm font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
+                onClick={() => setDirection(direction === 'ltr' ? 'rtl' : 'ltr')}
               >
-                <Sparkles className="h-4 w-4" aria-hidden />
-                {data.hero.cta}
+                <Earth className="h-4 w-4" aria-hidden />
+                {direction === 'ltr' ? 'Switch to RTL' : 'Switch to LTR'}
               </button>
+            </div>
+            <button
+              type="button"
+              className={cn(
+                'inline-flex min-h-[44px] items-center gap-2 rounded-full bg-[var(--primary-600)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-500)] focus-visible:focus-ring',
+                isRtl ? 'self-start' : 'self-end'
+              )}
+              onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
+            >
+              <Sparkles className="h-4 w-4" aria-hidden />
+              {data.hero.cta}
+            </button>
+            <div className={cn('w-full', isRtl ? 'self-start' : 'self-end')}>
               <GeneratedAtIndicator
                 moduleId={selectedModule}
                 moduleLabel={currentModuleLabel}
@@ -3723,12 +3739,18 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
               />
             </div>
           </div>
-          <div className="mt-8 flex flex-wrap items-center gap-3">
-            {dateRangeOptions.map((option) => (
-              <FilterChip
-                key={option.id}
-                label={option.label}
-                active={filters.dateRange === option.id}
+        </div>
+        <div
+          className={cn(
+            'mt-8 flex flex-wrap items-center gap-3',
+            isRtl && 'flex-row-reverse justify-end text-right'
+          )}
+        >
+          {dateRangeOptions.map((option) => (
+            <FilterChip
+              key={option.id}
+              label={option.label}
+              active={filters.dateRange === option.id}
                 onClick={() => setFilters({ dateRange: option.id as typeof filters.dateRange })}
                 icon={filters.dateRange === option.id ? <Check className="h-4 w-4" aria-hidden /> : undefined}
               />

--- a/portfolio-dashboard/frontend/src/app/globals.css
+++ b/portfolio-dashboard/frontend/src/app/globals.css
@@ -17,6 +17,11 @@
     --shadow-lg: 0 40px 90px rgba(11, 13, 18, 0.14);
 
     /* Semantic palette */
+    --neutral-400: #8b95a7;
+    --neutral-500: #5e6673;
+    --neutral-600: #4b5563;
+    --neutral-700: #384150;
+    --neutral-900: #0b0d12;
     --primary-50: #edf2ff;
     --primary-100: #dbeafe;
     --primary-200: #bfdbfe;
@@ -111,6 +116,14 @@
     --info-50: #0b192f;
     --info-500: #60a5fa;
     --info-600: #3b82f6;
+
+    --neutral-400: rgba(148, 163, 184, 0.88);
+    --neutral-500: rgba(203, 213, 225, 0.86);
+    --neutral-600: rgba(226, 232, 240, 0.85);
+    --neutral-700: rgba(226, 232, 240, 0.92);
+    --neutral-900: rgba(248, 250, 252, 0.96);
+
+    --vertical-content: #f08a2d;
   }
 
   [data-theme='dark'] body {
@@ -327,6 +340,11 @@
     transform: translateY(6px);
     transition: opacity 0.16s ease, transform 0.16s ease;
     z-index: 10;
+  }
+
+  [dir='rtl'] .freshness-tooltip {
+    inset-inline-end: auto;
+    inset-inline-start: 0;
   }
 
   .freshness-tooltip--visible {
@@ -591,6 +609,14 @@
   .legend-chip:hover {
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
     transform: translateY(-1px);
+  }
+
+  .section-caption {
+    letter-spacing: 0.01em;
+  }
+
+  [data-theme='dark'] .section-caption {
+    letter-spacing: -0.02em;
   }
 
   .story-row {

--- a/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { Download } from 'lucide-react';
 import { Card } from './Card';
 import { cn, downloadAs } from '@/lib/utils';
+import { useThemeContext } from '@/components/theme/ThemeProvider';
 
 type Column = {
   key: string;
@@ -37,6 +38,9 @@ export function ChartCard({
   className,
 }: ChartCardProps) {
   const borderClass = tone === 'accent' ? 'border-[var(--primary-300)]/50' : 'border-[var(--surface-border)]';
+  const { direction } = useThemeContext();
+  const isRtl = direction === 'rtl';
+  const downloadIconClass = cn('h-4 w-4', isRtl && 'scale-x-[-1]');
 
   return (
     <Card
@@ -51,7 +55,7 @@ export function ChartCard({
       )}
     >
       <div className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className={cn('flex flex-wrap items-start justify-between gap-4', isRtl && 'text-right')}>
           <div className="space-y-1">
             {description ? (
               <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-[var(--neutral-500,#5e6673)]">
@@ -61,16 +65,21 @@ export function ChartCard({
             <h3 id={`${id}-title`} className="text-[18px] font-semibold text-[var(--neutral-900,#0b0d12)]">
               {title}
             </h3>
-            {caption ? <p className="text-xs text-[var(--neutral-600,#5e6673)]">{caption}</p> : null}
+            {caption ? <p className="section-caption text-xs text-[var(--neutral-600,#5e6673)]">{caption}</p> : null}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div
+            className={cn(
+              'flex flex-wrap items-center gap-2',
+              isRtl ? 'flex-row-reverse justify-start' : 'justify-end'
+            )}
+          >
             {toolbar}
             <button
               type="button"
               className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-2 text-[12px] font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
               onClick={() => downloadAs('csv', `${id}.csv`, rows)}
             >
-              <Download className="h-4 w-4" aria-hidden />
+              <Download className={downloadIconClass} aria-hidden />
               Export CSV
             </button>
             <button
@@ -78,7 +87,7 @@ export function ChartCard({
               className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-3 py-2 text-[12px] font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
               onClick={() => downloadAs('json', `${id}.json`, rows)}
             >
-              <Download className="h-4 w-4" aria-hidden />
+              <Download className={downloadIconClass} aria-hidden />
               Export JSON
             </button>
           </div>

--- a/portfolio-dashboard/frontend/src/components/ui/FilterChip.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/FilterChip.tsx
@@ -1,4 +1,6 @@
+import { cloneElement, isValidElement } from 'react';
 import { cn } from '@/lib/utils';
+import { useThemeContext } from '@/components/theme/ThemeProvider';
 
 type FilterChipProps = {
   label: string;
@@ -8,19 +10,30 @@ type FilterChipProps = {
 };
 
 export function FilterChip({ label, active = false, onClick, icon }: FilterChipProps) {
+  const { direction } = useThemeContext();
+  const isRtl = direction === 'rtl';
+
+  const renderedIcon =
+    icon && isValidElement(icon)
+      ? cloneElement(icon, {
+          className: cn(icon.props.className, isRtl && 'scale-x-[-1]'),
+        })
+      : icon;
+
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
         'inline-flex min-h-[44px] items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:focus-ring',
+        isRtl && 'flex-row-reverse text-right',
         active
           ? 'border-[var(--primary-500)] bg-[var(--primary-50)] text-[var(--primary-600)]'
           : 'border-[var(--surface-border)] text-slate-600 hover:bg-slate-100/60'
       )}
       aria-pressed={active}
     >
-      {icon}
+      {renderedIcon}
       {label}
     </button>
   );

--- a/portfolio-dashboard/frontend/src/components/ui/SegmentedTabs.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/SegmentedTabs.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils';
 import type { TabDefinition } from '@/app/dashboard/data';
+import { useThemeContext } from '@/components/theme/ThemeProvider';
 
 type SegmentedTabsProps = {
   tabs: TabDefinition[];
@@ -8,9 +9,15 @@ type SegmentedTabsProps = {
 };
 
 export function SegmentedTabs({ tabs, activeId, onChange }: SegmentedTabsProps) {
+  const { direction } = useThemeContext();
+  const isRtl = direction === 'rtl';
+
   return (
     <div
-      className="flex w-full flex-wrap items-center justify-between gap-4 rounded-[24px] border border-[var(--surface-border)] bg-[var(--surface-s1)] p-2"
+      className={cn(
+        'flex w-full flex-wrap items-center justify-between gap-4 rounded-[24px] border border-[var(--surface-border)] bg-[var(--surface-s1)] p-2',
+        isRtl && 'flex-row-reverse text-right'
+      )}
       role="tablist"
       aria-label="Dashboard modules"
     >
@@ -26,6 +33,7 @@ export function SegmentedTabs({ tabs, activeId, onChange }: SegmentedTabsProps) 
             onClick={() => onChange(tab.id)}
             className={cn(
               'flex min-w-[160px] flex-1 items-center justify-center gap-2 rounded-[18px] px-4 py-3 text-sm font-semibold transition focus-visible:focus-ring',
+              isRtl && 'flex-row-reverse text-right',
               isActive
                 ? 'bg-gradient-to-r from-[var(--primary-500)] to-[var(--primary-600)] text-white shadow-md'
                 : 'text-slate-600 hover:bg-slate-100/80'


### PR DESCRIPTION
## Summary
- align the hero header actions, filter chips, segmented tabs, and chart toolbars based on the active text direction to improve RTL support
- mirror pill icons, export affordances, and the generated-at tooltip orientation so controls read naturally from right to left while keeping timestamps left-to-right
- refresh dark theme neutral tokens and section caption spacing for clearer typography in low-light mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dab17cc778832e9538a90fd849db27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add RTL-aware layout and icon mirroring across header, tabs, chips, and chart toolbars; keep timestamps LTR and fix tooltip RTL positioning; tweak dark-theme neutrals and caption spacing.
> 
> - **Dashboard (frontend/src/app/dashboard/DashboardClient.tsx)**
>   - RTL-aware layout: conditionally apply `text-right`, `flex-row-reverse`, and alignment classes for header, action buttons, segmented tabs, and filter chips.
>   - Reordered/realigned hero actions and CTA per direction; aligned `GeneratedAtIndicator` container accordingly.
>   - Keep timestamps LTR by adding `dir="ltr"` on `generated-at-button`.
> - **UI Components**
>   - `components/ui/SegmentedTabs.tsx`: Add RTL support (`flex-row-reverse`, `text-right`).
>   - `components/ui/FilterChip.tsx`: Add RTL support and mirror icons via `scale-x-[-1]` when applicable.
>   - `components/ui/ChartCard.tsx`: Add RTL support for header/toolbar; mirror download icons; use `section-caption` for captions.
> - **Styles (frontend/src/app/globals.css)**
>   - Add RTL positioning override for `.freshness-tooltip` using logical inset properties.
>   - Update dark-theme neutral tokens and introduce `--vertical-content` token.
>   - Add `.section-caption` with direction-aware letter-spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc9ed023f8a1f92962e16a002a4736f32e3d0ffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->