### PR TITLE
Improve dark RTL layout for dashboard header and controls

### DIFF
--- a/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/portfolio-dashboard/frontend/src/app/dashboard/DashboardClient.tsx
@@ -920,11 +920,15 @@ function GeneratedAtIndicator({
   moduleLabel,
   filters,
   initialGeneratedAt,
+  direction,
+  className,
 }: {
   moduleId: TabDefinition['id'];
   moduleLabel: string;
   filters: Filters;
   initialGeneratedAt: string;
+  direction: 'ltr' | 'rtl';
+  className?: string;
 }) {
   const prefersReducedMotion = usePrefersReducedMotion();
   const tooltipId = useId();
@@ -1143,10 +1147,19 @@ function GeneratedAtIndicator({
 
   return (
     <div
-      className="generated-at-surface w-full rounded-xl border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-[12px] text-[var(--neutral-600,#5e6673)] shadow-sm"
+      className={cn(
+        'generated-at-surface w-full rounded-xl border border-[var(--surface-border)] bg-[var(--surface-s1)] px-4 py-3 text-[12px] text-[var(--neutral-600,#5e6673)] shadow-sm',
+        className
+      )}
       data-prefers-reduced-motion={prefersReducedMotion}
+      data-direction={direction}
     >
-      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--neutral-500,#5e6673)]">
+      <div
+        className={cn(
+          'flex flex-wrap items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--neutral-500,#5e6673)]',
+          direction === 'rtl' && 'flex-row-reverse text-right'
+        )}
+      >
         <span className="flex items-center gap-2">
           <span
             className={cn(
@@ -1198,6 +1211,7 @@ function GeneratedAtIndicator({
                 !prefersReducedMotion && 'generated-at-value--swap',
                 freshness.phase === 'offline' && 'opacity-80'
               )}
+              dir="ltr"
             >
               {formattedTime}
             </span>
@@ -1258,7 +1272,12 @@ function GeneratedAtIndicator({
           )}
         </div>
       </div>
-      <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+      <div
+        className={cn(
+          'mt-3 flex flex-wrap items-center gap-2',
+          direction === 'rtl' ? 'justify-start' : 'justify-end'
+        )}
+      >
         <button
           type="button"
           onClick={handleManualRefresh}
@@ -3688,8 +3707,18 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                 <div className="h-px flex-1 self-center border-t border-dashed border-[var(--surface-border)]" aria-hidden />
               </div>
             </div>
-            <div className="col-span-12 lg:col-span-4 flex flex-col items-start gap-4 lg:items-end">
-              <div className="flex flex-wrap items-center justify-end gap-2">
+            <div
+              className={cn(
+                'col-span-12 lg:col-span-4 flex flex-col gap-4',
+                direction === 'rtl' ? 'lg:items-start text-right' : 'lg:items-end'
+              )}
+            >
+              <div
+                className={cn(
+                  'flex w-full flex-wrap items-center gap-2',
+                  direction === 'rtl' ? 'justify-start lg:flex-row-reverse' : 'justify-end'
+                )}
+              >
                 <button
                   type="button"
                   className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--surface-border)] px-4 py-2 text-sm font-medium text-[var(--neutral-700,#384150)] transition hover:bg-white focus-visible:focus-ring"
@@ -3707,20 +3736,32 @@ export default function DashboardClient({ initialData }: DashboardClientProps) {
                   {direction === 'ltr' ? 'Switch to RTL' : 'Switch to LTR'}
                 </button>
               </div>
-              <button
-                type="button"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-[var(--primary-600)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-500)] focus-visible:focus-ring"
-                onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
+              <div
+                className={cn(
+                  'flex w-full flex-col gap-3 sm:flex-row sm:items-stretch',
+                  direction === 'rtl' ? 'sm:flex-row-reverse' : undefined
+                )}
               >
-                <Sparkles className="h-4 w-4" aria-hidden />
-                {data.hero.cta}
-              </button>
-              <GeneratedAtIndicator
-                moduleId={selectedModule}
-                moduleLabel={currentModuleLabel}
-                filters={filters}
-                initialGeneratedAt={data.generatedAt}
-              />
+                <GeneratedAtIndicator
+                  moduleId={selectedModule}
+                  moduleLabel={currentModuleLabel}
+                  filters={filters}
+                  initialGeneratedAt={data.generatedAt}
+                  direction={direction}
+                  className={cn('sm:flex-1', direction === 'rtl' ? 'text-right' : undefined)}
+                />
+                <button
+                  type="button"
+                  className={cn(
+                    'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-full bg-[var(--primary-600)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-500)] focus-visible:focus-ring',
+                    'sm:min-w-[220px]'
+                  )}
+                  onClick={() => push({ title: 'Capability deck requested', description: 'We will send the full portfolio within 5 minutes.', tone: 'info' })}
+                >
+                  <Sparkles className="h-4 w-4" aria-hidden />
+                  {data.hero.cta}
+                </button>
+              </div>
             </div>
           </div>
           <div className="mt-8 flex flex-wrap items-center gap-3">

--- a/portfolio-dashboard/frontend/src/app/globals.css
+++ b/portfolio-dashboard/frontend/src/app/globals.css
@@ -74,6 +74,10 @@
     --radius-lg: 24px;
     --radius-md: 16px;
     --radius-sm: 12px;
+
+    --neutral-500: #5e6673;
+    --neutral-600: #4a5160;
+    --neutral-700: #384150;
   }
 
   [data-theme='dark'] {
@@ -111,6 +115,10 @@
     --info-50: #0b192f;
     --info-500: #60a5fa;
     --info-600: #3b82f6;
+
+    --neutral-500: rgba(203, 213, 225, 0.82);
+    --neutral-600: rgba(214, 223, 234, 0.86);
+    --neutral-700: rgba(226, 232, 240, 0.92);
   }
 
   [data-theme='dark'] body {
@@ -315,7 +323,8 @@
   .freshness-tooltip {
     position: absolute;
     inset-block-start: calc(100% + 10px);
-    inset-inline-end: 0;
+    left: 0;
+    right: auto;
     width: min(280px, 68vw);
     padding: 0.85rem 1rem;
     border-radius: 14px;
@@ -325,6 +334,7 @@
     opacity: 0;
     pointer-events: none;
     transform: translateY(6px);
+    transform-origin: left top;
     transition: opacity 0.16s ease, transform 0.16s ease;
     z-index: 10;
   }
@@ -481,6 +491,74 @@
   .generated-at-surface[data-prefers-reduced-motion='true'] .generated-at-value--swap {
     animation-duration: 0.12s;
     animation-timing-function: linear;
+  }
+
+  .filter-chip__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .filter-chip__label {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  [dir='rtl'] .filter-chip {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  [dir='rtl'] .filter-chip__icon {
+    transform: scaleX(-1);
+  }
+
+  [dir='rtl'] .filter-chip__label {
+    text-align: right;
+    justify-content: flex-end;
+  }
+
+  [dir='rtl'] .generated-at-surface[data-direction='rtl'] .freshness-inline-status {
+    flex-direction: row-reverse;
+  }
+
+  [dir='rtl'] .generated-at-surface[data-direction='rtl'] .freshness-inline-status svg {
+    transform: scaleX(-1);
+  }
+
+  .chart-card__caption {
+    letter-spacing: 0.01em;
+  }
+
+  [data-theme='dark'] .chart-card__caption {
+    letter-spacing: -0.02em;
+  }
+
+  [dir='rtl'] .chart-card__header {
+    flex-direction: row-reverse;
+  }
+
+  [dir='rtl'] .chart-card__title-block {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  [dir='rtl'] .chart-card__toolbar {
+    justify-content: flex-start;
+  }
+
+  [dir='rtl'] .chart-card__toolbar svg {
+    transform: scaleX(-1);
+  }
+
+  [dir='rtl'] .chart-card__header .text-left {
+    text-align: right;
+  }
+
+  [dir='rtl'] table .text-left {
+    text-align: right;
   }
 
   @keyframes generated-at-fade {

--- a/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/ChartCard.tsx
@@ -51,8 +51,8 @@ export function ChartCard({
       )}
     >
       <div className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="space-y-1">
+        <div className="chart-card__header flex flex-wrap items-start justify-between gap-4">
+          <div className="chart-card__title-block space-y-1">
             {description ? (
               <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-[var(--neutral-500,#5e6673)]">
                 {description}
@@ -61,9 +61,9 @@ export function ChartCard({
             <h3 id={`${id}-title`} className="text-[18px] font-semibold text-[var(--neutral-900,#0b0d12)]">
               {title}
             </h3>
-            {caption ? <p className="text-xs text-[var(--neutral-600,#5e6673)]">{caption}</p> : null}
+            {caption ? <p className="chart-card__caption text-xs text-[var(--neutral-600,#5e6673)]">{caption}</p> : null}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="chart-card__toolbar flex flex-wrap items-center gap-2">
             {toolbar}
             <button
               type="button"

--- a/portfolio-dashboard/frontend/src/components/ui/FilterChip.tsx
+++ b/portfolio-dashboard/frontend/src/components/ui/FilterChip.tsx
@@ -13,15 +13,15 @@ export function FilterChip({ label, active = false, onClick, icon }: FilterChipP
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex min-h-[44px] items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:focus-ring',
+        'filter-chip inline-flex min-h-[44px] items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:focus-ring',
         active
           ? 'border-[var(--primary-500)] bg-[var(--primary-50)] text-[var(--primary-600)]'
           : 'border-[var(--surface-border)] text-slate-600 hover:bg-slate-100/60'
       )}
       aria-pressed={active}
     >
-      {icon}
-      {label}
+      {icon ? <span className="filter-chip__icon" aria-hidden>{icon}</span> : null}
+      <span className="filter-chip__label">{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- align the dashboard header actions and generated timestamp with new RTL-aware flex behaviour and keep the freshness readout left-to-right
- refresh filter chips, chart card toolbars, and focus utilities so icons mirror in RTL while dark mode captions gain tighter letter-spacing
- raise neutral token contrast for dark mode and anchor the freshness tooltip to the left edge for better legibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dab17cc778832e9538a90fd849db27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make header/actions and freshness widget RTL-aware, introduce neutral tokens for dark mode, mirror icons/alignments, and add RTL styles for chips, chart cards, tables, and tooltip positioning.
> 
> - **Dashboard UI**:
>   - **GeneratedAtIndicator**: accepts `direction` and optional `className`; adds `data-direction`; keeps timestamp `dir="ltr"`; RTL-aware flex reversal and alignment; exposes container class override.
>   - **Header Controls**: RTL-responsive alignment for action buttons, CTA, and timestamp block; toggle to switch LTR/RTL.
>   - **FilterChip**: structure updated with `filter-chip`, `filter-chip__icon`, and `filter-chip__label` for RTL mirroring.
>   - **ChartCard**: adds `chart-card__header`, `__title-block`, `__toolbar`, and `chart-card__caption` for RTL/dark tweaks.
> - **Styles (globals.css)**:
>   - Adds `--neutral-500/600/700` tokens for light/dark.
>   - Freshness tooltip anchored to left with left-top origin; RTL-aware inline status layout.
>   - RTL rules for filter chips, chart card header/toolbar/title, general text alignment (including tables), and icon mirroring.
>   - Minor typography tweak: tighter caption letter-spacing in dark mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 181429b7e13cec9198d6b3fcc9864e9431dff01c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->